### PR TITLE
feat(serena): add Serena MCP toolkit plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -157,6 +157,15 @@
       "description": "Structural code search and bulk refactoring using AST patterns — model-triggered skill plus setup command",
       "name": "ast-grep",
       "source": "./plugins-claude/ast-grep"
+    },
+    {
+      "author": {
+        "name": "Logan Gagne"
+      },
+      "category": "development",
+      "description": "Serena MCP toolkit — language-server-driven code intelligence with quirks cheatsheet, setup helper, and context-isolated explorer agent",
+      "name": "serena",
+      "source": "./plugins-claude/serena"
     }
   ]
 }

--- a/plugins-claude/serena/.claude-plugin/plugin.json
+++ b/plugins-claude/serena/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "serena",
+  "version": "0.1.0",
+  "description": "Serena MCP toolkit — language-server-driven code intelligence with quirks cheatsheet, setup helper, and context-isolated explorer agent",
+  "author": {
+    "name": "Logan Gagne"
+  }
+}

--- a/plugins-claude/serena/agents/serena-explorer.md
+++ b/plugins-claude/serena/agents/serena-explorer.md
@@ -1,0 +1,151 @@
+---
+name: serena-explorer
+description: Context-isolated code exploration and meta-analysis using the Serena MCP server. Use this agent for verbose queries where the raw tool output would be large but the answer is small — call graphs, blast-radius analysis for renames, "which functions touch X", grouping symbols by some criterion, cross-module dependency mapping. The agent absorbs Serena's verbose JSON in its own context and returns a concise synthesis. Read-only — does not modify the codebase.
+model: haiku
+tools:
+  - mcp__serena__get_symbols_overview
+  - mcp__serena__find_symbol
+  - mcp__serena__find_referencing_symbols
+  - mcp__serena__initial_instructions
+  - Bash
+  - Read
+  - Glob
+  - Grep
+color: cyan
+---
+
+You are a code exploration agent. You answer questions about codebases using
+the Serena MCP server's symbolic tools, and return concise structured findings.
+You exist so the parent context doesn't have to absorb Serena's verbose JSON
+output for meta-analysis questions.
+
+## Hard rule — read-only
+
+You do not modify the codebase. Do not call any of:
+
+- `mcp__serena__replace_symbol_body`
+- `mcp__serena__insert_after_symbol`
+- `mcp__serena__insert_before_symbol`
+- `mcp__serena__rename_symbol`
+- `mcp__serena__safe_delete_symbol`
+- `mcp__serena__replace_content`
+- Edit / Write tools
+
+Do not run git mutations, file mutations, package installs, or any other
+state-changing command. Read-only Bash (`grep`, `cat`, `ls`, `cargo check`,
+`cargo clippy`, read-only `git log/diff/show`) is fine.
+
+If completing a task requires a mutation, report what you found and what
+action is needed — do not take it. The parent agent will execute the change.
+
+## Serena conventions you must know
+
+These are not in Serena's docs — they're learned conventions. Internalize them:
+
+### Symbol paths
+
+- **Rust impl methods**: `impl Type/method`, NOT `Type/method`. Querying without
+  the `impl` prefix returns empty.
+- Free functions and types: bare name (e.g. `ComposeCmd`, `run_compose`).
+- Python: `Class/method`. Java: `Class/method[index]` for overloads.
+
+### Line numbers
+
+Every line number Serena returns is **0-based**. Add 1 to match grep / editor
+output when reporting back to the parent.
+
+### Verbosity control
+
+Serena's reference queries are verbose. Always bound up front:
+
+- Use `relative_path` to restrict to a file or directory — single biggest reduction.
+- Use `max_matches` to cap result count when you expect many.
+- Use `max_answer_chars` as a hard ceiling.
+- For pure counts, drop to `grep -c`.
+
+### Discovery flow
+
+1. Start with `get_symbols_overview` on the relevant file(s) — cheap, structured.
+2. Use `find_symbol` for targeted lookups (use `include_body=true` only when
+   you actually need to read code).
+3. Use `find_referencing_symbols` for callers / dependency mapping.
+4. Fall back to `grep` / `Read` for non-symbolic searches (string literals,
+   comment grepping, full-file context).
+
+## Output format
+
+Structure findings with the parent's context efficiency in mind. Aim for
+**prose summary + structured table/list**, not raw JSON. The parent does not
+need to see Serena's tool output.
+
+Default template:
+
+```text
+## Summary
+
+<1-2 sentence direct answer to the question>
+
+## Findings
+
+| <relevant column> | <relevant column> | <count or location> |
+|---|---|---|
+| ... | ... | ... |
+
+## Notes
+
+<edge cases, gaps, assumptions, line numbers in 1-based form when citing>
+```
+
+Adapt the structure to the question. For "blast radius of renaming X", a
+file-grouped list with site counts is right. For "call graph of fn", a
+nested list works better. For "find dead code", a flat list with file:line.
+
+When citing locations, **convert 0-based Serena line numbers to 1-based** so
+the parent can paste them into editors / grep / cargo errors directly.
+
+## Common task patterns
+
+### Blast-radius analysis (rename impact)
+
+1. `find_referencing_symbols` for the target → group results by file
+2. Count: definition sites, use statements, call sites, test references, comments
+3. Note things `rename_symbol` won't auto-update: test function names, doc
+   comments mentioning the name, string literals
+4. Report: total sites, file-grouped counts, follow-up pass items
+
+### Call graph (depth N from a function)
+
+1. Start with target — `find_symbol` for body
+2. Extract called functions from the body (regex or manual)
+3. For each call, recurse: `find_symbol` to confirm, repeat
+4. Stop at depth N or at known leaf nodes (stdlib, external crates)
+5. Report as nested tree with file:line citations
+
+### Cross-module surface
+
+1. `get_symbols_overview` on each file in the directory
+2. Identify pub items
+3. `find_referencing_symbols` for each pub item, filter to references outside
+   the module's own files
+4. Report: per-symbol external usage count, unused-pub candidates
+
+### Dead-code candidates
+
+1. `get_symbols_overview` to enumerate symbols
+2. For each symbol, `find_referencing_symbols` — exclude self-references and
+   test references if requested
+3. Filter to zero-reference results
+4. Report file:line for each, noting which are pub (intentionally exposed)
+   vs private (real dead code)
+
+## When to push back
+
+If the question can be answered faster with grep alone, say so and use grep.
+You are not obligated to use Serena tools when they don't add value over a
+text search.
+
+If the question requires modifying code, refuse and report what would be
+needed. The parent will handle the mutation.
+
+If Serena is not active in your context (tools unavailable), report that and
+suggest the parent run the `serena-setup` skill.

--- a/plugins-claude/serena/skills/serena-cheatsheet/SKILL.md
+++ b/plugins-claude/serena/skills/serena-cheatsheet/SKILL.md
@@ -1,0 +1,161 @@
+---
+user-invocable: false
+name: serena-cheatsheet
+description: >-
+  Quirks, conventions, and pitfalls for the Serena MCP server. Use whenever
+  calling any `mcp__serena__*` tool — `find_symbol`, `find_referencing_symbols`,
+  `get_symbols_overview`, `replace_symbol_body`, `insert_after_symbol`,
+  `rename_symbol`, `safe_delete_symbol`, `replace_content`. Also use when
+  planning code navigation, refactors, or rename operations on a project that
+  has Serena active. Covers Rust impl-method syntax, 0-based line numbers, the
+  `replace_symbol_body` doc-comment hazard, identifier-aware rename semantics,
+  and verbosity controls.
+---
+
+# Serena cheatsheet
+
+Serena exposes language-server-driven code intelligence over MCP. It's
+genuinely better than grep for symbol-aware operations — but it has sharp
+edges that aren't in the official docs. This skill documents them.
+
+## Symbol path syntax
+
+`name_path` matches the symbol tree *within a source file*. Conventions vary
+by language:
+
+| Language | Pattern | Example |
+|----------|---------|---------|
+| Python | `Class/method` | `MyClass/__init__` |
+| Java | `Class/method[i]` (overload index) | `MyClass/format[1]` |
+| **Rust** | **`impl Type/method`** | `impl App/select_next_running` |
+
+**Rust gotcha:** the `impl` prefix is required. Querying `App/select_next_running`
+returns empty even though the method exists. This is not in Serena's docs — it
+only surfaces from the `name_path` field in `find_referencing_symbols` output.
+
+Free functions and types are bare:
+
+- `find_symbol("ComposeCmd")` — returns the enum
+- `find_symbol("run_compose")` — returns the free function
+
+## Line numbers are 0-based
+
+Every line number Serena emits — in `body_location`, `content_around_reference`,
+or `safe_delete_symbol` refusal output — is **0-based**. Everything else
+(grep, `cargo` errors, your editor, git blame) is 1-based.
+
+When cross-referencing with other tools, add 1.
+
+## `replace_symbol_body` silently deletes doc comments
+
+**This is the highest-impact pitfall.** Reading a symbol via `find_symbol` with
+`include_body=true` returns the body *without* preceding doc comments — the docs
+explicitly state this. But `replace_symbol_body`'s replacement scope **does**
+include the doc comment. So a "round-trip" replace (read body → write body
+back) silently destroys any rustdoc, Python docstring before a function (in
+some languages), or `///`-style comment block.
+
+**Before calling `replace_symbol_body`:**
+
+1. Check whether the target has preceding doc comments (read the file or check
+   surrounding context).
+2. If so, **include the doc comment as part of your new body string.** The
+   write operation needs to reproduce them or they're gone.
+
+Verify with `git diff` after every `replace_symbol_body` call.
+
+## `rename_symbol` is identifier-aware (not text-aware)
+
+This is the biggest win over grep-based rename. `rename_symbol` updates the
+target identifier across the codebase via the language server, so:
+
+- ✅ Updates `print_summary` everywhere it's used as a complete identifier
+- ✅ Crosses files (use statements, call sites, imports)
+- ❌ Does **not** touch `print_summary_to` (different identifier)
+- ❌ Does **not** rename `test_print_summary_*` test functions
+- ❌ Does **not** update string literals or comments mentioning the name
+
+Always verify with two checks:
+
+```bash
+grep -rn '<old_name>' src/   # any survivors?
+cargo check                  # or your language's typecheck
+```
+
+Test function names and rustdoc references usually need a follow-up pass.
+
+The "N changes applied" return count is **files modified**, not sites updated.
+
+## `safe_delete_symbol` returns 0-based references on refusal
+
+When a symbol still has references, `safe_delete_symbol` refuses and returns:
+
+```json
+{"src/runner.rs": [390, 405], "src/main.rs": [21, 291]}
+```
+
+These are 0-based line numbers. Add 1 to match grep / editor output.
+
+## Verbosity control
+
+`find_referencing_symbols` is verbose — every reference in a match arm or
+repeated test call gets its own entry with surrounding context. A query for a
+heavily-used symbol can return 30KB+ of JSON.
+
+Bound output up front:
+
+| Param | Use case |
+|-------|----------|
+| `relative_path` | Restrict to one file/dir — single biggest reduction |
+| `max_matches` | Cap result count; result indicates "more available" |
+| `max_answer_chars` | Hard cap; returns nothing if exceeded (forces refinement) |
+
+When you genuinely just want a count or simple list, **drop to `grep`**. Serena's
+own instruction manual permits grep/glob for discovery — use them.
+
+For verbose meta-analysis questions ("blast radius of renaming X", "call graph
+of run_compose two levels deep"), spawn the **`serena-explorer`** subagent —
+it absorbs the verbose output and returns a concise synthesis.
+
+## Discovery preferences
+
+Serena's instruction manual (loaded when its tools first activate) declares
+`Read` and `Edit` "FORBIDDEN" for code files in favor of symbolic tools. In
+practice this is mostly correct but situational:
+
+- **Use Serena symbolic tools for**: targeted symbol reads, cross-file
+  references, refactor-style edits (rename, delete, replace body, insert).
+- **Use Read for**: full-file reads when you genuinely need surrounding
+  context the symbolic tools strip out (e.g. understanding what's between
+  two top-level functions, reading config/data files, reading tests as a
+  whole).
+- **Use grep/glob for**: pure counts, string-literal searches, comment
+  searches, finding files by name.
+
+The forbidden framing in Serena's manual is overzealous — judgment still
+applies.
+
+## Memories are disabled by config
+
+This installation has Serena's memory tools (`write_memory`, `read_memory`,
+`list_memories`, etc.) explicitly disabled. The onboarding flow is also
+disabled.
+
+Project context lives in source-controlled files (CLAUDE.md, README.md,
+`.serena/project.yml`). Do not try to invoke memory tools — they will not
+appear in the available tool list.
+
+## Quick reference
+
+| Want to | Tool |
+|---------|------|
+| See symbols in a file | `get_symbols_overview` |
+| Read a symbol's body | `find_symbol` with `include_body=true` |
+| Find callers / references | `find_referencing_symbols` |
+| Rename across files | `rename_symbol` |
+| Add code after a symbol | `insert_after_symbol` |
+| Replace a symbol's definition | `replace_symbol_body` (⚠️ doc comments) |
+| Delete an unreferenced symbol | `safe_delete_symbol` |
+| Edit a few lines inside a symbol | `replace_content` (regex) |
+| Count usages of a string | `grep -c` |
+| Heavy meta-analysis | spawn `serena-explorer` agent |

--- a/plugins-claude/serena/skills/serena-setup/SKILL.md
+++ b/plugins-claude/serena/skills/serena-setup/SKILL.md
@@ -1,0 +1,119 @@
+---
+user-invocable: false
+name: serena-setup
+description: >-
+  Install the Serena MCP server and register it with Claude Code. Use when the
+  user asks to "install Serena", "set up Serena", "configure Serena MCP", or
+  when `mcp__serena__*` tools are unavailable / the Serena MCP server is
+  disconnected and needs to be installed. Installs via `uv tool install`
+  (Python — no Node.js / npm involved) and writes the MCP server entry to
+  `~/.claude.json`.
+---
+
+# Serena setup
+
+Serena is a Python project distributed via the `oraios/serena` GitHub repo.
+It exposes a stdio MCP server (`serena start-mcp-server`) that brings
+language-server-driven code intelligence into Claude Code.
+
+## Prerequisites
+
+- `uv` (Astral's Python package manager) — install via:
+
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
+
+  Or via system package manager (Arch: `pacman -S uv`).
+
+Serena's source tree includes Node.js artifacts only as a transitive concern;
+**this skill never touches npm/node/npx.** Installation is pure Python via uv.
+
+## Install
+
+```bash
+uv tool install --from git+https://github.com/oraios/serena serena
+```
+
+This puts the `serena` binary at `~/.local/bin/serena` (ensure that's on
+`PATH`). Verify:
+
+```bash
+which serena && serena --version
+```
+
+To upgrade later: `uv tool upgrade serena`.
+
+## Register with Claude Code
+
+Add an MCP server entry to `~/.claude.json`. The recommended invocation:
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "serena",
+      "args": [
+        "start-mcp-server",
+        "--context",
+        "claude-code",
+        "--project-from-cwd"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+Key flags:
+
+- `--context claude-code` — Serena tunes its behavior (prompts, tool descriptions) for Claude Code.
+- `--project-from-cwd` — Serena auto-detects the active project from the current
+  working directory. No per-project config needed.
+
+The entry can live at user level (`~/.claude.json` top-level `mcpServers`) for
+all projects, or per-project under `.projects[<path>].mcpServers`.
+
+## Disable memories (recommended)
+
+Serena's "memories" feature stores opaque sidecar notes that aren't
+source-controlled. Disable it for source-of-truth-in-the-repo workflows.
+
+Add to your Serena project config (`.serena/project.yml` or via CLI flag):
+
+```yaml
+# .serena/project.yml
+disable_memories: true
+disable_onboarding: true
+```
+
+Or pass `--disable-memories --disable-onboarding` to the `start-mcp-server`
+args. With memories disabled, the memory MCP tools (`write_memory`,
+`read_memory`, etc.) won't appear in the tool list, and the onboarding flow
+won't trigger.
+
+## Verify
+
+After registering and reconnecting Claude Code:
+
+1. `mcp__serena__*` tools should appear in the available tool list (some
+   surfaces show them as "deferred" until first use).
+2. Calling `mcp__serena__initial_instructions` should return Serena's
+   manual without errors.
+3. Calling `mcp__serena__get_symbols_overview` on a source file in your
+   project should return structured symbol data.
+
+If tools don't appear, check:
+
+- `serena` is on `PATH` (`which serena`)
+- The MCP entry uses `"type": "stdio"` and the correct args
+- Claude Code has reconnected (toggle the MCP server, or restart the session)
+- Logs: Serena writes to `~/.serena/logs/` by default
+
+## See also
+
+- The `serena-cheatsheet` skill (this plugin) covers usage quirks once Serena
+  is running.
+- The `serena-explorer` agent (this plugin) handles verbose meta-analysis
+  queries.


### PR DESCRIPTION
## Summary

Adds a new plugin bundling skills and an agent for the [Serena MCP server](https://github.com/oraios/serena), which provides language-server-driven code intelligence (`find_symbol`, `find_referencing_symbols`, `rename_symbol`, etc.) over MCP.

- **`skills/serena-cheatsheet`** — language-quirks reference. Auto-triggers on `mcp__serena__*` tool use. Covers Rust impl-method syntax (`impl Type/method`), 0-based line numbers, the `replace_symbol_body` doc-comment hazard, identifier-aware rename semantics, and verbosity controls (`max_matches`, `relative_path`).
- **`skills/serena-setup`** — install runbook. `uv tool install --from git+https://github.com/oraios/serena serena` + MCP registration in `~/.claude.json`. Pure Python via `uv` — no Node.js.
- **`agents/serena-explorer`** — read-only haiku-backed subagent for context-isolated meta-analysis (call graphs, blast-radius analysis for renames, dead-code candidates). Absorbs Serena's verbose JSON in subagent context and returns concise structured findings.

Quirks documented in the cheatsheet were learned through hands-on testing in a Rust project: Phase 2 read-only queries (overview/find/references) and Phase 3 mutating tests (insert, replace, rename, safe-delete) on a throwaway branch. The `replace_symbol_body` doc-comment loss is the highest-impact pitfall and is called out prominently.

Claude-only — no `plugins-copilot/` mirror, since the Copilot CLI plugin spec does not currently support shipping subagents. The cheatsheet skill alone could mirror cleanly when ported manually.

## Test plan

- [x] \`bash .github/scripts/validate-plugins.sh\` — 221 checks, 0 failures
- [x] \`bash .github/scripts/validate-frontmatter.sh\` — 81 checks, 0 failures
- [x] \`rumdl check plugins-claude/serena/\` — clean
- [x] \`bash test.sh\` — 8 pre-existing failures on master (\`scan\` tests), unrelated to this change
- [ ] CI passes
- [ ] Skills auto-trigger on \`mcp__serena__*\` tool use after install
- [ ] \`serena-explorer\` agent invokable for meta-analysis queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)