### PR TITLE
feat: add PostToolUse lint hooks and plugin-validator agent

### DIFF
--- a/.claude/agents/plugin-validator.md
+++ b/.claude/agents/plugin-validator.md
@@ -1,0 +1,82 @@
+---
+name: plugin-validator
+description: Validate plugin structure, manifests, hook configs, and marketplace consistency for this agent-toolkit repo. Use after modifying any plugin.
+model: haiku
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+color: blue
+---
+
+You are a plugin validator for the agent-toolkit marketplace repo. Validate the specified plugin(s) thoroughly.
+
+## Checks to Perform
+
+### 1. Plugin Manifest (`plugin.json`)
+
+- Required fields: `name`, `version`, `description`
+- Version follows semver
+- If `mcpServers` field exists, verify `mcp.json` exists
+
+### 2. Directory Structure
+
+- Plugin lives in `plugins-claude/<name>/`
+- Has `.claude-plugin/plugin.json`
+- Any referenced directories (commands/, skills/, hooks/, scripts/) exist
+
+### 3. Hook Configuration (`hooks/hooks.json`)
+
+- Valid JSON with `{"hooks": {"EventName": [...]}}` wrapper
+- Event names are PascalCase: PreToolUse, PostToolUse, Stop, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification
+- Each hook entry has `matcher` (string) and `hooks` array
+- Hook entries have `type: "command"` and a `command` field
+- Commands reference `${CLAUDE_PLUGIN_ROOT}` not hardcoded paths
+
+### 4. Commands & Skills
+
+- Command files are `.md` with valid YAML frontmatter
+- Skill directories contain `SKILL.md` with valid YAML frontmatter
+- Frontmatter has required fields: `name`, `description`
+- Skills with `user-invocable: false` should not appear in commands/
+
+### 5. Scripts
+
+- All scripts referenced in hooks/commands/skills actually exist
+- Shell scripts have `#!/usr/bin/env bash` shebang
+- Symlinks in `scripts/` resolve correctly
+
+### 6. Copilot Variant Consistency
+
+If `plugins-copilot/<name>/` exists:
+
+- Has its own `.claude-plugin/plugin.json` (can be a copy)
+- Has `hooks/hooks.json` in Copilot format (camelCase events, flat array, `version: 1`, `bash` key)
+- Symlinks point back to `../../plugins-claude/<name>/` for shared dirs (scripts, skills, etc.)
+- Shared content matches (no stale copies)
+
+### 7. Marketplace Entries
+
+- Plugin is listed in `.claude-plugin/marketplace.json` pointing to `plugins-claude/<name>`
+- Plugin is listed in `.github/plugin/marketplace.json` pointing to `plugins-copilot/<name>` (if variant exists) or `plugins-claude/<name>`
+- Names and descriptions are consistent across manifests and marketplace entries
+
+## Validation Scripts
+
+Run the CI validation scripts for comprehensive checks:
+
+```bash
+bash .github/scripts/validate-plugins.sh
+bash .github/scripts/validate-frontmatter.sh
+```
+
+## Output Format
+
+Report results as:
+
+- **PASS**: check passed
+- **WARN**: non-critical issue (missing optional field, etc.)
+- **FAIL**: must-fix issue
+
+Group by plugin name. End with a summary count of pass/warn/fail.

--- a/.claude/hooks/lint-markdown.sh
+++ b/.claude/hooks/lint-markdown.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# lint-markdown.sh — PostToolUse hook that runs rumdl on edited markdown files.
+# Always exits 0 — never blocks Claude. Linter output goes to stderr.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+[[ -n "$FILE" ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+[[ "$FILE" == *.md ]] || exit 0
+
+if ! command -v rumdl >/dev/null 2>&1; then
+  echo "[lint-markdown] WARN: rumdl not found — skipping $FILE" >&2
+  exit 0
+fi
+
+rumdl "$FILE" >&2 || true
+exit 0

--- a/.claude/hooks/lint-shell.sh
+++ b/.claude/hooks/lint-shell.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# lint-shell.sh — PostToolUse hook that runs shellcheck on edited shell scripts.
+# Always exits 0 — never blocks Claude. Linter output goes to stderr.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+[[ -n "$FILE" ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+[[ "$FILE" == *.sh || "$FILE" == *.bash ]] || exit 0
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "[lint-shell] WARN: shellcheck not found — skipping $FILE" >&2
+  exit 0
+fi
+
+shellcheck "$FILE" >&2 || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,64 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/lint-shell.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/lint-markdown.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(cat .deploy-profiles/*)",
+      "Bash(ls .deploy-profiles/)",
+      "Bash(ls .deploy-profiles/*.json *)",
+      "Bash(cargo --version)",
+      "Bash(cargo audit *)",
+      "Bash(cargo audit)",
+      "Bash(cargo check *)",
+      "Bash(cargo check)",
+      "Bash(cargo metadata *)",
+      "Bash(cargo metadata)",
+      "Bash(cargo tree *)",
+      "Bash(cargo tree)",
+      "Bash(rustc --version)",
+      "Bash(rustup --version)",
+      "Bash(rustup show *)",
+      "Bash(rustup show)",
+      "Bash(~/.claude/tools/frontmatter-query/bin/frontmatter-query *)",
+      "Bash(~/.claude/tools/frontmatter-query/bin/frontmatter-query)",
+      "Bash(.claude/skills/deploy/bin/discover *)",
+      "Bash(.claude/skills/deploy/bin/profile-diff *)",
+      "Bash(bash deploy-py/test.sh *)",
+      "Bash(bash deploy-py/test.sh)",
+      "Bash(bash deploy-rs/test.sh *)",
+      "Bash(bash deploy-rs/test.sh)",
+      "Bash(bash test.sh *)",
+      "Bash(bash test.sh)",
+      "Bash(bash tests/test.sh *)",
+      "Bash(bash tests/test.sh)",
+      "Bash(deploy-py/deploy.py *)",
+      "Bash(deploy-py/deploy.py)",
+      "Bash(rumdl *)",
+      "Bash(mkdir -p .deploy-profiles)",
+      "Bash(pandoc *)"
+    ],
+    "deny": []
+  },
+  "enabledPlugins": {
+    "claude-code-setup@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 !.claude/commands/
 .claude/commands/*
 !.claude/commands/test-permission-manager.md
+!.claude/hooks/
+!.claude/agents/
+!.claude/settings.json


### PR DESCRIPTION
## Summary
- Add **ShellCheck** and **rumdl** PostToolUse hooks that auto-lint `.sh` and `.md` files after Edit/Write operations
- Add a project-local **plugin-validator** agent (Haiku) for validating plugin structure, manifests, hook configs, Copilot variant consistency, and marketplace sync
- Track `.claude/hooks/`, `.claude/agents/`, and `.claude/settings.json` via gitignore exceptions

## Details

### Lint Hooks
Both hooks read the tool payload from stdin, extract the file path, filter by extension, and run the linter. They are non-blocking (always exit 0) and gracefully skip if the linter is not installed.

| Hook | Linter | File types | Timeout |
|------|--------|------------|---------|
| `lint-shell.sh` | shellcheck | `.sh`, `.bash` | 30s |
| `lint-markdown.sh` | rumdl | `.md` | 30s |

### Plugin Validator Agent
Runs on Haiku for speed. Checks:
- Plugin manifests (`plugin.json` required fields, semver)
- Directory structure and script references
- Hook config format (PascalCase events, `${CLAUDE_PLUGIN_ROOT}`)
- Command/skill frontmatter
- Copilot variant symlink consistency
- Marketplace entry sync across both catalogs
- CI validation scripts (`validate-plugins.sh`, `validate-frontmatter.sh`)

## Test plan
- [ ] Edit a `.sh` file and verify shellcheck output appears in stderr
- [ ] Edit a `.md` file and verify rumdl output appears in stderr
- [ ] Invoke plugin-validator agent on a plugin and verify structured output

🤖 Generated with [Claude Code](https://claude.com/claude-code)