### PR TITLE
fix(permission-manager): handle toolArgs as object or JSON string, add B1/B2 test cases

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/test-classify.sh
+++ b/plugins-claude/permission-manager/scripts/test-classify.sh
@@ -132,8 +132,10 @@ run_test deny "git push origin master" "git push to master"
 run_test deny "git push origin HEAD:main" "git push refspec to main"
 run_test deny "git push origin feature:master" "git push refspec to master"
 run_test deny "git branch -d main" "git branch -d main"
+run_test deny "git branch -D main" "git branch -D main"
 run_test deny "git branch -D master" "git branch -D master"
 run_test deny "git branch -m old-name main" "git branch -m to main"
+run_test deny "git branch -m main renamed" "git branch -m from main"
 
 # ===== ALLOW: switching to protected branches (read-only) =====
 echo "── Git switch to protected branch (allowed) ──"

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/utils/hook-compat.sh
+++ b/utils/hook-compat.sh
@@ -39,14 +39,16 @@ fi
 
 # --- Bash command (PreToolUse) ---
 if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-  HOOK_COMMAND=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .command) catch ""' 2>/dev/null || echo "")
+  # toolArgs may be a JSON string (needs fromjson) or already a JSON object — handle both
+  HOOK_COMMAND=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | if type == "string" then fromjson else . end | .command) catch ""' 2>/dev/null || echo "")
 else
   HOOK_COMMAND=$(echo "$HOOK_INPUT" | jq -r '.tool_input.command // empty')
 fi
 
 # --- File path (PostToolUse) ---
 if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-  HOOK_FILE_PATH=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .file_path) catch ""' 2>/dev/null || echo "")
+  # toolArgs may be a JSON string (needs fromjson) or already a JSON object — handle both
+  HOOK_FILE_PATH=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | if type == "string" then fromjson else . end | .file_path) catch ""' 2>/dev/null || echo "")
 else
   HOOK_FILE_PATH=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // empty')
 fi


### PR DESCRIPTION
## Summary

Fixes #8 — 7 classifier bugs found during Copilot CLI testing.

### Root cause

`hook-compat.sh` used `fromjson` to parse Copilot CLI's `toolArgs` field. When Copilot CLI sends `toolArgs` as a JSON **object** (rather than a JSON string), `fromjson` fails silently, leaving `HOOK_COMMAND` empty. The hook then exits early with no decision, causing every command to pass through unclassified — the root cause of all 7 Copilot CLI failures in the issue.

### Changes

**`utils/hook-compat.sh`**
- Updated `HOOK_COMMAND` and `HOOK_FILE_PATH` extraction to handle `toolArgs` as either a JSON string (existing) or a JSON object (new):
  ```
  .toolArgs | if type == "string" then fromjson else . end | .command
  ```

**`plugins-claude/permission-manager/scripts/test-classify.sh`**
- Added `git branch -D main` → `deny` (B1 test gap: had `-d main` and `-D master` but not `-D main`)
- Added `git branch -m main renamed` → `deny` (B2 test gap: had rename-to-main but not rename-from-main)

**Both `plugin.json` files** — bumped to `2.2.2`

### Test results

206 passed (up from 204) — all 2 new cases pass.