### PR TITLE
feat(permission-manager): protect main/master branches

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/cmd-gate.sh
+++ b/plugins-claude/permission-manager/scripts/cmd-gate.sh
@@ -242,6 +242,16 @@ extract_git_subcommand() {
   return 1
 }
 
+is_protected_branch() {
+  local name="$1"
+  name="${name#refs/heads/}"
+  name="${name#origin/}"
+  case "$name" in
+    main | master) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_readonly_branch() {
   local -a args=("$@")
   for arg in "${args[@]}"; do
@@ -253,6 +263,140 @@ is_readonly_branch() {
     esac
   done
   return 0
+}
+
+# Check if git branch write operation targets a protected branch.
+# Extracts positional args after write flags (-d, -m, etc.) to find branch names.
+branch_targets_protected() {
+  local -a args=("$@")
+  local skip_next=false
+  for arg in "${args[@]}"; do
+    if [[ "$skip_next" == true ]]; then
+      skip_next=false
+      if is_protected_branch "$arg"; then return 0; fi
+      continue
+    fi
+    case "$arg" in
+      -d | -D | --delete | -m | -M | --move | -c | -C | --copy)
+        skip_next=true
+        ;;
+      -*) ;;
+      *)
+        if is_protected_branch "$arg"; then return 0; fi
+        ;;
+    esac
+  done
+  return 1
+}
+
+# Check if checkout/switch is creating a new branch (-b/-B/-c/-C).
+has_create_branch_flag() {
+  local subcmd="$1"
+  shift
+  local -a args=("$@")
+  case "$subcmd" in
+    checkout)
+      for arg in "${args[@]}"; do
+        case "$arg" in -b | -B) return 0 ;; esac
+      done
+      ;;
+    switch)
+      for arg in "${args[@]}"; do
+        case "$arg" in -c | -C | --create | --force-create) return 0 ;; esac
+      done
+      ;;
+  esac
+  return 1
+}
+
+# Extract the target branch name from checkout/switch args.
+# For -b/-B/-c/-C, returns the name after the flag.
+# Otherwise, returns the first positional argument.
+extract_checkout_target() {
+  local subcmd="$1"
+  shift
+  local -a args=("$@")
+  local skip_next=false capture_next=false
+  for arg in "${args[@]}"; do
+    if [[ "$capture_next" == true ]]; then
+      echo "$arg"
+      return 0
+    fi
+    if [[ "$skip_next" == true ]]; then
+      skip_next=false
+      continue
+    fi
+    case "$arg" in
+      -b | -B | -c | -C | --create | --force-create)
+        capture_next=true
+        ;;
+      --track | -t | --orphan | --conflict | --pathspec-from-file)
+        skip_next=true
+        ;;
+      --track=* | --conflict=* | --pathspec-from-file=*) ;;
+      --detach | -d | --force | -f | --merge | -m | --quiet | -q | \
+        --progress | --no-progress | --guess | --no-guess | \
+        --recurse-submodules | --no-recurse-submodules | -l | --) ;;
+      -*) ;;
+      *)
+        echo "$arg"
+        return 0
+        ;;
+    esac
+  done
+}
+
+# Classify git push: deny if targeting a protected branch.
+check_git_push() {
+  local -a args=("$@")
+  local has_force=false
+
+  for arg in "${args[@]}"; do
+    case "$arg" in
+      --force | -f | --force-with-lease | --force-if-includes) has_force=true ;;
+    esac
+  done
+
+  # Extract positional args (remote, then refspecs)
+  local -a positionals=()
+  local skip_next=false
+  for arg in "${args[@]}"; do
+    if [[ "$skip_next" == true ]]; then
+      skip_next=false
+      continue
+    fi
+    case "$arg" in
+      --repo | --receive-pack | --exec | -o | --push-option | --recurse-submodules)
+        skip_next=true
+        ;;
+      -*) ;;
+      *) positionals+=("$arg") ;;
+    esac
+  done
+
+  # positionals[0] = remote, positionals[1+] = refspecs
+  local i
+  for ((i = 1; i < ${#positionals[@]}; i++)); do
+    local refspec="${positionals[$i]}"
+    local target
+    if [[ "$refspec" == *":"* ]]; then
+      target="${refspec#*:}"
+    else
+      target="$refspec"
+    fi
+    if is_protected_branch "$target"; then
+      deny "git push to protected branch ($target) is not allowed"
+      return 0
+    fi
+  done
+
+  # Force push without explicit branch could target a protected branch
+  if [[ "$has_force" == true && ${#positionals[@]} -le 1 ]]; then
+    ask "git push --force without explicit branch (may target protected branch)"
+    return 0
+  fi
+
+  allow "git push to non-protected branch"
 }
 
 is_readonly_stash() {
@@ -357,9 +501,35 @@ check_git() {
     branch)
       if is_readonly_branch "${args[@]+"${args[@]}"}"; then
         allow "git branch (read-only invocation)"
+      elif branch_targets_protected "${args[@]+"${args[@]}"}"; then
+        deny "git branch write operation on protected branch (main/master)"
       else
-        ask "git branch with write flags"
+        allow "git branch write operation on non-protected branch"
       fi
+      ;;
+    checkout | switch)
+      local target
+      target=$(extract_checkout_target "$subcmd" "${args[@]+"${args[@]}"}")
+      if has_create_branch_flag "$subcmd" "${args[@]+"${args[@]}"}"; then
+        if [[ -n "$target" ]] && is_protected_branch "$target"; then
+          deny "Creating a branch named $target is not allowed"
+        else
+          allow "git $subcmd creates a new branch"
+        fi
+      elif [[ -n "$target" ]] && is_protected_branch "$target"; then
+        deny "Switching to protected branch ($target) is not allowed"
+      else
+        allow "git $subcmd to non-protected branch"
+      fi
+      ;;
+    add)
+      allow "git add stages files"
+      ;;
+    commit)
+      allow "git commit to current branch"
+      ;;
+    push)
+      check_git_push "${args[@]+"${args[@]}"}"
       ;;
     stash)
       if is_readonly_stash "${args[@]+"${args[@]}"}"; then

--- a/plugins-claude/permission-manager/scripts/test-classify.sh
+++ b/plugins-claude/permission-manager/scripts/test-classify.sh
@@ -113,21 +113,44 @@ run_test allow "git rev-parse HEAD"
 run_test allow "git ls-files"
 run_test allow "git merge-base main HEAD"
 
-# ===== ASK: git write operations =====
-echo "── Git write operations ──"
-run_test ask "git commit -m 'test'"
-run_test ask "git push"
-run_test ask "git push origin main"
+# ===== ALLOW: git branch workflow (non-protected) =====
+echo "── Git branch workflow (allowed) ──"
+run_test allow "git commit -m 'test'" "git commit (current branch)"
+run_test allow "git push" "git push (current branch, no explicit target)"
+run_test allow "git push origin feature-branch" "git push to feature branch"
+run_test allow "git push -u origin wip/my-feature" "git push -u to feature branch"
+run_test allow "git checkout -b new-branch" "git checkout -b (create branch)"
+run_test allow "git switch -c new-feature" "git switch -c (create branch)"
+run_test allow "git add ." "git add stages files"
+run_test allow "git branch -d old-branch" "git branch -d non-protected"
+run_test allow "git branch -D old-branch" "git branch -D non-protected"
+
+# ===== DENY: git operations on protected branches =====
+echo "── Git protected branch operations (denied) ──"
+run_test deny "git push origin main" "git push to main"
+run_test deny "git push origin master" "git push to master"
+run_test deny "git push origin HEAD:main" "git push refspec to main"
+run_test deny "git push origin feature:master" "git push refspec to master"
+run_test deny "git checkout main" "git checkout main"
+run_test deny "git checkout master" "git checkout master"
+run_test deny "git switch main" "git switch main"
+run_test deny "git switch master" "git switch master"
+run_test deny "git checkout -b main" "git checkout -b main (create protected name)"
+run_test deny "git branch -d main" "git branch -d main"
+run_test deny "git branch -D master" "git branch -D master"
+run_test deny "git branch -m old-name main" "git branch -m to main"
+
+# ===== ASK: git write operations (other) =====
+echo "── Git write operations (ask) ──"
 run_test ask "git merge feature"
 run_test ask "git rebase main"
 run_test ask "git reset HEAD~1"
-run_test ask "git checkout -b new-branch"
-run_test ask "git branch -d old-branch"
 run_test ask "git tag -a v1.0 -m 'release'"
 run_test ask "git stash pop"
 run_test ask "git stash drop"
 run_test ask "git config --set user.name foo" "git config --set (write)"
 run_test ask "git worktree add ../wt"
+run_test ask "git push --force" "git push --force (no explicit branch)"
 
 # ===== ALLOW: gh read-only =====
 echo "── GitHub CLI read-only ──"
@@ -301,9 +324,14 @@ run_test allow "git status && git log --oneline -3" "compound: two read-only"
 run_test allow "pwd && uname -a" "compound: system tools"
 run_test allow "which node && node --version" "compound: which + version"
 
-# ===== ASK: compound with write segment =====
-echo "── Compound with write segment ──"
-run_test ask "git status && git push" "compound: read + write"
+# ===== ALLOW: compound with branch workflow =====
+echo "── Compound with branch workflow ──"
+run_test allow "git status && git push" "compound: read + push (current branch)"
+run_test allow "git add . && git commit -m 'fix'" "compound: add + commit"
+
+# ===== DENY: compound with protected branch =====
+echo "── Compound with protected branch ──"
+run_test deny "git status && git push origin main" "compound: read + push main"
 
 # ===== ALLOW: compound with local build segment =====
 echo "── Compound with local build segment ──"

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary
- Allow agent to freely `commit`, `add`, `push`, `checkout -b`, and `switch -c` on feature branches without permission prompts
- **Deny** any git operation targeting main/master: push, checkout/switch, branch delete/rename/create
- Force-push without an explicit branch falls back to `ask` as a safety net
- New helpers: `is_protected_branch()`, `branch_targets_protected()`, `has_create_branch_flag()`, `extract_checkout_target()`, `check_git_push()`
- Test suite expanded to 203 cases covering all protected-branch scenarios

## Test plan
- [x] All 203 tests pass via `bash scripts/test-classify.sh`
- [ ] Manual: verify `git push origin main` is denied
- [ ] Manual: verify `git checkout -b feature && git commit && git push` is allowed
- [ ] Manual: verify `git push --force` (no branch) triggers ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)