### PR TITLE
fix: allow gh run watch in permission-manager

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/classifiers/gh.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/gh.sh
@@ -47,7 +47,7 @@ check_gh() {
       ;;
     run)
       case "$subsubcmd" in
-        list | view) allow "gh run $subsubcmd is read-only" ;;
+        list | view | watch) allow "gh run $subsubcmd is read-only" ;;
         *) ask "gh run $subsubcmd modifies workflow runs" ;;
       esac
       ;;

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary
- `gh run watch` was incorrectly classified as a modifying command, prompting for permission when it's purely read-only (polls and displays CI status)
- Added `watch` to the read-only allow list alongside `list` and `view` in the `gh run` classifier
- Bumped permission-manager version to 2.4.3 in both Claude and Copilot variants

## Test plan
- [ ] Run `gh run watch <id> --exit-status` and verify it is auto-allowed
- [ ] Verify `gh run list` and `gh run view` still auto-allow
- [ ] Verify `gh run rerun` and other modifying subcommands still prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)