### PR TITLE
chore: bump plugin versions (permission-manager 2.1.1, session 3.2.1)

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Work session management — start, end, checkpoint, status, catchup, handoff, resume, plus summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Work session management — start, end, checkpoint, status, catchup, handoff, resume, plus summarize skill",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary
- Bump permission-manager version 2.1.0 → 2.1.1 (both Claude and Copilot variants)
- Bump session version 3.2.0 → 3.2.1 (both Claude and Copilot variants)

## Test plan
- [x] Version strings updated in all four plugin.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)