### PR TITLE
fix(git-cli): only emit failed_jobs in run watch on failure

### DIFF
--- a/plugins-claude/git-cli/.claude-plugin/plugin.json
+++ b/plugins-claude/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-cli/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-cli/skills/git-cli/SKILL.md
@@ -102,7 +102,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run logs <run-id> --failed-only
 
 # Watch for CI completion (polls until pass/fail/timeout)
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run watch --branch NAME [--initial-delay S] [--timeout S] [--interval S]
-# Outputs: status (pass|fail|closed|timeout|no-workflow), url, duration, failed_jobs
+# Outputs: status (pass|fail|closed|timeout|no-workflow), url, duration
+# On fail: also emits failed_jobs: <comma-separated names> and dumps failed job logs to stderr
 # On GitHub with a PR: uses statusCheckRollup for reliable CI + merge state detection
 # Without a PR: falls back to run list polling
 ```

--- a/plugins-copilot/git-cli/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "GitHub and Gitea CLI wrapper — issues, pull requests, CI runs, with auto-detected platform and normalized JSON output",
   "author": {
     "name": "Logan Gagne"

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -792,7 +792,6 @@ case "$cmd:$sub" in
         echo "status: pass"
         [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
         echo "duration: 0s"
-        echo "failed_jobs:"
         echo "PR #$pr_number already merged" >&2
         exit 0
       fi
@@ -800,7 +799,6 @@ case "$cmd:$sub" in
         echo "status: closed"
         [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
         echo "duration: 0s"
-        echo "failed_jobs:"
         echo "PR #$pr_number already closed without merging" >&2
         exit 0
       fi
@@ -824,7 +822,6 @@ case "$cmd:$sub" in
         echo "status: pass"
         [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
         echo "duration: 0s"
-        echo "failed_jobs:"
         echo "CI already passed on PR #$pr_number" >&2
         exit 0
       fi
@@ -863,7 +860,6 @@ case "$cmd:$sub" in
             echo "status: pass"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
-            echo "failed_jobs:"
             echo "CI already passed for branch '$branch'" >&2
             exit 0
             ;;
@@ -905,7 +901,6 @@ case "$cmd:$sub" in
           echo "status: pass"
           [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
           echo "duration: ${elapsed}s"
-          echo "failed_jobs:"
           echo "PR #$pr_number merged" >&2
           exit 0
         fi
@@ -915,7 +910,6 @@ case "$cmd:$sub" in
           echo "status: closed"
           [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
           echo "duration: ${elapsed}s"
-          echo "failed_jobs:"
           echo "PR #$pr_number closed without merging" >&2
           exit 0
         fi
@@ -944,7 +938,6 @@ case "$cmd:$sub" in
             echo "status: pass"
             [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
             echo "duration: ${elapsed}s"
-            echo "failed_jobs:"
             exit 0
             ;;
           failure)
@@ -979,7 +972,6 @@ case "$cmd:$sub" in
           echo "status: timeout"
           [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
           echo "duration: ${elapsed}s"
-          echo "failed_jobs:"
           echo "Timed out after ${elapsed}s waiting for CI on PR #$pr_number" >&2
           exit 2
         fi
@@ -1063,7 +1055,6 @@ case "$cmd:$sub" in
           echo "status: pass"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"
-          echo "failed_jobs:"
           exit 0
           ;;
       esac
@@ -1072,7 +1063,6 @@ case "$cmd:$sub" in
         echo "status: timeout"
         [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
         echo "duration: ${elapsed}s"
-        echo "failed_jobs:"
         echo "Timed out after ${elapsed}s waiting for CI on branch '$branch'" >&2
         exit 2
       fi


### PR DESCRIPTION
## Summary

- `run watch` no longer emits an empty `failed_jobs:` line on pass / merged / closed / timeout paths.
- The field is now only printed when a CI failure is detected, alongside the comma-separated list of failed job names.
- Bump `git-cli` plugin to `1.4.1` in both manifests; updated SKILL.md Outputs line.

## Motivation

An empty `failed_jobs:` on a passing run is noise — it implies a lookup happened and came back empty, when in fact we never queried job names at all. Dropping it from success paths makes the output both shorter and more honest: the field's presence now carries information.

## Test plan

- [x] `bash test.sh` — 989/989 pass (failure-path assertions on `failed_jobs:` still hold)
- [x] `bash .github/scripts/validate-plugins.sh` — 220/0
- [x] `bash .github/scripts/validate-frontmatter.sh` — 77/0
- [x] `rumdl check .` — clean
- [x] Verified grep shows only 4 remaining `echo "failed_jobs:"` calls, all in failure branches with a value

🤖 Generated with [Claude Code](https://claude.com/claude-code)