### PR TITLE
feat(permission-manager): curl classifier + WebFetch domain unification

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.10.1",
+  "version": "2.12.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/classifiers/curl.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/curl.sh
@@ -1,0 +1,155 @@
+# shellcheck shell=bash
+# shellcheck source=../lib-classify.sh
+# shellcheck source=../lib-web-domains.sh
+
+# --- curl classifier ---
+# Treats curl as read-only by default and asks when flags indicate a
+# state-changing request (POST/PUT/etc.), data/file upload, or a write
+# to local disk outside of /tmp//dev/null.
+#
+# When web-permissions is in "domains" mode, also restricts read-only curl
+# to URLs whose host matches the WebFetch allow-list. This unifies curl with
+# the WebFetch domain config — no need to maintain two lists.
+#
+# Mode behavior (after dangerous-flag screening):
+#   off     — allow read-only curl to any URL (no domain check)
+#   all     — allow read-only curl to any URL
+#   domains — every URL token in the command must match WEB_DOMAINS, else ask
+check_curl() {
+  echo "$command" | perl -ne '$f=1,last if /^\s*curl(\s|$)/; END{exit !$f}' || return 0
+
+  local -a tokens=() urls=()
+  read -ra tokens <<<"$command"
+
+  local i=1 len=${#tokens[@]}
+  local tok letters method target
+
+  while ((i < len)); do
+    tok="${tokens[$i]}"
+    case "$tok" in
+      # === Mutating / write flags → ask ===
+      --data | --data-ascii | --data-binary | --data-raw | --data-urlencode | \
+        --data=* | --data-ascii=* | --data-binary=* | --data-raw=* | --data-urlencode=* | \
+        --form | --form=* | --form-string | --form-string=* | \
+        --upload-file | --upload-file=* | \
+        --cookie-jar | --cookie-jar=* | \
+        --config | --config=* | \
+        --remote-name | --remote-name-all | --remote-header-name | --create-dirs | \
+        -O)
+        ask "curl ${tok%%=*} sends body / uploads / writes disk"
+        return 0
+        ;;
+
+      # Output to file — allow scratch destinations (/tmp/, /dev/null)
+      -o | --output)
+        target="${tokens[$((i + 1))]:-}"
+        if [[ "$target" == "/dev/null" || "$target" == /tmp/* ]]; then
+          ((i += 2)) || true
+          continue
+        fi
+        ask "curl writes to local file: $target"
+        return 0
+        ;;
+      --output=*)
+        target="${tok#*=}"
+        if [[ "$target" == "/dev/null" || "$target" == /tmp/* ]]; then
+          ((i++)) || true
+          continue
+        fi
+        ask "curl writes to local file: $target"
+        return 0
+        ;;
+
+      # -X / --request — only GET/HEAD allowed
+      -X | --request)
+        method="${tokens[$((i + 1))]:-}"
+        case "$method" in
+          GET | HEAD | get | head | "")
+            ((i += 2)) || true
+            ;;
+          *)
+            ask "curl -X $method (mutating method)"
+            return 0
+            ;;
+        esac
+        ;;
+      -X=* | --request=*)
+        method="${tok#*=}"
+        case "$method" in
+          GET | HEAD | get | head)
+            ((i++)) || true
+            ;;
+          *)
+            ask "curl -X $method (mutating method)"
+            return 0
+            ;;
+        esac
+        ;;
+      -X[A-Za-z]*)
+        method="${tok#-X}"
+        case "$method" in
+          GET | HEAD | get | head)
+            ((i++)) || true
+            ;;
+          *)
+            ask "curl -X$method (mutating method)"
+            return 0
+            ;;
+        esac
+        ;;
+
+      # === Flags whose next token is an argument value (not a URL) ===
+      # Skip these to avoid treating their values as fetch URLs (e.g. --referer
+      # https://x.com is the Referer header, not a request target).
+      -e | --referer | -x | --proxy | --proxy-user | --proxy-header | \
+        -H | --header | -A | --user-agent | -u | --user | -b | --cookie | \
+        -w | --write-out | -m | --max-time | --connect-timeout | \
+        --retry | --retry-delay | --retry-max-time | --retry-connrefused | \
+        --cert | --key | --cacert | --capath | -E | \
+        --resolve | --interface | --dns-servers | --connect-to | \
+        --hostpubmd5 | --hostpubsha256 | --pinnedpubkey | --tls-max | \
+        --tlsuser | --tlspassword | --range | -r | --speed-limit | --speed-time)
+        ((i += 2)) || true
+        ;;
+
+      # === Combined short flags (e.g. -sL, -sLI) ===
+      # Letters that imply write/upload/data/method: o O T c d F K X
+      -[!-]*)
+        letters="${tok#-}"
+        if [[ "$letters" == *[oOTcdFKX]* ]]; then
+          ask "curl short-flag bundle '$tok' contains write/upload/data/method flag"
+          return 0
+        fi
+        ((i++)) || true
+        ;;
+
+      # === URL token ===
+      http://* | https://* | ftp://* | ftps://* | file://*)
+        urls+=("$tok")
+        ((i++)) || true
+        ;;
+
+      *)
+        ((i++)) || true
+        ;;
+    esac
+  done
+
+  # === Domain allow-list check (only in "domains" mode) ===
+  # In "off" / "all" mode, behave as before — allow any read-only fetch.
+  # In "domains" mode, every fetched URL must match WEB_DOMAINS or we ask.
+  if [[ "${WEB_MODE:-off}" == "domains" && ${#urls[@]} -gt 0 ]]; then
+    local url domain
+    for url in "${urls[@]+"${urls[@]}"}"; do
+      domain=$(web_extract_domain "$url")
+      if ! web_domain_matches "$domain"; then
+        ask "curl to $domain (not in web-permissions allow-list)"
+        return 0
+      fi
+    done
+    allow "curl to allow-listed domain(s)"
+    return 0
+  fi
+
+  allow "curl is a read-only HTTP request"
+}

--- a/plugins-claude/permission-manager/scripts/cmd-gate.sh
+++ b/plugins-claude/permission-manager/scripts/cmd-gate.sh
@@ -104,6 +104,8 @@ fi
 SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=lib-classify.sh
 source "$SCRIPTS_DIR/lib-classify.sh"
+# shellcheck source=lib-web-domains.sh
+source "$SCRIPTS_DIR/lib-web-domains.sh"
 for _clf in "$SCRIPTS_DIR/classifiers/"*.sh; do
   # shellcheck disable=SC1090
   source "$_clf"
@@ -112,6 +114,7 @@ unset _clf
 
 load_custom_patterns
 load_allow_edit_commands
+web_load_config
 
 # --- Audit logging ---
 # Append ask/deny decisions to a JSONL log for learn.sh to analyze.

--- a/plugins-claude/permission-manager/scripts/explain.sh
+++ b/plugins-claude/permission-manager/scripts/explain.sh
@@ -63,6 +63,8 @@ fi
 SCRIPTS_DIR="$(dirname "$0")"
 # shellcheck source=lib-classify.sh
 source "$SCRIPTS_DIR/lib-classify.sh"
+# shellcheck source=lib-web-domains.sh
+source "$SCRIPTS_DIR/lib-web-domains.sh"
 for _clf in "$SCRIPTS_DIR/classifiers/"*.sh; do
   # shellcheck disable=SC1090
   source "$_clf"
@@ -71,6 +73,7 @@ unset _clf
 
 load_custom_patterns
 load_allow_edit_commands
+web_load_config
 
 # --- Explain trace state ---
 declare -a EXPLAIN_TRACE=()
@@ -125,6 +128,7 @@ CLASSIFIERS=(
   check_gh
   check_tea
   check_docker
+  check_curl
   check_npm
   check_pip
   check_cargo

--- a/plugins-claude/permission-manager/scripts/lib-classify.sh
+++ b/plugins-claude/permission-manager/scripts/lib-classify.sh
@@ -51,11 +51,16 @@ deny() {
 # Outputs one command per line.
 parse_segments() {
   printf '%s' "$1" | shfmt --tojson 2>/dev/null | jq -r '
+    def part_value:
+      if .Type? == "Lit" then .Value
+      elif .Type? == "SglQuoted" then .Value
+      elif .Type? == "DblQuoted" then ([.Parts[]? | part_value] | join(""))
+      else "" end;
     def extract_cmds:
       if .Cmd?.Type? == "BinaryCmd" then
         (.Cmd.X | extract_cmds), (.Cmd.Y | extract_cmds)
       elif .Cmd?.Type? == "CallExpr" then
-        [.Cmd.Args[]? | [.Parts[]? | select(.Type? == "Lit") | .Value] | join("")] | join(" ")
+        [.Cmd.Args[]? | [.Parts[]? | part_value] | join("")] | join(" ")
       elif type == "object" then
         if .Cmd? then .Cmd | extract_cmds else empty end
       else empty end;
@@ -178,6 +183,9 @@ classify_single_command() {
   [[ "$CLASSIFY_MATCHED" -eq 1 ]] && return 0
 
   check_docker
+  [[ "$CLASSIFY_MATCHED" -eq 1 ]] && return 0
+
+  check_curl
   [[ "$CLASSIFY_MATCHED" -eq 1 ]] && return 0
 
   check_npm

--- a/plugins-claude/permission-manager/scripts/lib-web-domains.sh
+++ b/plugins-claude/permission-manager/scripts/lib-web-domains.sh
@@ -1,0 +1,70 @@
+# shellcheck shell=bash
+# lib-web-domains.sh — Shared web-permissions config loader and domain matcher.
+# Sourced by web-gate.sh (WebFetch/WebSearch gating) and classifiers/curl.sh
+# (Bash curl gating) so both consult the same allow-list.
+#
+# Config file shape (global: ~/.claude/web-permissions.json,
+#                    project: .claude/web-permissions.json):
+#   { "mode": "off|all|domains", "domains": ["github.com", ...] }
+#
+# Mode resolution: project mode wins over global; domains arrays merge (union).
+#
+# Override paths via env vars for testing:
+#   WEB_PERMISSIONS_GLOBAL  — default: ~/.claude/web-permissions.json
+#   WEB_PERMISSIONS_PROJECT — default: .claude/web-permissions.json
+#
+# After web_load_config:
+#   WEB_MODE     — "off" | "all" | "domains"
+#   WEB_DOMAINS  — array of allow-listed domains (deduplicated)
+
+WEB_MODE="off"
+WEB_DOMAINS=()
+WEB_CONFIG_LOADED=0
+
+web_load_config() {
+  [[ "$WEB_CONFIG_LOADED" -eq 1 ]] && return 0
+  WEB_CONFIG_LOADED=1
+
+  local global_file="${WEB_PERMISSIONS_GLOBAL:-${HOME}/.claude/web-permissions.json}"
+  local project_file="${WEB_PERMISSIONS_PROJECT:-.claude/web-permissions.json}"
+
+  local global_mode="off" project_mode="off"
+  if [[ -f "$global_file" ]]; then
+    global_mode=$(jq -r '.mode // "off"' "$global_file" 2>/dev/null || echo "off")
+  fi
+  if [[ -f "$project_file" ]]; then
+    project_mode=$(jq -r '.mode // "off"' "$project_file" 2>/dev/null || echo "off")
+    WEB_MODE="$project_mode"
+  else
+    WEB_MODE="$global_mode"
+  fi
+
+  WEB_DOMAINS=()
+  while IFS= read -r d; do
+    [[ -z "$d" ]] && continue
+    WEB_DOMAINS+=("$d")
+  done < <({
+    [[ -f "$global_file" ]] && jq -r '.domains[]? // empty' "$global_file" 2>/dev/null
+    [[ -f "$project_file" ]] && jq -r '.domains[]? // empty' "$project_file" 2>/dev/null
+  } | sort -u)
+}
+
+web_extract_domain() {
+  local url="$1"
+  local host="${url#*://}"
+  host="${host%%/*}"
+  host="${host%%\?*}"
+  host="${host%%#*}"
+  host="${host%%:*}"
+  host="${host##*@}"
+  printf '%s' "$host"
+}
+
+web_domain_matches() {
+  local check="$1" allowed
+  for allowed in "${WEB_DOMAINS[@]+"${WEB_DOMAINS[@]}"}"; do
+    [[ "$check" == "$allowed" ]] && return 0
+    [[ "$check" == *".${allowed}" ]] && return 0
+  done
+  return 1
+}

--- a/plugins-claude/permission-manager/scripts/web-gate.sh
+++ b/plugins-claude/permission-manager/scripts/web-gate.sh
@@ -28,49 +28,15 @@ if [[ "$HOOK_PERMISSION_MODE" == "bypassPermissions" ]]; then
 fi
 
 # --- Config loading ---
-GLOBAL_CONFIG="${WEB_PERMISSIONS_GLOBAL:-${HOME}/.claude/web-permissions.json}"
-PROJECT_CONFIG="${WEB_PERMISSIONS_PROJECT:-.claude/web-permissions.json}"
-
-load_mode() {
-  local file="$1"
-  if [[ -f "$file" ]]; then
-    jq -r '.mode // "off"' "$file" 2>/dev/null || echo "off"
-  else
-    echo "off"
-  fi
-}
-
-load_domains() {
-  local file="$1"
-  if [[ -f "$file" ]]; then
-    jq -r '.domains[]? // empty' "$file" 2>/dev/null || true
-  fi
-}
-
-# Project mode wins over global; domains merge (union)
-GLOBAL_MODE=$(load_mode "$GLOBAL_CONFIG")
-PROJECT_MODE=$(load_mode "$PROJECT_CONFIG")
-
-if [[ -f "$PROJECT_CONFIG" ]]; then
-  MODE="$PROJECT_MODE"
-else
-  MODE="$GLOBAL_MODE"
-fi
+# shellcheck source=lib-web-domains.sh
+source "$(dirname "$0")/lib-web-domains.sh"
+web_load_config
+MODE="$WEB_MODE"
 
 # off → passthrough
 if [[ "$MODE" == "off" ]]; then
   exit 0
 fi
-
-# Merge domains from both scopes (deduplicated)
-DOMAINS=()
-while IFS= read -r d; do
-  [[ -z "$d" ]] && continue
-  DOMAINS+=("$d")
-done < <({
-  load_domains "$GLOBAL_CONFIG"
-  load_domains "$PROJECT_CONFIG"
-} | sort -u)
 
 # --- Extract request details ---
 if [[ "$HOOK_FORMAT" == "copilot" ]]; then
@@ -127,40 +93,9 @@ if [[ "$MODE" == "all" ]]; then
 fi
 
 # Mode is "domains" — extract domain from URL and check allow-list
-extract_domain() {
-  local url="$1"
-  # Strip protocol
-  local host="${url#*://}"
-  # Strip path/query
-  host="${host%%/*}"
-  host="${host%%\?*}"
-  host="${host%%#*}"
-  # Strip port
-  host="${host%%:*}"
-  # Strip userinfo
-  host="${host##*@}"
-  echo "$host"
-}
+DOMAIN=$(web_extract_domain "$URL")
 
-DOMAIN=$(extract_domain "$URL")
-
-# Check domain against allow-list (exact or subdomain match)
-domain_matches() {
-  local check="$1"
-  for allowed in "${DOMAINS[@]}"; do
-    # Exact match
-    if [[ "$check" == "$allowed" ]]; then
-      return 0
-    fi
-    # Subdomain match: check ends with .allowed
-    if [[ "$check" == *".${allowed}" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-if [[ ${#DOMAINS[@]} -gt 0 ]] && domain_matches "$DOMAIN"; then
+if [[ ${#WEB_DOMAINS[@]} -gt 0 ]] && web_domain_matches "$DOMAIN"; then
   log_decision "allow" "web-gate: domain $DOMAIN in allow-list"
   hook_allow "web-gate: domain $DOMAIN in allow-list"
   exit 0

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.10.1",
+  "version": "2.12.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -317,6 +317,103 @@ run_test_both ask "docker exec container1 cargo publish" "docker exec cargo publ
 run_test_both ask "docker exec -it container1 bash" "docker exec bash (unrecognized inner → ask)"
 run_test_both deny "docker exec container1 find /tmp -delete" "docker exec find -delete (deny inner)"
 
+# ===== ALLOW: curl read-only =====
+echo "── curl read-only ──"
+run_test_both allow "curl https://example.com"
+run_test_both allow "curl -sL https://example.com"
+run_test_both allow "curl -sS https://example.com"
+run_test_both allow "curl -sI https://example.com" "curl -sI (HEAD)"
+run_test_both allow "curl -I https://example.com" "curl -I (HEAD)"
+run_test_both allow "curl -L --compressed https://example.com"
+run_test_both allow "curl -H 'Authorization: Bearer x' https://example.com" "curl -H header"
+run_test_both allow "curl -A 'agent' https://example.com" "curl -A user agent"
+run_test_both allow "curl -u user:pass https://example.com" "curl -u basic auth"
+run_test_both allow "curl --max-time 5 https://example.com" "curl --max-time"
+run_test_both allow "curl -X GET https://example.com" "curl -X GET"
+run_test_both allow "curl -X HEAD https://example.com" "curl -X HEAD"
+run_test_both allow "curl -XGET https://example.com" "curl -XGET (attached)"
+run_test_both allow "curl -o /tmp/foo.json https://example.com" "curl -o /tmp/ (scratch)"
+run_test_both allow "curl -o /dev/null -w '%{http_code}' https://example.com" "curl -o /dev/null"
+run_test_both allow "curl --output=/tmp/foo https://example.com" "curl --output=/tmp/"
+run_test_both allow "curl -sL 'https://hub.docker.com/v2/repositories/seerr/seerr/tags?page_size=100'" "curl docker hub api"
+
+# ===== ASK: curl write/mutating operations =====
+echo "── curl write/mutating ──"
+run_test_both ask "curl -X POST https://example.com" "curl -X POST"
+run_test_both ask "curl -X PUT https://example.com" "curl -X PUT"
+run_test_both ask "curl -X DELETE https://example.com" "curl -X DELETE"
+run_test_both ask "curl -XPOST https://example.com" "curl -XPOST (attached)"
+run_test_both ask "curl -d '{\"x\":1}' https://example.com" "curl -d data"
+run_test_both ask "curl --data-binary @file https://example.com" "curl --data-binary"
+run_test_both ask "curl -F field=value https://example.com" "curl -F form"
+run_test_both ask "curl -T file https://example.com" "curl -T upload"
+run_test_both ask "curl --upload-file file https://example.com" "curl --upload-file"
+run_test_both ask "curl -O https://example.com/file.zip" "curl -O remote-name"
+run_test_both ask "curl -o /etc/hosts https://example.com" "curl -o non-scratch path"
+run_test_both ask "curl -o ./out.txt https://example.com" "curl -o cwd-relative"
+run_test_both ask "curl --output=./out.txt https://example.com" "curl --output= non-scratch"
+run_test_both ask "curl -K config.txt https://example.com" "curl -K config"
+run_test_both ask "curl --cookie-jar jar.txt https://example.com" "curl --cookie-jar"
+run_test_both ask "curl -sLo out.txt https://example.com" "curl -sLo bundle (writes file)"
+run_test_both ask "curl -sLd '{}' https://example.com" "curl -sLd bundle (data)"
+
+# ===== ALLOW: curl pipelines (regression for the python3 case) =====
+echo "── curl pipelines ──"
+run_test_both allow "curl -sL https://example.com | jq ." "curl | jq"
+run_test_both allow "curl -sL https://example.com | grep foo | head -5" "curl | grep | head"
+run_test_both allow "curl -sL https://example.com 2>&1 | jq -r '.results[].name' | head -30" "curl with stderr redirect | jq | head"
+
+# ===== curl + web-permissions domain integration =====
+# When web-permissions is in "domains" mode, curl URLs must match the allow-list.
+# In "off" / "all" mode, curl auto-allows any read fetch (current behavior).
+echo "── curl + web-permissions domains ──"
+
+CURL_WEB_TMP=$(mktemp -d)
+trap 'rm -rf "$CURL_WEB_TMP"' EXIT
+CURL_WEB_PROJECT="$CURL_WEB_TMP/web-permissions.json"
+export WEB_PERMISSIONS_GLOBAL="$CURL_WEB_TMP/global-empty.json"
+export WEB_PERMISSIONS_PROJECT="$CURL_WEB_PROJECT"
+
+# domains mode: only allow-listed hosts pass
+echo '{"mode":"domains","domains":["github.com","hub.docker.com","docker.io"]}' >"$CURL_WEB_PROJECT"
+run_test_both allow "curl -sL https://hub.docker.com/v2/repositories/seerr/seerr/tags" "domains: hub.docker.com (exact match)"
+run_test_both allow "curl -sL https://api.github.com/repos/anthropics/claude-code" "domains: api.github.com (subdomain match)"
+run_test_both allow "curl -sL https://hub.docker.com/v2/foo | jq -r '.name'" "domains: pipeline through allow-listed host"
+run_test_both ask "curl -sL https://evil.example.com/secrets" "domains: unlisted host → ask"
+run_test_both ask "curl -sL https://example.com" "domains: bare unlisted host → ask"
+# When ANY URL in the command is unlisted, ask
+run_test_both ask "curl https://hub.docker.com/foo https://evil.com/bar" "domains: one good + one bad → ask"
+# No URL token at all (e.g. --version) — allow
+run_test_both allow "curl --version" "domains: no URL → allow"
+run_test_both allow "curl --help" "domains: --help no URL → allow"
+# Headers with non-URL values are correctly skipped
+run_test_both allow "curl -H 'Authorization: Bearer abc' https://hub.docker.com/foo" "domains: -H non-URL value skipped"
+run_test_both allow "curl -A 'my-agent/1.0' https://hub.docker.com/foo" "domains: -A user agent skipped"
+# Single-token URL-shaped flag values get consumed correctly
+run_test_both allow "curl --referer https://elsewhere.com https://hub.docker.com/foo" "domains: --referer single-token value consumed"
+run_test_both allow "curl -e https://elsewhere.com https://hub.docker.com/foo" "domains: -e referer single-token value consumed"
+# Known limitation: a multi-word header value containing a URL (e.g. -H 'Referer: https://x.com')
+# gets re-split by the classifier's whitespace tokenizer and the URL inside is treated as a
+# separate fetch URL. Asking is the safe answer — a Referer leak isn't a fetch but the user
+# can still approve. Most curl usage doesn't put URLs in header values.
+run_test_both ask "curl -H 'Referer: https://elsewhere.com' https://hub.docker.com/foo" "domains: -H 'Referer: URL' multi-word value (false positive → ask)"
+
+# all mode: any URL passes (read-only flags only)
+echo '{"mode":"all"}' >"$CURL_WEB_PROJECT"
+run_test_both allow "curl -sL https://random.example.org/data" "all: any URL allowed"
+
+# off mode: no domain check, current blanket-allow behavior
+echo '{"mode":"off"}' >"$CURL_WEB_PROJECT"
+run_test_both allow "curl -sL https://random.example.org/data" "off: any URL allowed"
+
+# Missing config file → behaves like off
+rm -f "$CURL_WEB_PROJECT"
+run_test_both allow "curl -sL https://random.example.org/data" "no config → any URL allowed"
+
+unset WEB_PERMISSIONS_GLOBAL WEB_PERMISSIONS_PROJECT
+rm -rf "$CURL_WEB_TMP"
+trap - EXIT
+
 # ===== ALLOW: npm/node read-only =====
 echo "── npm/node read-only ──"
 run_test_both allow "node --version"
@@ -527,7 +624,6 @@ run_test_both allow "cd /tmp && bash test.sh" "compound: cd + bash script"
 
 # ===== PASSTHROUGH: unrecognized commands (no opinion — defer to Claude Code) =====
 echo "── Unrecognized commands (passthrough) ──"
-run_test_both none "curl https://example.com" "curl (passthrough)"
 run_test_both none "wget https://example.com" "wget (passthrough)"
 run_test_both none "make build" "make (passthrough)"
 run_test_both none "rm -rf /tmp/test" "rm (passthrough)"

--- a/tests/permission-manager/test-explain.sh
+++ b/tests/permission-manager/test-explain.sh
@@ -92,8 +92,8 @@ run_test "docker exec find -delete → DENY, inner command trace" \
 
 # ===== Unrecognized command =====
 echo "── Unrecognized command traces ──"
-run_test "curl → no classifier matched" \
-  "curl https://example.com" \
+run_test "wget → no classifier matched" \
+  "wget https://example.com" \
   "no classifier matched"
 
 # ===== Custom pattern match =====


### PR DESCRIPTION
## Summary

- Adds a `curl` classifier so read-only HTTP requests auto-allow without prompting (silent, follow, headers, basic auth, custom user-agent, etc.). Mutating flags (`-X POST`, `-d`, `-F`, `-T`, `-O`, `-K`, `--cookie-jar`) and writes outside `/tmp/` / `/dev/null` ask for approval.
- Unifies curl with the existing `WebFetch` domain allow-list. `web-gate.sh` and the new curl classifier now read the same `web-permissions.json` via a shared `lib-web-domains.sh` library. In `domains` mode, curl URLs must match the allow-list — same mental model as `WebFetch`, no second list to maintain.
- Fixes a pre-existing limitation in `parse_segments` that stripped quoted-string content during compound-command segmentation. Walks `DblQuoted` / `SglQuoted` parts now so `curl "https://host/path?x=1"` survives parsing.

## Context

`curl` was previously unclassified and fell through to Claude Code's built-in permission system, prompting on every read-only fetch. The pre-existing `web-gate.sh` already implemented domain gating for `WebFetch`/`WebSearch`, but its config was unreachable from Bash classification. This PR factors the loader/matcher into a shared lib and wires curl into it so a single `web-permissions.json` governs both pathways.

Behavior by mode:

| `mode` | curl in this command |
|---|---|
| `off` (default) | blanket-allow read-only fetches (current behavior preserved) |
| `all` | blanket-allow read-only fetches |
| `domains` | every URL token must match `domains` allow-list, else ask |

## Files

- **new** `plugins-claude/permission-manager/scripts/classifiers/curl.sh` — flag screening, URL extraction, optional domain check
- **new** `plugins-claude/permission-manager/scripts/lib-web-domains.sh` — `web_load_config` / `web_extract_domain` / `web_domain_matches`
- **refactor** `plugins-claude/permission-manager/scripts/web-gate.sh` — uses the shared lib (45 web-gate tests still pass)
- **wire** `cmd-gate.sh`, `explain.sh`, `lib-classify.sh` (parse_segments + dispatch order)
- **tests** 41 new cases in `test-classify.sh` covering flag screening, scratch-path output, pipelines, and domains-mode integration. One documented false-positive (multi-word header values like `-H 'Referer: https://x.com'` re-tokenize and the inner URL gets domain-checked).
- **bump** `2.10.1` → `2.12.0` (Claude + Copilot variants)

## Test plan

- [ ] `bash test.sh` — 1156 passed
- [ ] `bash tests/permission-manager/test-classify.sh` — 792 passed
- [ ] `bash tests/permission-manager/test-web-gate.sh` — 45 passed
- [ ] `bash tests/permission-manager/test-explain.sh` — 10 passed
- [ ] `bash .github/scripts/validate-plugins.sh` — 265 checks, 0 failures
- [ ] `bash .github/scripts/validate-frontmatter.sh` — 94 checks, 0 failures
- [ ] `rumdl check .` — clean
- [ ] Smoke-tested end-to-end: `curl -sL "https://hub.docker.com/..." | jq | head` → allow when `hub.docker.com` is in `domains`; → ask when target is unlisted; → allow when mode is `off` / no config