### PR TITLE
feat: permission-manager integration test

### DIFF
--- a/.claude/commands/test-permission-manager.md
+++ b/.claude/commands/test-permission-manager.md
@@ -1,0 +1,175 @@
+---
+description: "Live integration test for the permission-manager hook classifier"
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# Permission-Manager Integration Test
+
+You are running a live integration test of the permission-manager hook. This test verifies the full end-to-end path: hook registration → payload → classifier → response → CLI behavior.
+
+## Instructions
+
+Follow these phases exactly. Track results as you go.
+
+### Setup
+
+Run the setup script to create a temporary test directory with fixtures and a git repo:
+
+```bash
+bash test/permission-manager/test-integration.sh setup
+```
+
+Capture the output path as `$TD`. All subsequent commands use this path.
+
+### Phase 1: Deny (8 tests)
+
+These commands should be **hard-blocked** by the hook. The hook will deny them — no user interaction needed. Attempt each via the Bash tool and observe the deny response.
+
+**PASS** = hook blocked the command (you see a deny/block response).
+**FAIL** = command executed or you were prompted to approve.
+
+| Test | Command |
+|------|---------|
+| D1 | `echo foo > $TD/output.txt` |
+| D2 | `cat $TD/hello.txt > $TD/copy.txt` |
+| D3 | `echo foo >> $TD/log.txt` |
+| D4 | `find $TD -name '*.txt' -delete` |
+| D5 | `find $TD -exec rm {} \;` |
+| D6 | `git -C $TD push origin main` |
+| D7 | `git -C $TD branch -D main` |
+| D8 | `git -C $TD status && git -C $TD push origin main` |
+
+Replace `$TD` with the actual path from setup.
+
+### Phase 2: Ask (15 tests)
+
+These commands should **prompt for permission**. Before starting this phase, tell the user:
+
+> **Phase 2: Ask tests starting.** I'll attempt 15 commands that should trigger permission prompts. Please **reject each prompt** when it appears. Say "go" when you're ready.
+
+Wait for the user to confirm before proceeding. Then attempt each command via the Bash tool.
+
+**PASS** = hook prompted for permission (and user rejected it).
+**FAIL** = command was allowed without prompting, or was hard-blocked instead of asking.
+
+Note: In Copilot CLI, "ask" maps to "deny" — both are acceptable PASS outcomes.
+
+| Test | Command |
+|------|---------|
+| A1 | `git -C $TD merge feature-branch` |
+| A2 | `git -C $TD rebase feature-branch` |
+| A3 | `git -C $TD reset HEAD~1` |
+| A4 | `git -C $TD stash pop` |
+| A5 | `git -C $TD tag -a v1.0 -m 'release'` |
+| A6 | `git -C $TD push --force` |
+| A7 | `git -C $TD checkout -b main` |
+| A8 | `git -C $TD worktree add /tmp/perm-wt` |
+| A9 | `docker run --rm alpine echo hi` |
+| A10 | `docker compose -f $TD/docker-compose.yml up -d` |
+| A11 | `docker --context atlas run --rm alpine echo hi` |
+| A12 | `gh pr create --title 'test'` |
+| A13 | `gh issue create --title 'test'` |
+| A14 | `npm publish` |
+| A15 | `cargo run` |
+
+Replace `$TD` with the actual path from setup.
+
+### Phase 3: Allow (42 tests)
+
+These commands should be **silently allowed** by the hook. Tell the user:
+
+> **Phase 3: Allow tests starting.** These 42 commands should all run without prompting. You can step away — no interaction needed.
+
+**PASS** = no permission prompt appeared. The command's exit code does not matter (missing tools, no remote, etc. are fine).
+**FAIL** = a permission prompt appeared, or the hook blocked the command.
+
+| Test | Command |
+|------|---------|
+| L1 | `cat $TD/hello.txt` |
+| L2 | `grep -r 'lorem' $TD` |
+| L3 | `head -5 $TD/hello.txt` |
+| L4 | `diff $TD/hello.txt $TD/notes.txt` |
+| L5 | `ls -la $TD` |
+| L6 | `wc -l $TD/hello.txt` |
+| L7 | `find $TD -name '*.txt'` |
+| L8 | `find $TD -name '*.txt' -exec grep -l lorem {} \;` |
+| L9 | `echo hello > /dev/null` |
+| L10 | `cat $TD/hello.txt 2>/dev/null` |
+| L11 | `git -C $TD status` |
+| L12 | `git -C $TD log --oneline -5` |
+| L13 | `git -C $TD branch -a` |
+| L14 | `git -C $TD tag -l 'v*'` |
+| L15 | `git -C $TD checkout feature-branch` |
+| L16 | `git -C $TD checkout main` |
+| L17 | `git -C $TD checkout -b test-branch` |
+| L18 | `git -C $TD add .` |
+| L19 | `git -C $TD commit --allow-empty -m 'test'` |
+| L20 | `git -C $TD stash list` |
+| L21 | `git -C $TD remote -v` |
+| L22 | `git -C $TD rev-parse HEAD` |
+| L23 | `docker ps` |
+| L24 | `docker images` |
+| L25 | `docker --context atlas ps` |
+| L26 | `docker compose -f $TD/docker-compose.yml ps` |
+| L27 | `docker compose -f $TD/docker-compose.yml config` |
+| L28 | `gh pr list` |
+| L29 | `gh issue list` |
+| L30 | `gh api repos/owner/repo/pulls` |
+| L31 | `npm list` |
+| L32 | `node --version` |
+| L33 | `gradle --version` |
+| L34 | `cargo --version` |
+| L35 | `pip list` |
+| L36 | `python3 --version` |
+| L37 | `java -version` |
+| L38 | `mvn --version` |
+| L39 | `git -C $TD status && git -C $TD log --oneline -3` |
+| L40 | `git -C $TD add . && git -C $TD commit --allow-empty -m 'compound'` |
+| L41 | `find $TD -name '*.txt' \| grep hello` |
+| L42 | `docker stats --no-stream` |
+
+Replace `$TD` with the actual path from setup.
+
+### Phase 4: Passthrough (3 tests)
+
+These commands have **no classifier opinion** — the hook passes through silently. Record observed behavior but do not score pass/fail.
+
+| Test | Command | Notes |
+|------|---------|-------|
+| P1 | `curl -s https://example.com` | network tool — no classifier opinion |
+| P2 | `make --version` | build tool — no classifier opinion |
+| P3 | `rm $TD/hello.txt` | file delete — Claude built-in handles this |
+
+Replace `$TD` with the actual path from setup.
+
+### Teardown
+
+Run cleanup:
+
+```bash
+bash test/permission-manager/test-integration.sh teardown $TD
+```
+
+If A8 created a worktree at `/tmp/perm-wt`, clean it up first:
+
+```bash
+rm -rf /tmp/perm-wt
+```
+
+### Results
+
+Print a summary table:
+
+```text
+| Phase       | Total | Pass | Fail |
+|-------------|-------|------|------|
+| Deny        | 8     | ?    | ?    |
+| Ask         | 15    | ?    | ?    |
+| Allow       | 42    | ?    | ?    |
+| Passthrough | 3     | —    | —    |
+```
+
+Then list any failures with details:
+
+- Test ID, command, expected behavior, actual behavior
+- Note which failures are due to missing tools vs actual hook misclassification

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ __pycache__/
 /.mcp.json
 
 # .claude/ — machine-specific settings, deprecated skills
-.claude/
+.claude/*
+!.claude/commands/
+.claude/commands/*
+!.claude/commands/test-permission-manager.md

--- a/test/permission-manager/fixtures/build.gradle
+++ b/test/permission-manager/fixtures/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}

--- a/test/permission-manager/fixtures/docker-compose.yml
+++ b/test/permission-manager/fixtures/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"

--- a/test/permission-manager/fixtures/hello.txt
+++ b/test/permission-manager/fixtures/hello.txt
@@ -1,0 +1,12 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+Nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit.
+Esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident.
+Sunt in culpa qui officia deserunt mollit anim id est laborum.
+The quick brown fox jumps over the lazy dog.
+Pack my box with five dozen liquor jugs.
+How vexingly quick daft zebras jump.
+Sphinx of black quartz, judge my vow.

--- a/test/permission-manager/fixtures/notes.txt
+++ b/test/permission-manager/fixtures/notes.txt
@@ -1,0 +1,8 @@
+These are test notes for the permission-manager integration test.
+This file exists so we can test diff operations between two files.
+It contains different content from hello.txt on purpose.
+The classifier should allow read-only operations on both files.
+Testing grep, cat, head, tail, wc, and diff commands.
+Each line is unique to make grep results easy to verify.
+Integration tests validate the full hook pipeline end-to-end.
+No sensitive data here — just fixture content for automated testing.

--- a/test/permission-manager/fixtures/settings.gradle
+++ b/test/permission-manager/fixtures/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'test-project'

--- a/test/permission-manager/test-integration.sh
+++ b/test/permission-manager/test-integration.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Setup/teardown helper for permission-manager integration tests.
+# Usage:
+#   test-integration.sh setup     — creates temp dir with fixtures + git repo, prints path
+#   test-integration.sh teardown <path> — removes the temp dir
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURES="$SCRIPT_DIR/fixtures"
+
+case "${1:-}" in
+  setup)
+    TD=$(mktemp -d /tmp/perm-test-XXXXXX)
+    cp -r "$FIXTURES"/. "$TD/"
+    git -C "$TD" init -b main >/dev/null 2>&1
+    git -C "$TD" config user.email "test@test.local"
+    git -C "$TD" config user.name "Test"
+    git -C "$TD" add -A >/dev/null 2>&1
+    git -C "$TD" commit -m "initial commit" >/dev/null 2>&1
+    git -C "$TD" checkout -b feature-branch >/dev/null 2>&1
+    git -C "$TD" tag v0.1.0 >/dev/null 2>&1
+    git -C "$TD" checkout main >/dev/null 2>&1
+    echo "$TD"
+    ;;
+  teardown)
+    dir="${2:-}"
+    if [[ "$dir" == /tmp/perm-test-* && -d "$dir" ]]; then
+      rm -rf "$dir"
+      echo "Cleaned up $dir"
+    else
+      echo "Invalid path: $dir" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Usage: $0 {setup|teardown <path>}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `/test-permission-manager` repo-level command with 68 live tests across 4 phases (deny/ask/allow/passthrough)
- Adds `test/permission-manager/` with fixtures and setup/teardown script (temp git repo with branches + tags)
- Gitignore updated to track only this specific command file

## Test plan
- [x] Unit tests pass: `bash plugins-claude/permission-manager/scripts/test-classify.sh` (424/424)
- [ ] Run `/test-permission-manager` with `claude --plugin-dir ./plugins-claude/permission-manager`
- [ ] Verify deny phase blocks all 8 commands
- [ ] Verify ask phase prompts on all 15 commands
- [ ] Verify allow phase runs all 42 commands without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)