### PR TITLE
feat: improve git-cli skill triggering and reduce context footprint

### DIFF
--- a/plugins-claude/git-cli/.claude-plugin/plugin.json
+++ b/plugins-claude/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-cli/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-cli/skills/git-cli/SKILL.md
@@ -2,122 +2,31 @@
 user-invocable: false
 name: git-cli
 description: >-
-  Interact with GitHub and Gitea issue trackers and CI systems. List and show
-  issues, file bugs, comment on issues or PRs, list and show pull requests,
-  and fetch CI run logs — all from any repo context without leaving the session.
+  This skill MUST be used for ALL GitHub and Gitea CLI operations. Never run
+  `gh`, `tea`, `gh issue`, `gh pr`, `gh run`, `gh api`, `gh repo`, `tea issues`,
+  or `tea pr` directly — always use git-cli instead. This skill should be used
+  when the user asks to "list issues", "show issue", "file a bug", "create issue",
+  "comment on issue", "list PRs", "show PR", "create PR", "merge PR", "check CI",
+  "view run logs", "check build status", or any interaction with GitHub or Gitea
+  issue trackers, pull requests, or CI systems. Provides a unified wrapper that
+  auto-detects the platform from the git remote.
 allowed-tools: Bash
 ---
 
 # git-cli
 
-Use `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli` to interact with the issue tracker and CI
-system for the current repository. Platform (GitHub or Gitea) is auto-detected from the
-git remote — no configuration needed.
+**CRITICAL: Never run `gh` or `tea` directly.** Always use the wrapper script below.
+The current repository may use GitHub or Gitea — the wrapper auto-detects the platform
+from the git remote so the correct CLI is used every time. Running `gh` directly will
+fail on Gitea repositories and vice versa.
 
-## When to use this skill
-
-- File a bug or enhancement issue discovered mid-session
-- Check open issues to understand what work is planned or in progress
-- Post a progress comment on a linked issue
-- Check CI run status or fetch logs for a failing build
-- Inspect the current state of a pull request
-
-## Available commands
-
-### Issues
-
-```bash
-# List open issues (returns normalized JSON array)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue list [--limit N] [--state open|closed|all] [--label LABEL] [--assignee USER]
-
-# Show a single issue with full body and comments
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue show <number>
-
-# Create an issue (--body-file accepts a markdown file)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body-file /tmp/body.md [--label bug]
-
-# Add a comment (use --body-file for multi-line structured content)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body-file /tmp/comment.md
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body "Short comment"
-
-# Close or reopen
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue close <number>
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue reopen <number>
+```text
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli <command> <subcommand> [flags]
 ```
 
-### Pull Requests
+The interface mirrors `gh` syntax. Run `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli --help`
+for full usage. Commands: `issue`, `pr`, `run`, `repo`, `user` — each with subcommands
+like `list`, `show`, `create`, `comment`, `close`, `merge`, `logs`.
 
-```bash
-# List PRs
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr list [--state open|closed|merged|all] [--limit N]
-
-# Show a single PR with details
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show <number>
-
-# Create a PR (auto-assigns to current user)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch --base main --body-file /tmp/pr.md
-
-# Comment on a PR
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body-file /tmp/comment.md
-
-# Merge or close
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr merge <number> [--squash | --rebase]
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr close <number>
-```
-
-### CI Runs
-
-```bash
-# List recent runs (JSON with id, status, workflow, branch, event, started_at)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run list [--limit N] [--status failure|success|pending] [--branch BRANCH]
-
-# Show details of a specific run
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run show <run-id>
-
-# Fetch logs (--failed-only shows only failing steps on GitHub)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run logs <run-id>
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run logs <run-id> --failed-only
-```
-
-### Repo / User
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo default-branch   # e.g. "main" or "master"
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo info             # name, description, stars, etc.
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli user whoami           # {"login": "username"}
-```
-
-## Output format
-
-All commands return JSON. Issue and PR objects use a normalized schema:
-
-```json
-{
-  "number": 42,
-  "title": "...",
-  "body": "...",
-  "state": "open",
-  "author": "username",
-  "labels": ["bug", "high-priority"],
-  "milestone": null,
-  "assignees": ["username"],
-  "created_at": "2026-01-01T00:00:00Z",
-  "updated_at": "2026-01-01T00:00:00Z",
-  "url": "https://..."
-}
-```
-
-## Writing issue/PR bodies
-
-Use `--body-file` with a temporary markdown file for any structured content:
-
-```bash
-cat > /tmp/issue.md << 'EOF'
-## Problem
-...
-
-## Steps to reproduce
-...
-EOF
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --body-file /tmp/issue.md --label bug
-```
+All output is normalized JSON regardless of platform. Use `--body-file /tmp/file.md`
+for multi-line issue/PR bodies.


### PR DESCRIPTION
## Summary

- Rewrote skill description to explicitly intercept `gh`/`tea` CLI token usage, adding strong negative instructions and specific trigger phrases
- Stripped SKILL.md body from ~120 lines of command reference down to ~12 lines, relying on Claude's training-data knowledge of `gh` syntax and `--help` fallback
- Bumped plugin version to 1.1.0

## Test plan

- [ ] Install plugin and verify skill triggers when asking to list issues, create PRs, etc.
- [ ] Verify Claude does NOT attempt direct `gh` or `tea` commands in Gitea repos
- [ ] Confirm `--help` fallback works when Claude needs flag details

🤖 Generated with [Claude Code](https://claude.com/claude-code)