### PR TITLE
fix: run watch default-terminal polling prevents timeout loops

### DIFF
--- a/plugins-claude/git-cli/.claude-plugin/plugin.json
+++ b/plugins-claude/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-cli/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/tests/session/test-ci-poll.sh
+++ b/tests/session/test-ci-poll.sh
@@ -129,6 +129,33 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test: completed with null conclusion (GitHub race condition) → treated as pass
+#
+# REGRESSION GUARD — this is the exact scenario that caused repeated watch
+# timeouts (#53, #57, #58, #60).  GitHub's API can return status:"completed"
+# with conclusion:null.  The jq transform in `run list` maps this to
+# "success", but if that transform ever breaks again the fallback case
+# statement must still exit (not loop).  If this test fails, the watch loop
+# will spin for the full timeout on completed runs.
+# ---------------------------------------------------------------------------
+
+write_mock_gh <<'EOF'
+case "$1:$2" in
+  pr:view)
+    exit 1
+    ;;
+  run:list)
+    echo '[{"databaseId":250,"status":"completed","conclusion":null,"workflowName":"CI","headBranch":"test-branch","event":"push","createdAt":"2024-01-01T00:00:00Z","url":"https://github.com/test/repo/actions/runs/250"}]'
+    ;;
+  run:view)
+    echo '{"databaseId":250,"status":"completed","conclusion":null,"workflowName":"CI","headBranch":"test-branch","event":"push","createdAt":"2024-01-01T00:00:00Z","url":"https://github.com/test/repo/actions/runs/250","jobs":[]}'
+    ;;
+esac
+EOF
+
+run_test "pass" "0" "completed (null conclusion) → status: pass, exit 0"
+
+# ---------------------------------------------------------------------------
 # Test: cancelled → treated as pass
 # ---------------------------------------------------------------------------
 

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -46,9 +46,15 @@ die_usage() { echo "git-tools: $*" >&2; echo "Run 'git-tools --help' for usage."
 # Run a CLI command and pipe its stdout through a jq filter.
 # If the command fails, die with its stderr instead of feeding junk to jq.
 # Usage: cli_json [jq-flags...] <jq-filter> <cmd> [args...]
+#
+# IMPORTANT: stderr is captured to a temp file, NOT mixed into stdout.
+# Using 2>&1 here would merge any gh/tea stderr output (upgrade notices,
+# auth warnings, progress text) into the JSON, silently corrupting jq
+# parsing and producing wrong results downstream (e.g. run watch seeing
+# unexpected status values).
 cli_json() {
   local jq_flags=()
-  while [[ "$1" == -* && "$1" != -* || "$1" =~ ^-[a-zA-Z] ]]; do
+  while [[ "$1" =~ ^-[a-zA-Z] ]]; do
     # Collect jq flags (e.g. -r, -e) — stop at the filter string
     case "$1" in
       -r|-e|-c|-S|-s|-R) jq_flags+=("$1"); shift ;;
@@ -56,11 +62,16 @@ cli_json() {
     esac
   done
   local filter="$1"; shift
-  local raw rc=0
-  raw=$("$@" 2>&1) || rc=$?
+  local raw stderr_file rc=0
+  stderr_file=$(mktemp)
+  raw=$("$@" 2>"$stderr_file") || rc=$?
   if [[ $rc -ne 0 ]]; then
-    die "$raw"
+    local err
+    err=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+    die "$err"
   fi
+  rm -f "$stderr_file"
   echo "$raw" | jq "${jq_flags[@]+"${jq_flags[@]}"}" "$filter"
 }
 
@@ -958,7 +969,26 @@ case "$cmd:$sub" in
       done
     fi
 
-    # Fallback: no PR found — poll run list directly (skip flaky run show)
+    # Fallback: no PR found — poll run list directly (skip flaky run show).
+    #
+    # CRITICAL DESIGN RULE — default-terminal polling:
+    #
+    #   This loop has caused repeated regressions (#53, #57, #58, #60).
+    #   The recurring bug pattern is:
+    #     1. The API returns an unexpected status value (e.g. "completed"
+    #        with null conclusion, or a new status GitHub adds later).
+    #     2. The case statement doesn't recognise it.
+    #     3. A catch-all `*) keep polling` silently loops until timeout.
+    #
+    #   The fix (applied here) inverts the logic:
+    #     - ONLY explicitly non-terminal states keep polling.
+    #     - The `*` catch-all EXITS (as pass).
+    #
+    #   DO NOT add a `*) keep polling` catch-all to this case statement.
+    #   If a new non-terminal status appears, add it to the explicit list.
+    #   If you're unsure whether a status is terminal, it's safer to exit
+    #   early (the caller can retry) than to loop for 5 minutes.
+    #
     run_url=""
     while true; do
       list_json=$("$0" run list --branch "$branch" --limit 1 2>/dev/null) || list_json="[]"
@@ -984,13 +1014,11 @@ case "$cmd:$sub" in
 
       echo "Run $run_id: $run_status (${elapsed}s elapsed)" >&2
 
+      # See "CRITICAL DESIGN RULE" above — non-terminal states are listed
+      # explicitly; everything else exits.  Do NOT add a `*) keep polling`.
       case "$run_status" in
-        success|completed)
-          echo "status: pass"
-          [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
-          echo "duration: ${elapsed}s"
-          echo "failed_jobs:"
-          exit 0
+        queued|in_progress|waiting|running|pending|requested)
+          # Non-terminal — keep polling
           ;;
         failure|timed_out)
           # Best-effort single run show for failed job names (not in a loop)
@@ -1007,18 +1035,16 @@ case "$cmd:$sub" in
           fi
           exit 0
           ;;
-        completed|cancelled|skipped)
+        *)
+          # Terminal — covers success, completed, cancelled, skipped, neutral,
+          # and any future/unexpected status.  Exiting here is intentional:
+          # a false-positive "pass" is recoverable, a false-negative "keep
+          # polling" wastes 5 minutes and blocks the caller.
           echo "status: pass"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"
           echo "failed_jobs:"
           exit 0
-          ;;
-        queued|in_progress|waiting|running|pending|requested)
-          # Non-terminal — keep polling
-          ;;
-        *)
-          # Unknown from run list — just keep polling until timeout
           ;;
       esac
 


### PR DESCRIPTION
## Summary

- Invert the fallback watch loop's case logic: only explicitly non-terminal states (`queued|in_progress|waiting|running|pending|requested`) keep polling; the `*` catch-all exits as pass
- Fix `cli_json` to capture stderr to a temp file instead of `2>&1`, preventing gh/tea stderr from corrupting JSON parsing
- Add regression test for `completed` status with `null` conclusion (the exact GitHub race condition from #60)
- Heavy comments documenting the design rule and regression history (#53 → #57 → #58 → #60) so future changes don't reintroduce `*) keep polling`

## Test plan

- [x] All 24 CI poll tests pass (23 existing + 1 new regression guard)
- [x] Full test suite passes (986/986)

🤖 Generated with [Claude Code](https://claude.com/claude-code)