### PR TITLE
feat(git-cli)!: --body reads from stdin

### DIFF
--- a/plugins-claude/git-cli/.claude-plugin/plugin.json
+++ b/plugins-claude/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-cli/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-cli/skills/git-cli/SKILL.md
@@ -39,12 +39,17 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue list [--limit N] [--state open|close
 # Show a single issue with full body and comments
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue show <number>
 
-# Create an issue (--body-file accepts a markdown file)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body-file /tmp/body.md [--label bug]
+# Create an issue (pipe body to --body via heredoc)
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body [--label bug] <<'EOF'
+## Problem
+...
+EOF
 
-# Add a comment (use --body-file for multi-line structured content)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body-file /tmp/comment.md
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body "Short comment"
+# Add a comment (heredoc for multi-line, printf for short)
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body <<'EOF'
+Progress update...
+EOF
+printf 'LGTM' | ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body
 
 # Close or reopen
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue close <number>
@@ -61,10 +66,18 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr list [--state open|closed|merged|all] [
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show <number>
 
 # Create a PR (auto-assigns to current user; --base defaults to repo's primary branch)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch [--base main] [--body-file /tmp/pr.md]
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch [--base main] --body <<'EOF'
+## Summary
+...
+
+## Test plan
+...
+EOF
 
 # Comment on a PR
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body-file /tmp/comment.md
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body <<'EOF'
+Review follow-up...
+EOF
 
 # Merge or close
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr merge <number> [--squash | --rebase]
@@ -124,15 +137,19 @@ All commands return JSON. Issue and PR objects use a normalized schema:
 
 ## Writing issue/PR bodies
 
-Use `--body-file` with a temporary markdown file for any structured content:
+Pipe the body to `--body` via a heredoc. No temp file, no cleanup:
 
 ```bash
-cat > /tmp/issue.md << 'EOF'
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body <<'EOF'
 ## Problem
 ...
 
 ## Steps to reproduce
 ...
 EOF
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --body-file /tmp/issue.md --label bug
 ```
+
+`--body-file FILE` remains available when the body is already on disk, and
+`--body-file -` is equivalent to `--body` (reads stdin). There is no
+`--body TEXT` form — stdin handles every size from one-liners to full PR
+descriptions.

--- a/plugins-copilot/git-cli/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-cli/skills/git-cli/SKILL.md
+++ b/plugins-copilot/git-cli/skills/git-cli/SKILL.md
@@ -33,12 +33,17 @@ ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue list [--limit N] [--state open|clos
 # Show a single issue with full body and comments
 ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue show <number>
 
-# Create an issue (--body-file accepts a markdown file)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body-file /tmp/body.md [--label bug]
+# Create an issue (pipe body to --body via heredoc)
+${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body [--label bug] <<'EOF'
+## Problem
+...
+EOF
 
-# Add a comment (use --body-file for multi-line structured content)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body-file /tmp/comment.md
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body "Short comment"
+# Add a comment (heredoc for multi-line, printf for short)
+${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body <<'EOF'
+Progress update...
+EOF
+printf 'LGTM' | ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body
 
 # Close or reopen
 ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue close <number>
@@ -55,10 +60,18 @@ ${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr list [--state open|closed|merged|all] 
 ${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr show <number>
 
 # Create a PR (auto-assigns to current user)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch --base main --body-file /tmp/pr.md
+${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch --base main --body <<'EOF'
+## Summary
+...
+
+## Test plan
+...
+EOF
 
 # Comment on a PR
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body-file /tmp/comment.md
+${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body <<'EOF'
+Review follow-up...
+EOF
 
 # Merge or close
 ${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr merge <number> [--squash | --rebase]
@@ -109,15 +122,19 @@ All commands return JSON. Issue and PR objects use a normalized schema:
 
 ## Writing issue/PR bodies
 
-Use `--body-file` with a temporary markdown file for any structured content:
+Pipe the body to `--body` via a heredoc. No temp file, no cleanup:
 
 ```bash
-cat > /tmp/issue.md << 'EOF'
+${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body <<'EOF'
 ## Problem
 ...
 
 ## Steps to reproduce
 ...
 EOF
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --body-file /tmp/issue.md --label bug
 ```
+
+`--body-file FILE` remains available when the body is already on disk, and
+`--body-file -` is equivalent to `--body` (reads stdin). There is no
+`--body TEXT` form — stdin handles every size from one-liners to full PR
+descriptions.

--- a/tests/git-cli/test-pr-create.sh
+++ b/tests/git-cli/test-pr-create.sh
@@ -112,7 +112,7 @@ MOCK_EOF
 chmod +x "$MOCK_DIR/gh"
 
 if run_test "0" "base omitted → auto-detects default branch" \
-  --title "Test PR" --head "feature-branch" --body "test body"; then
+  --title "Test PR" --head "feature-branch"; then
   # Verify --base main was passed to gh pr create
   gh_args=$(cat "$ARGS_FILE" 2>/dev/null || echo "")
   if echo "$gh_args" | grep -q -- "--base main"; then
@@ -152,7 +152,7 @@ chmod +x "$MOCK_DIR/gh"
 rm -f "$ARGS_FILE.default_branch_called"
 
 if run_test "0" "base provided → uses it directly" \
-  --title "Test PR" --head "feature-branch" --base "develop" --body "test body"; then
+  --title "Test PR" --head "feature-branch" --base "develop"; then
   gh_args=$(cat "$ARGS_FILE" 2>/dev/null || echo "")
   if echo "$gh_args" | grep -q -- "--base develop"; then
     pass "base provided → uses --base develop"
@@ -185,7 +185,7 @@ MOCK_EOF
 chmod +x "$MOCK_DIR/gh"
 
 if run_test "1" "base omitted + detection fails → error" \
-  --title "Test PR" --head "feature-branch" --body "test body"; then
+  --title "Test PR" --head "feature-branch"; then
   if echo "$TEST_STDERR" | grep -q "could not detect default branch"; then
     pass "base omitted + detection fails → helpful error message"
   else
@@ -235,6 +235,96 @@ if [[ "$exit_code" == "1" ]]; then
   pass "missing --head → exit 1"
 else
   fail "missing --head → exit 1" "got exit $exit_code"
+fi
+
+# ---------------------------------------------------------------------------
+# Test: --body reads from stdin (heredoc)
+# ---------------------------------------------------------------------------
+
+echo "── pr create: --body stdin ──"
+
+BODY_FILE="$MOCK_DIR/.gh_body"
+
+cat >"$MOCK_DIR/gh" <<MOCK_EOF
+#!/usr/bin/env bash
+# Capture the value passed to --body into BODY_FILE
+args=("\$@")
+case "\$1:\$2" in
+  repo:view) echo "main" ;;
+  pr:create)
+    for ((i=0; i<\${#args[@]}; i++)); do
+      if [[ "\${args[\$i]}" == "--body" ]]; then
+        printf '%s' "\${args[\$((i+1))]}" > "$BODY_FILE"
+      fi
+    done
+    echo "https://github.com/owner/repo/pull/3"
+    ;;
+  api:*) echo '{"login":"testuser"}' ;;
+esac
+MOCK_EOF
+chmod +x "$MOCK_DIR/gh"
+
+exit_code=0
+output=$(
+  PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
+    --title "Stdin PR" --head "feature" --body <<'BODY_EOF' 2>"$MOCK_DIR/stderr"
+## Summary
+multi-line body from stdin
+
+- bullet one
+- bullet two
+BODY_EOF
+) || exit_code=$?
+
+if [[ "$exit_code" == "0" ]] && [[ -f "$BODY_FILE" ]] &&
+  grep -q "multi-line body from stdin" "$BODY_FILE" &&
+  grep -q "bullet one" "$BODY_FILE"; then
+  pass "--body reads heredoc from stdin and passes to gh"
+else
+  fail "--body reads heredoc from stdin" \
+    "exit=$exit_code body=$(cat "$BODY_FILE" 2>/dev/null) stderr=$(cat "$MOCK_DIR/stderr")"
+fi
+
+# --body with no stdin (terminal) should error
+exit_code=0
+PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
+  --title "No stdin" --head "feature" --body </dev/null 2>"$MOCK_DIR/stderr" >/dev/null || exit_code=$?
+# /dev/null satisfies the `-t 0` check (not a terminal), so gh will be called with empty body.
+# The real "terminal" path can't be exercised non-interactively, so we skip that assertion.
+if [[ "$exit_code" == "0" ]]; then
+  pass "--body with empty stdin (pipe from /dev/null) succeeds with empty body"
+else
+  fail "--body with empty stdin" "exit=$exit_code stderr=$(cat "$MOCK_DIR/stderr")"
+fi
+
+# --body-file - is an alias for stdin
+cat >"$MOCK_DIR/gh" <<MOCK_EOF
+#!/usr/bin/env bash
+args=("\$@")
+case "\$1:\$2" in
+  repo:view) echo "main" ;;
+  pr:create)
+    for ((i=0; i<\${#args[@]}; i++)); do
+      if [[ "\${args[\$i]}" == "--body" ]]; then
+        printf '%s' "\${args[\$((i+1))]}" > "$BODY_FILE"
+      fi
+    done
+    echo "https://github.com/owner/repo/pull/4"
+    ;;
+  api:*) echo '{"login":"testuser"}' ;;
+esac
+MOCK_EOF
+chmod +x "$MOCK_DIR/gh"
+
+exit_code=0
+echo "body via body-file dash" | PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
+  --title "Dash PR" --head "feature" --body-file - 2>"$MOCK_DIR/stderr" >/dev/null || exit_code=$?
+
+if [[ "$exit_code" == "0" ]] && grep -q "body via body-file dash" "$BODY_FILE"; then
+  pass "--body-file - reads stdin"
+else
+  fail "--body-file - reads stdin" \
+    "exit=$exit_code body=$(cat "$BODY_FILE" 2>/dev/null) stderr=$(cat "$MOCK_DIR/stderr")"
 fi
 
 # ---------------------------------------------------------------------------

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -7,15 +7,17 @@
 # Usage:
 #   git-tools issue list   [--limit N] [--assignee USER] [--label L] [--state open|closed|all]
 #   git-tools issue show   <N>
-#   git-tools issue create --title T [--body-file FILE] [--label L] [--assignee U]
-#   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+#   git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
+#   git-tools issue comment <N> [--body | --body-file FILE]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
 #   git-tools pr show      <N>
-#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body-file FILE]
-#   git-tools pr comment   <N> [--body TEXT | --body-file FILE]
+#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
+#   git-tools pr comment   <N> [--body | --body-file FILE]
+#
+#   (--body reads from stdin; --body-file FILE reads from disk, or "-" for stdin)
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
@@ -76,21 +78,39 @@ cli_json() {
 }
 
 # Read body from --body or --body-file flags. Sets BODY variable.
-# Call: parse_body "$@" then access $BODY and $REMAINING_ARGS
+# Call: parse_body_args "$@" then access $BODY and $REMAINING_ARGS.
+#
+# --body reads from stdin. This is the only stdin-capable flag: no --body TEXT,
+# no temp-file pattern required. Multi-line structured content uses heredoc;
+# short comments pipe in via printf. --body-file FILE (or --body-file -) remains
+# for callers that already have content on disk.
+#   git-cli pr create --title "..." --head branch --body <<'EOF'
+#   ## Summary
+#   ...
+#   EOF
+#   printf 'LGTM' | git-cli pr comment 42 --body
 BODY=""
 REMAINING_ARGS=()
 
 parse_body_args() {
   BODY=""
   REMAINING_ARGS=()
+  local read_stdin=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --body)      [[ $# -gt 1 ]] || die "--body requires a value"; shift; BODY="$1" ;;
-      --body-file) [[ $# -gt 1 ]] || die "--body-file requires a file path"; shift; [[ -f "$1" ]] || die "body-file not found: $1"; BODY="$(cat "$1")" ;;
-      *)           REMAINING_ARGS+=("$1") ;;
+      --body)        read_stdin=1 ;;
+      --body-file)   [[ $# -gt 1 ]] || die "--body-file requires a file path"; shift
+                     if [[ "$1" == "-" ]]; then read_stdin=1
+                     else [[ -f "$1" ]] || die "body-file not found: $1"; BODY="$(cat "$1")"
+                     fi ;;
+      *)             REMAINING_ARGS+=("$1") ;;
     esac
     shift
   done
+  if [[ "$read_stdin" == "1" ]]; then
+    [[ ! -t 0 ]] || die "--body requires body on stdin (pipe or heredoc)"
+    BODY="$(cat)"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1115,19 +1135,23 @@ git-tools — unified issue/PR/CI wrapper for GitHub and Gitea
 
 Platform is auto-detected from the git remote using tea login configuration.
 
+BODY INPUT
+  --body            read body from stdin (heredoc or pipe)
+  --body-file FILE  read body from FILE (use "-" for stdin)
+
 ISSUE COMMANDS
   git-tools issue list   [--limit N] [--assignee U] [--label L] [--state open|closed|all]
   git-tools issue show   <N>
-  git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
-  git-tools issue comment <N> [--body TEXT | --body-file FILE]
+  git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
+  git-tools issue comment <N> [--body | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
   git-tools pr show      <N>
-  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
-  git-tools pr comment   <N> [--body TEXT | --body-file FILE]
+  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
+  git-tools pr comment   <N> [--body | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]


### PR DESCRIPTION
## Summary

- Repurpose `--body` as a stdin-only flag. `--body-file FILE` stays for on-disk content; `--body-file -` aliases to stdin.
- Drop `--body TEXT` entirely — breaking change, hence the `!` in the commit title.
- Rewrite skill docs in both `plugins-claude/git-cli` and `plugins-copilot/git-cli` to use heredoc-to-stdin; remove the `/tmp/pr-body` documentation pattern.
- Bump plugin to `1.4.0` in both manifests.

## Motivation

The previous pattern of writing bodies to `/tmp/pr-body` left stale files that caused follow-up `Write` calls to fail with "file exists, read first." A stdin-only surface eliminates the temp file entirely — no collisions, no cleanup, no shell-escaping. One-liners still work via `printf 'LGTM' | git-cli pr comment N --body`.

## Test plan

- [x] `bash tests/git-cli/test-pr-create.sh` — 8/8 pass (3 new stdin-focused cases)
- [x] `bash test.sh` — 989/989 pass
- [x] `bash .github/scripts/validate-plugins.sh` — 220/0
- [x] `bash .github/scripts/validate-frontmatter.sh` — 77/0
- [x] `rumdl check .` — clean
- [x] Dogfooded: this PR description was piped to `./utils/git-cli pr create --body` via heredoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)