### PR TITLE
fix(permission-manager): unbrick /setup when deps are missing

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.9.5",
+  "version": "2.10.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/README.md
+++ b/plugins-claude/permission-manager/README.md
@@ -11,7 +11,7 @@ claude plugin install St0nefish/agent-toolkit/permission-manager
 Then install required dependencies:
 
 ```bash
-/permissions setup
+/permission-manager:setup
 ```
 
 ## How It Works
@@ -30,7 +30,7 @@ For compound commands, the **most restrictive** decision wins: deny > ask > allo
 
 ### Classification Pipeline
 
-1. **Dependency check** — if `shfmt` or `jq` are missing, all Bash commands are denied with an install message
+1. **Dependency check** — if `shfmt` or `jq` are missing, all Bash commands are denied with an install message (the `/permission-manager:setup` command itself is allowed through via a bootstrap bypass so you can recover)
 2. **Redirection check** — denies `>` and `>>` redirections (except stderr, `/dev/null`, and `/tmp/`)
 3. **shfmt AST parsing** — segments compound commands into individual call expressions
 4. **Per-segment classification** — each segment runs through the classifier chain (first match wins):
@@ -58,14 +58,19 @@ Protected branches (`main`, `master`) get special treatment — `git push` to th
 
 ## Commands
 
-All management is through `/permissions [action]`:
+Dependency setup is its own top-level command:
+
+| Command | Description |
+|---------|-------------|
+| `/permission-manager:setup` | Install `shfmt` and `jq` (allowed through the hook via a bootstrap bypass) |
+
+All other management is through `/permission-manager:permissions [action]`:
 
 | Action | Description |
 |--------|-------------|
 | `commands` | Manage custom command patterns — `list`, `add --scope global\|project`, `remove` |
 | `allow-edit` | Manage the allow-edit command list for accept-edits mode |
 | `web` | Manage WebFetch/WebSearch domain permissions |
-| `setup` | Install `shfmt` and `jq` |
 | `explain` | Trace the classification pipeline for any command |
 | `learn` | Analyze the audit log and suggest custom patterns for frequently seen commands |
 
@@ -74,7 +79,7 @@ All management is through `/permissions [action]`:
 Add glob patterns to auto-allow commands you run frequently:
 
 ```bash
-/permissions commands add --scope project
+/permission-manager:permissions commands add --scope project
 # Then provide patterns like: docker exec myapp cat *
 ```
 
@@ -87,10 +92,10 @@ Both are merged. Patterns use bash glob matching against the full command string
 
 ### Learning From History
 
-The `/permissions learn` action analyzes your audit log to find commands that are frequently prompted and suggests glob patterns:
+The `/permission-manager:permissions learn` action analyzes your audit log to find commands that are frequently prompted and suggests glob patterns:
 
 ```bash
-/permissions learn
+/permission-manager:permissions learn
 # Scans ~/.claude/permission-audit.jsonl
 # Groups by command prefix, computes glob patterns
 # Offers to add them to your config
@@ -103,7 +108,7 @@ When Claude Code is in `acceptEdits` permission mode, the allow-edit classifier 
 Customize the command list:
 
 ```bash
-/permissions allow-edit
+/permission-manager:permissions allow-edit
 ```
 
 Config files: `~/.claude/allow-edit-permissions.json` (global), `.claude/allow-edit-permissions.json` (project).
@@ -119,7 +124,7 @@ Separately from Bash commands, the plugin gates web access with three modes:
 | `domains` | Per-domain allow-list with subdomain matching (e.g. `github.com` matches `api.github.com`) |
 
 ```bash
-/permissions web
+/permission-manager:permissions web
 ```
 
 Config files: `~/.claude/web-permissions.json` (global), `.claude/web-permissions.json` (project). Project mode overrides global; domain lists are merged.
@@ -129,7 +134,7 @@ Config files: `~/.claude/web-permissions.json` (global), `.claude/web-permission
 Trace exactly how any command would be classified:
 
 ```bash
-/permissions explain 'git push origin feature/42-export && docker exec app cat /etc/nginx.conf'
+/permission-manager:permissions explain 'git push origin feature/42-export && docker exec app cat /etc/nginx.conf'
 ```
 
 This runs the full pipeline with instrumented output showing each classifier's decision per segment.
@@ -152,7 +157,7 @@ Override the log location with the `PERMISSION_AUDIT_LOG` environment variable.
 | `jq` | Yes | JSON processing for AST traversal and config |
 | `perl` | Yes | Regex checks in classifiers (standard on macOS/Linux) |
 
-Install via `/permissions setup` (supports Homebrew, apt, dnf, pacman, and `go install` for shfmt).
+Install via `/permission-manager:setup` (supports Homebrew, apt, dnf, pacman, and `go install` for shfmt).
 
 ## Environment Variables
 

--- a/plugins-claude/permission-manager/commands/permissions.md
+++ b/plugins-claude/permission-manager/commands/permissions.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 # Permissions
 
 $IF($1, Run the **$1** action below.)
-$IF(!$1, Available actions: `commands`, `allow-edit`, `setup`, `web`, `explain`, `learn`. Usage: `/permissions [action]`)
+$IF(!$1, Available actions: `commands`, `allow-edit`, `web`, `explain`, `learn`. Usage: `/permission-manager:permissions [action]`. To install dependencies, use `/permission-manager:setup`.)
 
 ---
 
@@ -116,22 +116,6 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/manage-custom-patterns.sh remove --type allow
 #### 4. Show updated state and repeat
 
 After each action, re-run `list --type allow-edit` to show the updated commands, then go back to step 2.
-
----
-
-## setup
-
-Install the required dependencies for the cmd-gate hook.
-
-### Instructions
-
-Run the setup script:
-
-```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup-deps.sh
-```
-
-Report the result to the user. If installation fails, show the manual install links from the script output.
 
 ---
 

--- a/plugins-claude/permission-manager/commands/setup.md
+++ b/plugins-claude/permission-manager/commands/setup.md
@@ -1,0 +1,21 @@
+---
+description: "Install shfmt and jq dependencies for the cmd-gate hook"
+allowed-tools: Bash
+disable-model-invocation: true
+---
+
+# Setup
+
+Install the required dependencies (`shfmt`, `jq`) for the cmd-gate classification hook.
+
+The cmd-gate hook blocks all Bash commands until these are installed. This command is allowed through the hook via a bootstrap bypass so it can recover from that state.
+
+## Instructions
+
+Run the setup script:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup-deps.sh
+```
+
+Report the result to the user. If installation fails, show the manual install links from the script output.

--- a/plugins-claude/permission-manager/scripts/cmd-gate.sh
+++ b/plugins-claude/permission-manager/scripts/cmd-gate.sh
@@ -51,6 +51,17 @@ if [[ "$HOOK_PERMISSION_MODE" == "bypassPermissions" ]]; then
   exit 0
 fi
 
+# --- Bootstrap bypass ---
+# Allow this plugin's own dep-install script through without classification so the
+# user can recover from a missing-deps state (otherwise /permission-manager:setup
+# would itself be blocked by the dep check below — chicken and egg).
+case "$command" in
+  *permission-manager/scripts/setup-deps.sh*)
+    hook_allow "permission-manager: bootstrap (installing dependencies)"
+    exit 0
+    ;;
+esac
+
 # --- Allow-edit mode detection ---
 # In allow-edits mode, Claude Code auto-approves file edits. We promote safe
 # project-local writes (chmod, ln, mkdir, etc.) to auto-allow as well.
@@ -68,7 +79,7 @@ check_dependencies() {
   command -v shfmt &>/dev/null || missing+=("shfmt")
   command -v jq &>/dev/null || missing+=("jq")
   if [[ ${#missing[@]} -gt 0 ]]; then
-    hook_deny "cmd-gate: missing required dependencies: ${missing[*]}. Run /permissions setup to install."
+    hook_deny "cmd-gate: missing required dependencies: ${missing[*]}. Run /permission-manager:setup to install."
     exit 0
   fi
 }

--- a/plugins-claude/permission-manager/scripts/explain.sh
+++ b/plugins-claude/permission-manager/scripts/explain.sh
@@ -44,7 +44,7 @@ command -v shfmt &>/dev/null || missing+=("shfmt")
 command -v jq &>/dev/null || missing+=("jq")
 if [[ ${#missing[@]} -gt 0 ]]; then
   echo "ERROR: Missing required dependencies: ${missing[*]}"
-  echo "Run /permissions setup to install."
+  echo "Run /permission-manager:setup to install."
   exit 0
 fi
 

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.9.5",
+  "version": "2.10.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

- Fix a chicken-and-egg lockout: when `shfmt` or `jq` are missing, the cmd-gate hook denied every Bash command — including the one that installs them. Users had no in-CLI recovery path.
- Promote dep install to its own top-level command `/permission-manager:setup` (symlinked `commands/` means Copilot gets it too).
- Correct slash command references throughout: `/permissions …` → `/permission-manager:permissions …` or `/permission-manager:setup`.

## Changes

- `scripts/cmd-gate.sh`: add a bootstrap bypass before the dep check and Op-code probe — any command containing `permission-manager/scripts/setup-deps.sh` is auto-allowed with reason `"permission-manager: bootstrap (installing dependencies)"`.
- `scripts/cmd-gate.sh` + `scripts/explain.sh`: deny message now points at `/permission-manager:setup` (kept as hard deny — loud failure).
- `commands/setup.md` (new): dedicated setup command runs `setup-deps.sh`.
- `commands/permissions.md`: drop the `setup` sub-action; update usage hint to `/permission-manager:permissions [action]`.
- `README.md`: fix all slash command references and document the bootstrap bypass in the classification pipeline.
- `plugin.json` (both variants): 2.9.5 → 2.10.0.

## Test plan

- [x] `bash test.sh` — 989 tests pass
- [x] `bash .github/scripts/validate-plugins.sh` — 237 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 84 checks, 0 failures
- [x] `rumdl check plugins-claude/permission-manager/` — clean
- [x] Manual: with `shfmt` stripped from `PATH`, `ls -la` denies with new message (`Run /permission-manager:setup to install.`); `bash /opt/foo/permission-manager/scripts/setup-deps.sh` allows with bootstrap reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)