### PR TITLE
feat(permission-manager): Python read-only classifier for python -c

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/README.md
+++ b/plugins-claude/permission-manager/README.md
@@ -32,8 +32,9 @@ For compound commands, the **most restrictive** decision wins: deny > ask > allo
 
 1. **Dependency check** — if `shfmt` or `jq` are missing, all Bash commands are denied with an install message (the `/permission-manager:setup` command itself is allowed through via a bootstrap bypass so you can recover)
 2. **Redirection check** — denies `>` and `>>` redirections (except stderr, `/dev/null`, and `/tmp/`)
-3. **shfmt AST parsing** — segments compound commands into individual call expressions
-4. **Per-segment classification** — each segment runs through the classifier chain (first match wins):
+3. **Inline Python check** — for `python[3] -c "..."` or `python[3] -m <module>` invocations, statically analyses the inline source via `check-python-readonly.py` (allowlisted imports, read-only `open()`, no subprocess/exec/network/dunder escapes); allow when safe, ask with reason when unsafe
+4. **shfmt AST parsing** — segments compound commands into individual call expressions
+5. **Per-segment classification** — each segment runs through the classifier chain (first match wins):
    1. Custom user patterns
    2. Allow-edit commands (when in accept-edits mode)
    3. `find` safety
@@ -47,8 +48,8 @@ For compound commands, the **most restrictive** decision wins: deny > ask > allo
    11. `pip`/`python`/`poetry`/`pyenv`/`uv`
    12. `cargo`/`rustc`/`rustup`
    13. JVM tools (`java`/`javac`/`javap`/`mvn`/`jar`/`kotlin`)
-5. **Aggregate** — most restrictive across all segments wins
-6. **Audit log** — all decisions are appended to `~/.claude/permission-audit.jsonl`
+6. **Aggregate** — most restrictive across all segments wins
+7. **Audit log** — all decisions are appended to `~/.claude/permission-audit.jsonl`
 
 ### What Gets Classified
 
@@ -156,6 +157,7 @@ Override the log location with the `PERMISSION_AUDIT_LOG` environment variable.
 | `shfmt` | Yes | Shell AST parsing via `--tojson` |
 | `jq` | Yes | JSON processing for AST traversal and config |
 | `perl` | Yes | Regex checks in classifiers (standard on macOS/Linux) |
+| `python3` | Optional | Static read-only check for `python -c` payloads (falls through to ask if missing) |
 
 Install via `/permission-manager:setup` (supports Homebrew, apt, dnf, pacman, and `go install` for shfmt).
 

--- a/plugins-claude/permission-manager/scripts/check-python-readonly.py
+++ b/plugins-claude/permission-manager/scripts/check-python-readonly.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Read Python source from stdin; exit 0 if statically read-only-safe.
+
+Used by the python classifier to auto-allow `python3 -c "..."` invocations
+that only read data and produce output. Heuristic: any unsafe construct
+falls back to ask, never silently allowed.
+
+Exit codes:
+  0 — safe to allow
+  1 — unsafe (reason on stdout)
+  2 — parse error (reason on stdout)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+
+
+# Modules whose top-level import is safe — pure parsing, math, text, encoding,
+# data-structure utilities. No filesystem writes, no network, no subprocess.
+ALLOWED_MODULES = frozenset(
+    {
+        "json",
+        "csv",
+        "re",
+        "string",
+        "textwrap",
+        "difflib",
+        "math",
+        "statistics",
+        "decimal",
+        "fractions",
+        "random",
+        "datetime",
+        "time",
+        "calendar",
+        "zoneinfo",
+        "collections",
+        "collections.abc",
+        "itertools",
+        "functools",
+        "operator",
+        "heapq",
+        "bisect",
+        "array",
+        "queue",
+        "hashlib",
+        "hmac",
+        "base64",
+        "binascii",
+        "codecs",
+        "secrets",
+        "unicodedata",
+        "stringprep",
+        "io",
+        "typing",
+        "dataclasses",
+        "enum",
+        "types",
+        "copy",
+        "html",
+        "html.parser",
+        "html.entities",
+        # xml.* modules removed — `xml.etree.ElementTree.write(path)` writes
+        # arbitrary files, and `xml.sax.saxutils` exposes `os`/`codecs`/`urllib`.
+        # JSON is the dominant use case; XML can fall through to a prompt.
+        "urllib.parse",
+        "ipaddress",
+        "uuid",
+        "os.path",
+        "posixpath",
+        "ntpath",
+        "genericpath",
+        "sys",
+        "pprint",
+        "reprlib",
+        "abc",
+    }
+)
+
+
+# Names that, when called, can sidestep the static check or escape the sandbox.
+BANNED_CALLS = frozenset(
+    {
+        "exec",
+        "eval",
+        "compile",
+        "__import__",
+        "getattr",
+        "setattr",
+        "delattr",
+        "vars",
+        "globals",
+        "locals",
+        "breakpoint",
+        "input",
+        "open",  # handled separately to permit read modes
+    }
+)
+
+
+# Dunder attributes that are safe to read. Everything else is rejected to prevent
+# the classic `().__class__.__bases__[0].__subclasses__()` escape.
+SAFE_DUNDERS = frozenset(
+    {
+        "__name__",
+        "__doc__",
+        "__file__",
+        "__version__",
+        "__main__",
+        "__init__",  # __init__ as attr name appears in dataclass-y code
+    }
+)
+
+
+# Dunder *Names* (read as a bare identifier, not via attribute access). Reading
+# `__builtins__` opens a backdoor to every banned call via subscript:
+# `__builtins__["open"]("/x", "w")`. Same for `__import__` (the function-form
+# of the banned import system), `__loader__`, `__spec__`, `__package__`,
+# `__path__`, `__cached__`. The Names below are the safe ones — bare reads
+# of any other dunder identifier are rejected.
+SAFE_DUNDER_NAMES = frozenset(
+    {
+        "__name__",
+        "__doc__",
+        "__file__",
+        "__version__",
+        "__main__",
+    }
+)
+
+
+# Specific attributes on `sys` that are escape vectors even though `sys`
+# itself is in the allowlist. `sys.modules` is the worst — `os` is already
+# loaded by the runtime, so `sys.modules["os"].system(...)` runs commands.
+# `sys.path` writes affect later imports, `sys.meta_path` installs import
+# hooks, and `sys._getframe()` walks the call stack to escape scope checks.
+SYS_BANNED_ATTRS = frozenset(
+    {
+        "modules",
+        "path",
+        "path_hooks",
+        "path_importer_cache",
+        "meta_path",
+        "settrace",
+        "setprofile",
+        "_getframe",
+        "_current_frames",
+        "addaudithook",
+    }
+)
+
+
+# Modules whose `.open(path, mode)` should be mode-checked the same way as the
+# bare `open()` builtin. Both `io.open` and `codecs.open` accept mode and
+# can be used to write files.
+MODE_CHECKED_MODULES = frozenset({"io", "codecs"})
+
+# io.* constructors that can write to disk. `io.FileIO(path, "w")` is a direct
+# bypass of the `open()` mode check — same mode argument, different name.
+# Buffered wrappers take an already-open writable; ban them too.
+IO_MODE_CHECKED = frozenset({"open", "FileIO"})
+IO_BANNED_WRITE_WRAPPERS = frozenset(
+    {
+        "BufferedWriter",
+        "BufferedRandom",
+        "BufferedRWPair",
+    }
+)
+
+
+# `from <module> import <attr>` is banned for these (module, attr) pairs.
+# Importing them rebinds a dangerous attribute to a bare Name, bypassing
+# attribute-access checks. Several allowed modules expose `os`, `sys`, or
+# `builtins` as a transitive attribute — banning the from-import closes
+# that side-channel. Users can always do `import sys; sys.X` /
+# `import io; io.X` and still hit the proper validation.
+BANNED_FROM_IMPORTS = {
+    "sys": SYS_BANNED_ATTRS,
+    "io": IO_MODE_CHECKED | IO_BANNED_WRITE_WRAPPERS,
+    "codecs": frozenset({"open", "builtins", "sys"}),
+    "reprlib": frozenset({"builtins"}),
+    # `json` re-exports `codecs` as a module attribute, so `from json import
+    # codecs` would rebind it.
+    "json": frozenset({"codecs"}),
+    # Path / utility modules expose `os` (and sometimes `sys`/`builtins`) as
+    # module-level attributes — `from posixpath import os` then `os.system()`
+    # would pass without these blocks.
+    "os.path": frozenset({"os", "sys", "builtins"}),
+    "posixpath": frozenset({"os", "sys", "builtins"}),
+    "ntpath": frozenset({"os", "sys", "builtins"}),
+    "genericpath": frozenset({"os", "sys", "builtins"}),
+    "uuid": frozenset({"os", "sys"}),
+    "calendar": frozenset({"sys"}),
+    "fractions": frozenset({"sys"}),
+    "statistics": frozenset({"sys"}),
+    "typing": frozenset({"sys"}),
+    "dataclasses": frozenset({"sys"}),
+    # `enum` exposes `bltns` (an alias for the `builtins` module) on top of
+    # the usual `sys`. Both rebind to a clean Name.
+    "enum": frozenset({"sys", "bltns"}),
+    "collections.abc": frozenset({"sys"}),
+    # `queue` imports `threading` for its synchronization primitives.
+    "queue": frozenset({"threading"}),
+}
+
+
+# `import X as Y` rebinds the module under an alias. Several attribute-based
+# checks (`io.open` mode-check, `sys.modules` block, `codecs.open` mode-check)
+# depend on the receiver's Name id matching the original module name —
+# aliasing defeats them.
+NO_ALIAS_MODULES = frozenset({"io", "sys", "codecs"})
+
+
+# Attribute names that should never be read on any receiver. Reaching `.os`,
+# `.sys`, `.builtins`, or `.codecs` on an allowed module pierces the
+# import-system sandbox (`posixpath.os.system(...)`,
+# `reprlib.builtins.open(...)`, `codecs.sys.modules[...]`).
+BANNED_ATTR_NAMES = frozenset(
+    {
+        "os",
+        "sys",
+        "builtins",
+        "subprocess",
+        "socket",
+        "shutil",
+        "ctypes",
+        "multiprocessing",
+        "threading",
+        "importlib",
+        "pty",
+        "codecs",  # codecs is itself allowed but reaching it transitively
+        # (e.g. `json.codecs.open(...)`) is always an escape attempt
+        "bltns",  # `enum.bltns` is an alias for `builtins`
+        "urllib",  # `xml.sax.saxutils.urllib` exposes the urllib package
+        "_thread",
+        "_socket",
+    }
+)
+
+
+# `operator.attrgetter("name")(obj)` and `operator.methodcaller("name")(obj)`
+# are string-based attribute / method dispatchers — equivalent to `getattr`
+# and indirect method calls. Treat them as banned the same way `getattr` is.
+OPERATOR_BANNED_DISPATCHERS = frozenset({"attrgetter", "methodcaller"})
+
+
+# Bare `Name(id=X)` Loads that are only legitimate as the immediate `func` of
+# a Call. `_o = open; _o(p, "w")` defeats the call-site mode check by aliasing
+# the builtin. Block any reference to `open` outside a direct call position.
+BANNED_LOAD_NAMES_OUTSIDE_CALL = frozenset({"open"})
+
+
+def fail(msg: str) -> None:
+    print(msg)
+    sys.exit(1)
+
+
+def check_import_module(module: str) -> str | None:
+    """Return error message if module is not allowed, else None."""
+    if module in ALLOWED_MODULES:
+        return None
+    # Allow submodules of allowed parents (e.g. xml.etree.ElementTree.foo)
+    parts = module.split(".")
+    for i in range(len(parts), 0, -1):
+        if ".".join(parts[:i]) in ALLOWED_MODULES:
+            return None
+    return f"import of '{module}' not in read-only allowlist"
+
+
+def check_open_call(node: ast.Call) -> str | None:
+    """Allow open() only with read mode."""
+    mode = None
+    if len(node.args) >= 2:
+        mode_node = node.args[1]
+        if isinstance(mode_node, ast.Constant) and isinstance(mode_node.value, str):
+            mode = mode_node.value
+        else:
+            return "open() with non-literal mode"
+    for kw in node.keywords:
+        if kw.arg == "mode":
+            if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                mode = kw.value.value
+            else:
+                return "open() with non-literal mode"
+    if mode is None:
+        return None  # default 'r'
+    # Read modes: 'r', 'rb', 'rt', 'br', 'tr'. Anything with w/a/x/+ is a write.
+    if any(c in mode for c in "wax+"):
+        return f"open() with write mode '{mode}'"
+    return None
+
+
+def main() -> None:
+    source = sys.stdin.read()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as e:
+        print(f"python parse error: {e.msg}")
+        sys.exit(2)
+
+    # Pre-pass: collect every Name node that appears as the immediate func of
+    # a Call. Used to allow `open(...)` while rejecting `f = open` aliasing.
+    call_func_name_ids: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            call_func_name_ids.add(id(node.func))
+
+    for node in ast.walk(tree):
+        # --- Imports ---
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                err = check_import_module(alias.name)
+                if err:
+                    fail(err)
+                # `import io as X` / `import sys as X` — alias defeats
+                # name-based attribute checks downstream.
+                if alias.asname and alias.name in NO_ALIAS_MODULES:
+                    fail(
+                        f"import {alias.name} as {alias.asname} rebinds the "
+                        f"module past the static check"
+                    )
+                # `import os.path` binds the bare name `os` in the namespace,
+                # which then permits `os.system(...)` directly. Disallow the
+                # dotted import; users can use `from os.path import join, ...`.
+                if "." in alias.name and alias.name in {"os.path"} and not alias.asname:
+                    fail(
+                        f"`import {alias.name}` binds the bare `os` namespace "
+                        f"— use `from {alias.name} import <names>` instead"
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level > 0:
+                fail("relative import not allowed")
+            err = check_import_module(mod)
+            if err:
+                fail(err)
+            banned = BANNED_FROM_IMPORTS.get(mod)
+            if banned:
+                for alias in node.names:
+                    if alias.name == "*":
+                        fail(f"wildcard import from '{mod}' not allowed")
+                    if alias.name in banned:
+                        fail(
+                            f"from {mod} import {alias.name} rebinds a dangerous "
+                            f"attribute past the static check"
+                        )
+
+        # --- Function/method calls ---
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                if func.id == "open":
+                    err = check_open_call(node)
+                    if err:
+                        fail(err)
+                elif func.id in BANNED_CALLS:
+                    fail(f"call to banned builtin '{func.id}'")
+            elif isinstance(func, ast.Attribute):
+                # io.open / codecs.open / io.FileIO take a mode arg — apply
+                # the same mode check as the bare `open()` builtin.
+                if isinstance(func.value, ast.Name):
+                    mod_name = func.value.id
+                    if (
+                        mod_name in MODE_CHECKED_MODULES
+                        and func.attr in IO_MODE_CHECKED
+                    ):
+                        err = check_open_call(node)
+                        if err:
+                            fail(err)
+                    elif mod_name == "io" and func.attr in IO_BANNED_WRITE_WRAPPERS:
+                        fail(f"call to write-capable io.{func.attr}")
+                    elif (
+                        mod_name == "operator"
+                        and func.attr in OPERATOR_BANNED_DISPATCHERS
+                    ):
+                        fail(
+                            f"operator.{func.attr} dispatches by string name — "
+                            f"equivalent to getattr"
+                        )
+
+        # --- Bare Name reads ---
+        elif isinstance(node, ast.Name):
+            name = node.id
+            # Dunder Name (Subscript-bypass for __builtins__, etc.)
+            if (
+                name.startswith("__")
+                and name.endswith("__")
+                and name not in SAFE_DUNDER_NAMES
+            ):
+                fail(f"reference to dunder name '{name}'")
+            # `open` is allowed only as the direct func of a Call. Any other
+            # Load — assignment RHS, function arg, dict value, etc. — is an
+            # aliasing attempt.
+            if (
+                name in BANNED_LOAD_NAMES_OUTSIDE_CALL
+                and id(node) not in call_func_name_ids
+            ):
+                fail(
+                    f"reference to '{name}' outside a direct call — would "
+                    f"defeat the mode-check (e.g. `f = open; f(p, 'w')`)"
+                )
+
+        # --- Attribute access ---
+        elif isinstance(node, ast.Attribute):
+            attr = node.attr
+            # sys.modules / sys.path / sys.meta_path etc. — escape vectors
+            # even though `sys` itself is allowed.
+            if (
+                isinstance(node.value, ast.Name)
+                and node.value.id == "sys"
+                and attr in SYS_BANNED_ATTRS
+            ):
+                fail(f"sys.{attr} is an import-system escape vector")
+            # `.os`, `.sys`, `.builtins`, etc. on any receiver pierce the
+            # sandbox — `posixpath.os.system(...)`, `reprlib.builtins.open(...)`.
+            if attr in BANNED_ATTR_NAMES:
+                fail(f"attribute access '.{attr}' reaches a sandboxed module")
+            # Dunder attribute escape: `().__class__.__bases__[0].__subclasses__()`
+            if (
+                attr.startswith("__")
+                and attr.endswith("__")
+                and attr not in SAFE_DUNDERS
+            ):
+                fail(f"dunder attribute access '.{attr}'")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins-claude/permission-manager/scripts/classifiers/python.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/python.sh
@@ -1,0 +1,159 @@
+# shellcheck shell=bash
+# shellcheck source=../lib-classify.sh
+
+# --- Inline Python classifier ---
+# Handles `python[3] -c "<code>"` and `python[3] -m <safe-module>` invocations
+# by statically analysing the inline source via check-python-readonly.py.
+#
+# Operates on the FULL original command (not per-segment), since the shfmt
+# segmenter strips quoted -c arguments. Called from cmd-gate.sh main() before
+# segmentation, similar to check_redirections_ast.
+#
+# Scope: single-statement invocations only. Compound/piped/substituted forms
+# abstain (no opinion -> falls through to normal segmentation).
+
+# -m modules that only inspect input or print built-in info -- no writes.
+# Excludes anything network-capable (http.server, smtpd) or that runs arbitrary
+# code (timeit, profile, pdb). json.tool is excluded because its 2-arg form
+# `python -m json.tool <infile> <outfile>` writes to <outfile>.
+PYTHON_SAFE_M_MODULES="tabnanny base64 dis tokenize this calendar uuid"
+
+check_python_inline() {
+  local cmd="$1"
+  local ast
+  ast=$(printf '%s' "$cmd" | shfmt --tojson 2>/dev/null) || return 0
+  [[ -n "$ast" ]] || return 0
+
+  # Must be exactly one top-level statement.
+  local stmt_count
+  stmt_count=$(echo "$ast" | jq '.Stmts // [] | length')
+  [[ "$stmt_count" == "1" ]] || return 0
+
+  # Must be a CallExpr (a simple command, not a pipe/subshell/binary).
+  local cmd_type
+  cmd_type=$(echo "$ast" | jq -r '.Stmts[0].Cmd.Type // empty')
+  [[ "$cmd_type" == "CallExpr" ]] || return 0
+
+  # Abstain if there are inline env-var assignments (`PYTHONPATH=/tmp python3 -c
+  # "import json"` would import a malicious /tmp/json.py without our payload
+  # check seeing anything dangerous). Also covers PYTHONSTARTUP, LD_PRELOAD,
+  # and any other prefix variable.
+  local assign_count
+  assign_count=$(echo "$ast" | jq '.Stmts[0].Cmd.Assigns // [] | length')
+  [[ "$assign_count" == "0" ]] || return 0
+
+  # First arg must be python or python3 as a pure literal.
+  local prog
+  prog=$(echo "$ast" | jq -r '
+    .Stmts[0].Cmd.Args[0] |
+    if ([.. | objects | select(.Type?) | .Type] | all(. == "Lit")) then
+      [.. | objects | select(.Type? == "Lit") | .Value] | join("")
+    else "" end
+  ')
+  case "$prog" in
+    python | python3) ;;
+    *) return 0 ;;
+  esac
+
+  # Walk remaining args looking for -c <code> or -m <module>.
+  # Skip flags that take no value, and flag-with-value pairs.
+  local args_json n i=1
+  args_json=$(echo "$ast" | jq -c '.Stmts[0].Cmd.Args')
+  n=$(echo "$args_json" | jq 'length')
+
+  local mode="" payload=""
+  while ((i < n)); do
+    local arg_lit
+    arg_lit=$(echo "$args_json" | jq -r --argjson i "$i" '
+      .[$i] |
+      if ([.. | objects | select(.Type?) | .Type] | all(. == "Lit")) then
+        [.. | objects | select(.Type? == "Lit") | .Value] | join("")
+      else "" end
+    ')
+    case "$arg_lit" in
+      --version | -V)
+        allow "$prog --version is read-only"
+        return 0
+        ;;
+      -c)
+        mode="c"
+        i=$((i + 1))
+        if ((i < n)); then
+          # Abstain if -c arg has dynamic parts (CmdSubst, ParamExp, etc.) or
+          # ANSI-C quoting ($'...'). Bash decodes \x/\n/\u escapes inside
+          # $'...' at runtime, so the static source we read differs from what
+          # Python actually runs.
+          local bad_count
+          bad_count=$(echo "$args_json" | jq --argjson i "$i" '
+            .[$i] |
+            (
+              [.. | objects | select(.Type?) | .Type
+                | select(. != "Lit" and . != "DblQuoted" and . != "SglQuoted")]
+              + [.. | objects | select(.Type? == "SglQuoted" and .Dollar == true)]
+            ) | length
+          ')
+          if [[ "$bad_count" != "0" ]]; then
+            return 0
+          fi
+          payload=$(echo "$args_json" | jq -r --argjson i "$i" '
+            .[$i] |
+            [.. | objects | (
+              if .Type? == "Lit" then .Value
+              elif .Type? == "SglQuoted" then .Value
+              else empty end
+            )] | join("")
+          ')
+        fi
+        break
+        ;;
+      -m)
+        mode="m"
+        i=$((i + 1))
+        if ((i < n)); then
+          payload=$(echo "$args_json" | jq -r --argjson i "$i" '
+            .[$i] |
+            if ([.. | objects | select(.Type?) | .Type] | all(. == "Lit")) then
+              [.. | objects | select(.Type? == "Lit") | .Value] | join("")
+            else "" end
+          ')
+        fi
+        break
+        ;;
+      -u | -S | -E | -I | -O | -OO | -B | -q | -d | -v | -b | -bb | -s | -P | -R)
+        i=$((i + 1))
+        ;;
+      -W | -X | --check-hash-based-pycs)
+        i=$((i + 2))
+        ;;
+      *)
+        # First non-flag non-known arg -> script file or unknown; abstain.
+        return 0
+        ;;
+    esac
+  done
+
+  if [[ "$mode" == "c" ]]; then
+    [[ -n "$payload" ]] || return 0
+    local helper="${SCRIPTS_DIR}/check-python-readonly.py"
+    [[ -f "$helper" ]] || return 0
+    local check_out check_rc=0
+    check_out=$(printf '%s' "$payload" | python3 "$helper" 2>&1) || check_rc=$?
+    case "$check_rc" in
+      0) allow "$prog -c is statically read-only (no writes/network/exec)" ;;
+      1) ask "$prog -c not auto-allowed: $check_out" ;;
+      *) return 0 ;;
+    esac
+    return 0
+  fi
+
+  if [[ "$mode" == "m" ]]; then
+    [[ -n "$payload" ]] || return 0
+    for m in $PYTHON_SAFE_M_MODULES; do
+      if [[ "$payload" == "$m" ]]; then
+        allow "$prog -m $payload is read-only"
+        return 0
+      fi
+    done
+    return 0
+  fi
+}

--- a/plugins-claude/permission-manager/scripts/classifiers/read-only-tools.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/read-only-tools.sh
@@ -17,8 +17,37 @@ check_read_only_tools() {
     # bash-read (output inspection, text processing, path/env utilities)
     cat | column | cut | diff | file | grep | head | jq | ls | md5sum | readlink | realpath | rg | \
       sha256sum | sha1sum | sort | stat | tail | test | tr | tree | uniq | wc | which | \
-      basename | dirname | echo | printf | command | env)
+      basename | dirname | echo | printf | command)
       allow "$first_token is read-only"
+      ;;
+
+    # env: only allow as a pure environment inspector (`env`, `env -i`,
+    # `env --help`, etc.). When followed by a program (`env python3 -c "..."`,
+    # `env VAR=val cmd`), env is acting as a launcher and the inner command
+    # must be classified — we abstain here so other classifiers see it, but
+    # since the classifier chain matches by first_token, the wrapped command
+    # falls through to passthrough → ask. That's the correct conservative
+    # default for an inline launcher.
+    env)
+      local -a etokens
+      read -ra etokens <<<"$command"
+      local has_program=0 i=1
+      while ((i < ${#etokens[@]})); do
+        local tok="${etokens[$i]}"
+        case "$tok" in
+          -*) ((i++)) || true ;;  # env flags (-i, -u VAR, --)
+          *=*) ((i++)) || true ;; # VAR=val pair
+          *)
+            has_program=1
+            break
+            ;;
+        esac
+      done
+      if [[ "$has_program" -eq 0 ]]; then
+        allow "env (no program) is read-only"
+      fi
+      # else: fall through, no opinion (lets the wrapped command be classified
+      # — currently passthrough → ask).
       ;;
 
     # system (system state inspection)
@@ -67,13 +96,16 @@ check_read_only_tools() {
             # flags that consume a next argument
             case "$tok" in
               -I | -J | -n | -L | -l | -s | -d | -P | -a | -E | -e)
-                ((i += 2)) || true ;;
+                ((i += 2)) || true
+                ;;
               *)
-                ((i++)) || true ;;
+                ((i++)) || true
+                ;;
             esac
             ;;
           -*)
-            ((i++)) || true ;;
+            ((i++)) || true
+            ;;
           *)
             xsub="$tok"
             break

--- a/plugins-claude/permission-manager/scripts/cmd-gate.sh
+++ b/plugins-claude/permission-manager/scripts/cmd-gate.sh
@@ -156,6 +156,33 @@ main() {
     exit 0
   fi
 
+  # Inline Python (-c "..." or -m <safe-module>) — uses full command since
+  # parse_segments strips quoted -c args.
+  check_python_inline "$command"
+  if [[ "$CLASSIFY_MATCHED" -eq 1 ]]; then
+    SEGMENT_MODE=0
+    case "$CLASSIFY_RESULT" in
+      0)
+        log_decision "allow" "$CLASSIFY_REASON" "$command"
+        hook_allow "$CLASSIFY_REASON"
+        exit 0
+        ;;
+      1)
+        log_decision "ask" "$CLASSIFY_REASON" "$command"
+        if [[ "$HOOK_FORMAT" == "claude" ]]; then
+          hook_ask "$CLASSIFY_REASON"
+          exit 0
+        fi
+        exit 0
+        ;;
+      2)
+        log_decision "deny" "$CLASSIFY_REASON" "$command"
+        hook_deny "$CLASSIFY_REASON"
+        exit 0
+        ;;
+    esac
+  fi
+
   local segments
   segments=$(parse_segments "$command")
 

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -453,6 +453,727 @@ run_test_both allow "pip install requests"
 echo "── pip destructive operations ──"
 run_test_both ask "pip3 uninstall flask"
 
+# ===== ALLOW: python -c read-only (AST-checked) =====
+echo "── python -c read-only ──"
+run_test_both allow "python3 -c 'import json; print(json.dumps({}))'" \
+  "python -c json single-quoted"
+run_test_both allow 'python3 -c "import json; print(1)"' \
+  "python -c json double-quoted"
+run_test_both allow "python3 -c 'import csv,sys; r=csv.reader(open(\"/tmp/x\")); [print(row) for row in r]'" \
+  "python -c csv read"
+run_test_both allow "python3 -c 'import re; print(re.findall(r\"\\d+\", \"a1\"))'" \
+  "python -c regex"
+run_test_both allow "python3 -c 'from datetime import datetime; print(datetime.now())'" \
+  "python -c datetime"
+run_test_both allow "python3 -c 'from os.path import join; print(join(\"a\",\"b\"))'" \
+  "python -c os.path import"
+run_test_both allow "python3 -c 'open(\"/tmp/x\", \"r\").read()'" \
+  "python -c open read mode"
+run_test_both allow "python3 -c 'open(\"/tmp/x\")'" \
+  "python -c open default mode"
+run_test_both allow "python3 -u -c 'import json; print(1)'" \
+  "python -c with -u flag"
+run_test_both allow "python3 -m base64 -d /tmp/x" \
+  "python -m base64"
+
+# ===== ASK: python -c with unsafe operations =====
+echo "── python -c unsafe ──"
+run_test_both ask "python3 -c 'import subprocess; subprocess.run([\"ls\"])'" \
+  "python -c subprocess"
+run_test_both ask "python3 -c 'import os; os.system(\"ls\")'" \
+  "python -c os.system"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"w\").write(\"hi\")'" \
+  "python -c open write mode"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"a\")'" \
+  "python -c open append mode"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", mode=\"wb\")'" \
+  "python -c open mode=wb keyword"
+run_test_both ask "python3 -c 'import urllib.request; urllib.request.urlopen(\"http://x\")'" \
+  "python -c urllib"
+run_test_both ask "python3 -c 'import shutil; shutil.rmtree(\"/tmp/x\")'" \
+  "python -c shutil"
+run_test_both ask "python3 -c 'exec(\"print(1)\")'" \
+  "python -c exec"
+run_test_both ask "python3 -c 'eval(\"1+1\")'" \
+  "python -c eval"
+run_test_both ask "python3 -c '__import__(\"os\").system(\"ls\")'" \
+  "python -c __import__"
+run_test_both ask "python3 -c '().__class__.__bases__[0].__subclasses__()'" \
+  "python -c dunder escape"
+run_test_both ask "python3 -c 'getattr(__builtins__, \"eval\")(\"1\")'" \
+  "python -c getattr"
+run_test_both ask "python3 -c 'import pickle; pickle.loads(b\"\")'" \
+  "python -c pickle"
+run_test_both ask "python3 -c 'from pathlib import Path; Path(\"/tmp/x\").write_text(\"y\")'" \
+  "python -c pathlib"
+
+# ===== ALLOW: complex JSON parsing =====
+# This is the dominant real-world use case for python -c — Claude reaches for
+# Python to parse/aggregate/filter JSON files with shapes that are awkward in
+# jq. All of these must auto-allow without prompting.
+echo "── python -c complex JSON parsing ──"
+
+_PY_JSONL_COUNTER=$(
+  cat <<'PY'
+import json
+counts = {}
+with open("/tmp/log.jsonl") as f:
+    for line in f:
+        try:
+            obj = json.loads(line)
+            counts[obj.get("event_type", "unknown")] = counts.get(obj.get("event_type", "unknown"), 0) + 1
+        except json.JSONDecodeError:
+            continue
+for k, v in sorted(counts.items(), key=lambda x: -x[1]):
+    print(f"{k}: {v}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_JSONL_COUNTER'" "complex: jsonl event counter"
+
+_PY_NESTED_TRAVERSAL=$(
+  cat <<'PY'
+import json
+data = json.load(open("/tmp/api.json"))
+for user in data.get("users", []):
+    name = user.get("name", "?")
+    for project in user.get("projects", []):
+        pname = project.get("name", "?")
+        for task in project.get("tasks", []):
+            if task.get("status") == "open":
+                ttitle = task.get("title", "?")
+                print(f"{name} -> {pname} -> {ttitle}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_NESTED_TRAVERSAL'" "complex: nested user/project/task traversal"
+
+_PY_SCHEMA_CHECK=$(
+  cat <<'PY'
+import json
+errors = []
+with open("/tmp/config.json") as f:
+    cfg = json.load(f)
+for k in ["name", "version", "main"]:
+    if k not in cfg:
+        errors.append(f"missing key: {k}")
+if "dependencies" in cfg and not isinstance(cfg["dependencies"], dict):
+    errors.append("dependencies must be a dict")
+print("\n".join(errors) or "OK")
+PY
+)
+run_test_both allow "python3 -c '$_PY_SCHEMA_CHECK'" "complex: json schema check"
+
+_PY_MULTI_FILE_STATS=$(
+  cat <<'PY'
+import json
+from collections import Counter
+import statistics
+durations = []
+tags = Counter()
+for path in ["/tmp/run1.json", "/tmp/run2.json", "/tmp/run3.json"]:
+    with open(path) as f:
+        data = json.load(f)
+    durations.append(data.get("duration_ms", 0))
+    tags.update(data.get("tags", []))
+print(f"mean: {statistics.mean(durations):.2f}ms")
+print(f"median: {statistics.median(durations):.2f}ms")
+print(f"top tags: {tags.most_common(5)}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_MULTI_FILE_STATS'" "complex: multi-file aggregated stats"
+
+_PY_REGEX_FILTER=$(
+  cat <<'PY'
+import json, re
+pattern = re.compile(r"error.*timeout", re.IGNORECASE)
+matches = []
+with open("/tmp/events.jsonl") as f:
+    for line in f:
+        obj = json.loads(line)
+        msg = obj.get("message", "")
+        if pattern.search(msg):
+            matches.append((obj.get("timestamp"), msg[:100]))
+matches.sort()
+for ts, msg in matches[:20]:
+    print(f"{ts}: {msg}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_REGEX_FILTER'" "complex: jsonl regex value filter"
+
+_PY_DATETIME_FILTER=$(
+  cat <<'PY'
+import json
+from datetime import datetime, timedelta, timezone
+cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+recent = []
+with open("/tmp/events.jsonl") as f:
+    for line in f:
+        obj = json.loads(line)
+        ts = datetime.fromisoformat(obj.get("timestamp", "").replace("Z", "+00:00"))
+        if ts >= cutoff:
+            recent.append(obj)
+print(f"recent: {len(recent)}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_DATETIME_FILTER'" "complex: datetime-window filter"
+
+_PY_PRETTY_FILTER=$(
+  cat <<'PY'
+import json
+with open("/tmp/api.json") as f:
+    data = json.load(f)
+filtered = {k: v for k, v in data.items() if k in ("id", "name", "status", "created_at")}
+print(json.dumps(filtered, indent=2, sort_keys=True))
+PY
+)
+run_test_both allow "python3 -c '$_PY_PRETTY_FILTER'" "complex: pretty-print + dict comprehension"
+
+_PY_RECURSIVE_WALK=$(
+  cat <<'PY'
+import json
+def walk(node, path=""):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from walk(v, f"{path}.{k}" if path else k)
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            yield from walk(item, f"{path}[{i}]")
+    else:
+        yield (path, node)
+with open("/tmp/deep.json") as f:
+    data = json.load(f)
+for path, value in walk(data):
+    if isinstance(value, str) and len(value) > 100:
+        print(f"{path}: {value[:80]}...")
+PY
+)
+run_test_both allow "python3 -c '$_PY_RECURSIVE_WALK'" "complex: recursive json walker (function def + yield from)"
+
+_PY_JSON_DIFF=$(
+  cat <<'PY'
+import json
+with open("/tmp/before.json") as f:
+    before = json.load(f)
+with open("/tmp/after.json") as f:
+    after = json.load(f)
+for k in sorted(set(before) | set(after)):
+    if k not in before:
+        print(f"+ {k}: {after[k]}")
+    elif k not in after:
+        print(f"- {k}: {before[k]}")
+    elif before[k] != after[k]:
+        print(f"~ {k}: {before[k]!r} -> {after[k]!r}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_JSON_DIFF'" "complex: json diff with set ops"
+
+_PY_RPC_GROUPING=$(
+  cat <<'PY'
+import json
+from collections import defaultdict
+methods = defaultdict(list)
+with open("/tmp/rpc.jsonl") as f:
+    for line in f:
+        msg = json.loads(line)
+        if msg.get("method"):
+            methods[msg["method"]].append(msg.get("duration_ms", 0))
+for m, durs in sorted(methods.items()):
+    avg = sum(durs) / len(durs) if durs else 0
+    print(f"{m:30s} count={len(durs):4d} avg={avg:7.2f}ms")
+PY
+)
+run_test_both allow "python3 -c '$_PY_RPC_GROUPING'" "complex: defaultdict per-method stats"
+
+_PY_USER_EXAMPLE=$(
+  cat <<'PY'
+import json
+messages = []
+with open("/tmp/foo.jsonl") as f:
+    for line in f:
+        try:
+            obj = json.loads(line)
+            if obj.get("type") in ("user", "assistant"):
+                role = obj.get("type")
+                msg = obj.get("message", {})
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    texts = []
+                    for c in content:
+                        if isinstance(c, dict) and c.get("type") == "text":
+                            texts.append(c.get("text", ""))
+                        elif isinstance(c, dict) and c.get("type") == "tool_use":
+                            name = c.get("name", "")
+                            texts.append(f"[TOOL:{name}]")
+                    content = " ".join(texts)
+                ts = obj.get("timestamp", "")
+                messages.append((ts, role, str(content)))
+        except: pass
+print(f"Total: {len(messages)} messages")
+mid = len(messages) // 2
+for ts, role, content in messages[mid-5:mid+25]:
+    print(f"[{ts}] {role}: {content[:400]}")
+    print()
+PY
+)
+run_test_both allow "python3 -c '$_PY_USER_EXAMPLE'" "complex: real session-jsonl extractor (the canonical case)"
+
+_PY_BASE64_HASH=$(
+  cat <<'PY'
+import json, base64, hashlib
+with open("/tmp/payloads.jsonl") as f:
+    for line in f:
+        obj = json.loads(line)
+        raw = base64.b64decode(obj.get("blob", ""))
+        digest = hashlib.sha256(raw).hexdigest()[:16]
+        idstr = str(obj.get("id"))
+        print(f"{idstr:>10} {len(raw):>8}B  sha256={digest}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_BASE64_HASH'" "complex: base64-decode + sha256 each row"
+
+_PY_UNIQUE_BY_DAY=$(
+  cat <<'PY'
+import json
+from collections import defaultdict
+from datetime import datetime
+by_day = defaultdict(set)
+with open("/tmp/events.jsonl") as f:
+    for line in f:
+        obj = json.loads(line)
+        if not obj.get("user_id"):
+            continue
+        ts = obj.get("ts", "")
+        try:
+            day = datetime.fromisoformat(ts).date().isoformat()
+        except (ValueError, TypeError):
+            continue
+        by_day[day].add(obj["user_id"])
+for day in sorted(by_day):
+    print(f"{day}: {len(by_day[day])} users")
+PY
+)
+run_test_both allow "python3 -c '$_PY_UNIQUE_BY_DAY'" "complex: unique users per day"
+
+_PY_PERCENTILES=$(
+  cat <<'PY'
+import json
+import statistics
+durations = []
+with open("/tmp/spans.jsonl") as f:
+    for line in f:
+        obj = json.loads(line)
+        if "duration_ms" in obj:
+            durations.append(obj["duration_ms"])
+durations.sort()
+quantiles = statistics.quantiles(durations, n=100)
+print(f"count: {len(durations)}")
+print(f"p50:   {quantiles[49]:.1f}ms")
+print(f"p95:   {quantiles[94]:.1f}ms")
+print(f"p99:   {quantiles[98]:.1f}ms")
+print(f"max:   {max(durations):.1f}ms")
+PY
+)
+run_test_both allow "python3 -c '$_PY_PERCENTILES'" "complex: latency percentile summary"
+
+_PY_GET_PATH=$(
+  cat <<'PY'
+import json
+def get_path(obj, *keys, default=None):
+    for k in keys:
+        if not isinstance(obj, dict) or k not in obj:
+            return default
+        obj = obj[k]
+    return obj
+with open("/tmp/api.json") as f:
+    data = json.load(f)
+for item in data.get("items", []):
+    name = get_path(item, "metadata", "name", default="?")
+    status = get_path(item, "status", "phase", default="Unknown")
+    containers = get_path(item, "spec", "containers", default=[{}])
+    image = containers[0].get("image", "?") if containers else "?"
+    print(f"{name:30s} {status:12s} {image}")
+PY
+)
+run_test_both allow "python3 -c '$_PY_GET_PATH'" "complex: nested key extraction with helper fn"
+
+# ===== ASK: python -c adversarial / sandbox-escape attempts =====
+# Each of these is a real attempted bypass — process exec, file write, network
+# egress, or scope-leak via constructs that look benign. They MUST classify as
+# ask, never allow. If any of these flips to allow, the static check is broken.
+echo "── python -c adversarial / sandbox-escape attempts ──"
+
+# --- sys.modules pivot (transitive os via allowed import) ---
+run_test_both ask "python3 -c 'import sys, json; sys.modules[\"os\"].system(\"id\")'" \
+  "escape: sys.modules subscript"
+run_test_both ask "python3 -c 'import sys, json; sys.modules.get(\"os\").system(\"id\")'" \
+  "escape: sys.modules.get"
+run_test_both ask "python3 -c 'from sys import modules
+import json
+modules[\"os\"].system(\"id\")'" \
+  "escape: from sys import modules (rebind to clean Name)"
+run_test_both ask "python3 -c 'from sys import modules as m
+import json
+m[\"os\"].system(\"id\")'" \
+  "escape: from sys import modules as m (alias)"
+run_test_both ask "python3 -c 'from sys import *'" \
+  "escape: wildcard import from sys"
+
+# --- __builtins__ subscript bypass ---
+run_test_both ask "python3 -c '__builtins__[\"open\"](\"/tmp/x\",\"w\").write(\"x\")'" \
+  "escape: __builtins__ subscript"
+run_test_both ask "python3 -c '__builtins__.eval(\"1+1\")'" \
+  "escape: __builtins__ attribute"
+run_test_both ask "python3 -c 'b = __builtins__; b[\"exec\"](\"x\")'" \
+  "escape: __builtins__ rebind"
+
+# --- bare dunder Name reads ---
+run_test_both ask "python3 -c 'print(__loader__)'" \
+  "escape: __loader__ Name read"
+run_test_both ask "python3 -c 'print(__spec__)'" \
+  "escape: __spec__ Name read"
+run_test_both ask "python3 -c 'print(__package__)'" \
+  "escape: __package__ Name read"
+run_test_both ask "python3 -c 'fn = __import__'" \
+  "escape: __import__ rebind to Name"
+
+# --- sys attribute escapes ---
+run_test_both ask "python3 -c 'import sys; sys.path.insert(0, \"/evil\")'" \
+  "escape: sys.path mutation"
+run_test_both ask "python3 -c 'import sys; sys.meta_path.insert(0, x)'" \
+  "escape: sys.meta_path mutation"
+run_test_both ask "python3 -c 'import sys; f = sys._getframe(0); print(f.f_globals)'" \
+  "escape: sys._getframe stack walk"
+run_test_both ask "python3 -c 'import sys; sys.settrace(lambda *a: a)'" \
+  "escape: sys.settrace"
+run_test_both ask "python3 -c 'import sys; sys.addaudithook(lambda *a: None)'" \
+  "escape: sys.addaudithook"
+
+# --- io low-level write bypasses ---
+run_test_both ask "python3 -c 'import io; io.FileIO(\"/tmp/x\", \"w\").write(b\"pwned\")'" \
+  "escape: io.FileIO write mode"
+run_test_both ask "python3 -c 'import io; io.FileIO(\"/tmp/x\", mode=\"wb\")'" \
+  "escape: io.FileIO mode kwarg"
+run_test_both ask "python3 -c 'import io; io.FileIO(\"/tmp/x\", \"a\")'" \
+  "escape: io.FileIO append mode"
+run_test_both ask "python3 -c 'import io; io.BufferedWriter(raw)'" \
+  "escape: io.BufferedWriter wrapper"
+run_test_both ask "python3 -c 'import io; io.BufferedRandom(raw)'" \
+  "escape: io.BufferedRandom wrapper"
+run_test_both ask "python3 -c 'from io import FileIO
+FileIO(\"/tmp/x\", \"w\")'" \
+  "escape: from io import FileIO (rebind)"
+run_test_both ask "python3 -c 'from io import open as o
+o(\"/tmp/x\", \"w\")'" \
+  "escape: from io import open as o"
+
+# --- aliased dangerous imports ---
+run_test_both ask "python3 -c 'import os as o; o.system(\"id\")'" \
+  "escape: import os as alias"
+run_test_both ask "python3 -c 'import subprocess as s; s.run([\"id\"])'" \
+  "escape: import subprocess as alias"
+
+# --- dunder-attribute traversal escapes ---
+run_test_both ask "python3 -c '().__class__.__bases__[0].__subclasses__()'" \
+  "escape: tuple class subclasses traversal"
+run_test_both ask "python3 -c '\"\".__class__.__mro__[-1].__subclasses__()'" \
+  "escape: str class mro traversal"
+run_test_both ask "python3 -c 'type([]).__bases__'" \
+  "escape: type().__bases__"
+run_test_both ask "python3 -c 'def f(): pass
+print(f.__globals__)'" \
+  "escape: function.__globals__"
+run_test_both ask "python3 -c 'def f(): pass
+print(f.__code__)'" \
+  "escape: function.__code__"
+
+# --- code execution primitives ---
+run_test_both ask "python3 -c 'exec(\"import os; os.system(\\\"id\\\")\")'" \
+  "escape: exec() builtin"
+run_test_both ask "python3 -c 'eval(\"1+1\")'" \
+  "escape: eval() builtin"
+run_test_both ask "python3 -c 'compile(\"x\", \"<s>\", \"exec\")'" \
+  "escape: compile() builtin"
+run_test_both ask "python3 -c '__import__(\"os\").system(\"id\")'" \
+  "escape: __import__() bare call"
+run_test_both ask "python3 -c 'getattr(some, \"x\")'" \
+  "escape: getattr() builtin"
+run_test_both ask "python3 -c 'setattr(some, \"x\", y)'" \
+  "escape: setattr() builtin"
+run_test_both ask "python3 -c 'globals()[\"x\"] = 1'" \
+  "escape: globals() builtin"
+run_test_both ask "python3 -c 'vars()[\"x\"] = 1'" \
+  "escape: vars() builtin"
+
+# --- write-mode open() in many forms ---
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"w\")'" \
+  "escape: open w"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"a\")'" \
+  "escape: open a"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"x\")'" \
+  "escape: open x (exclusive create)"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"r+\")'" \
+  "escape: open r+"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"w+\")'" \
+  "escape: open w+"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"a+\")'" \
+  "escape: open a+"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"wb\")'" \
+  "escape: open wb"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"ab\")'" \
+  "escape: open ab"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", \"xb\")'" \
+  "escape: open xb"
+run_test_both ask "python3 -c 'open(\"/tmp/x\", mode)'" \
+  "escape: open mode non-literal"
+run_test_both ask "python3 -c 'mode=\"w\"; open(\"/tmp/x\", mode)'" \
+  "escape: open mode via variable"
+
+# --- banned-module imports across all categories ---
+run_test_both ask "python3 -c 'import os'" \
+  "escape: import os"
+run_test_both ask "python3 -c 'import subprocess'" \
+  "escape: import subprocess"
+run_test_both ask "python3 -c 'import socket'" \
+  "escape: import socket"
+run_test_both ask "python3 -c 'import urllib.request'" \
+  "escape: import urllib.request"
+run_test_both ask "python3 -c 'import http.client'" \
+  "escape: import http.client"
+run_test_both ask "python3 -c 'import ftplib'" \
+  "escape: import ftplib"
+run_test_both ask "python3 -c 'import smtplib'" \
+  "escape: import smtplib"
+run_test_both ask "python3 -c 'import asyncio'" \
+  "escape: import asyncio"
+run_test_both ask "python3 -c 'import shutil; shutil.rmtree(\"/tmp/x\")'" \
+  "escape: import shutil"
+run_test_both ask "python3 -c 'import pickle; pickle.loads(b\"\")'" \
+  "escape: import pickle (RCE on load)"
+run_test_both ask "python3 -c 'import marshal; marshal.loads(b\"\")'" \
+  "escape: import marshal"
+run_test_both ask "python3 -c 'import shelve'" \
+  "escape: import shelve"
+run_test_both ask "python3 -c 'import ctypes; ctypes.CDLL(\"libc.so.6\")'" \
+  "escape: import ctypes (load shared lib)"
+run_test_both ask "python3 -c 'import multiprocessing'" \
+  "escape: import multiprocessing"
+run_test_both ask "python3 -c 'import threading'" \
+  "escape: import threading"
+run_test_both ask "python3 -c 'import importlib; importlib.import_module(\"os\")'" \
+  "escape: import importlib"
+run_test_both ask "python3 -c 'import tempfile; tempfile.mkstemp()'" \
+  "escape: import tempfile (creates file)"
+run_test_both ask "python3 -c 'from pathlib import Path; Path(\"/tmp/x\").write_text(\"y\")'" \
+  "escape: pathlib write_text"
+run_test_both ask "python3 -c 'from pathlib import Path; Path(\"/tmp/x\").touch()'" \
+  "escape: pathlib touch"
+run_test_both ask "python3 -c 'from pathlib import Path; Path(\"/tmp/x\").unlink()'" \
+  "escape: pathlib unlink"
+run_test_both ask "python3 -c 'import pty; pty.spawn(\"/bin/sh\")'" \
+  "escape: import pty (spawn shell)"
+run_test_both ask "python3 -c 'import xmlrpc.client'" \
+  "escape: import xmlrpc.client"
+
+# --- code embedded in expressions / statements that ast.walk must reach ---
+run_test_both ask "python3 -c '(lambda: __import__(\"os\"))()'" \
+  "escape: lambda body w/ __import__"
+run_test_both ask "python3 -c '[exec(x) for x in [1]]'" \
+  "escape: exec inside list comprehension"
+run_test_both ask "python3 -c '{k: __import__(\"os\") for k in [1]}'" \
+  "escape: __import__ in dict comprehension"
+run_test_both ask "python3 -c '(__import__(\"os\") for x in [1])'" \
+  "escape: __import__ in generator"
+run_test_both ask "python3 -c '(x := __import__(\"os\"))'" \
+  "escape: walrus assignment"
+run_test_both ask "python3 -c 'def f(x=__import__(\"os\")): pass'" \
+  "escape: __import__ in default arg"
+run_test_both ask "python3 -c 'try:
+    import os
+except: pass'" \
+  "escape: import os inside try"
+run_test_both ask "python3 -c 'class X:
+    import os'" \
+  "escape: import os inside class body"
+run_test_both ask "python3 -c 'def f():
+    import os
+    os.system(\"id\")'" \
+  "escape: import os inside function body"
+run_test_both ask "python3 -c 'async def f():
+    import os'" \
+  "escape: import os inside async function"
+run_test_both ask "python3 -c 'match x:
+    case _:
+        __import__(\"os\")'" \
+  "escape: __import__ inside match-case"
+
+# --- relative imports / wildcard in unsafe modules ---
+run_test_both ask "python3 -c 'from io import *'" \
+  "escape: wildcard import from io"
+
+# --- agent-discovered escapes (from sandbox-escape research, Apr 2026) ---
+# Each was verified to: (a) actually obtain process exec / file write / etc.
+# at runtime, AND (b) initially pass an earlier version of the static check.
+
+# Open aliasing — `f = open; f(p, "w")` defeats the call-site mode check
+run_test_both ask "python3 -c '_o = open; _o(\"/tmp/x\",\"w\").write(\"x\")'" \
+  "agent-A1: open aliased via assignment"
+run_test_both ask "python3 -c 'import functools
+functools.partial(open, mode=\"w\")(\"/tmp/x\").write(\"x\")'" \
+  "agent-A2: functools.partial(open, mode=w)"
+run_test_both ask "python3 -c 'fs = {\"w\": open}; fs[\"w\"](\"/tmp/x\",\"w\").write(\"x\")'" \
+  "agent-A3: open stored in dict"
+# io alias defeats name-based io.open mode check
+run_test_both ask "python3 -c 'import io as _io; _io.open(\"/tmp/x\",\"w\").write(\"x\")'" \
+  "agent-A4: import io as alias (io.open bypass)"
+run_test_both ask "python3 -c 'import io as _io; _io.FileIO(\"/tmp/x\",\"w\").write(b\"x\")'" \
+  "agent-A5: io.FileIO via aliased io"
+
+# codecs as a write path
+run_test_both ask "python3 -c 'import codecs; codecs.open(\"/tmp/x\",\"w\").write(\"x\")'" \
+  "agent-B1: codecs.open() write mode"
+run_test_both ask "python3 -c 'import codecs; codecs.builtins.open(\"/tmp/x\",\"w\")'" \
+  "agent-B2: codecs.builtins.open"
+run_test_both ask "python3 -c 'import json; json.codecs.open(\"/tmp/x\",\"w\")'" \
+  "agent-B3: json.codecs.open"
+
+# os reachable via path/utility modules
+run_test_both ask "python3 -c 'import os.path; os.system(\"id\")'" \
+  "agent-C1: import os.path binds os namespace"
+run_test_both ask "python3 -c 'import posixpath; posixpath.os.system(\"id\")'" \
+  "agent-C2: posixpath.os.system"
+run_test_both ask "python3 -c 'import ntpath; ntpath.os.system(\"id\")'" \
+  "agent-C3: ntpath.os.system"
+run_test_both ask "python3 -c 'import genericpath; genericpath.os.system(\"id\")'" \
+  "agent-C4: genericpath.os.system"
+run_test_both ask "python3 -c 'import uuid; uuid.os.system(\"id\")'" \
+  "agent-C5: uuid.os.system"
+run_test_both ask "python3 -c 'from xml.sax.saxutils import os
+os.system(\"id\")'" \
+  "agent-C6: from xml.sax.saxutils import os"
+run_test_both ask "python3 -c 'from posixpath import os
+os.system(\"id\")'" \
+  "agent-C7a: from posixpath import os"
+run_test_both ask "python3 -c 'from os.path import os
+os.system(\"id\")'" \
+  "agent-C7b: from os.path import os"
+run_test_both ask "python3 -c 'from genericpath import os
+os.system(\"id\")'" \
+  "agent-C7c: from genericpath import os"
+run_test_both ask "python3 -c 'import posixpath; posixpath.os.fdopen(0,\"w\")'" \
+  "agent-C8: posixpath.os.fdopen"
+
+# sys reachability via alias / transitive attribute
+run_test_both ask "python3 -c 'import sys as s; s.modules[\"os\"].system(\"id\")'" \
+  "agent-D1: import sys as alias"
+run_test_both ask "python3 -c 'import codecs; codecs.sys.modules[\"os\"].system(\"id\")'" \
+  "agent-D2a: codecs.sys.modules"
+run_test_both ask "python3 -c 'import statistics; statistics.sys.modules[\"os\"].system(\"id\")'" \
+  "agent-D2b: statistics.sys.modules"
+run_test_both ask "python3 -c 'import uuid; uuid.sys.modules[\"os\"].system(\"id\")'" \
+  "agent-D2c: uuid.sys.modules"
+run_test_both ask "python3 -c 'import xml.etree.ElementTree as ET
+ET.sys.modules[\"os\"].system(\"id\")'" \
+  "agent-D2d: ET.sys.modules"
+
+# builtins reachable via reprlib
+run_test_both ask "python3 -c 'import reprlib; reprlib.builtins.open(\"/tmp/x\",\"w\").write(\"x\")'" \
+  "agent-E1: reprlib.builtins.open"
+
+# operator/functools indirection
+run_test_both ask "python3 -c 'import operator, posixpath
+operator.attrgetter(\"os\")(posixpath).system(\"id\")'" \
+  "agent-F1: operator.attrgetter dispatch"
+run_test_both ask "python3 -c 'import functools, posixpath
+functools.partial(posixpath.os.system, \"id\")()'" \
+  "agent-F2: functools.partial deferred call"
+
+# --- additional bypasses found by introspection scan of allowed modules ---
+run_test_both ask "python3 -c 'import enum; enum.bltns.open(\"/tmp/x\",\"w\")'" \
+  "scan: enum.bltns is alias for builtins"
+run_test_both ask "python3 -c 'from enum import bltns
+bltns.open(\"/tmp/x\",\"w\")'" \
+  "scan: from enum import bltns"
+run_test_both ask "python3 -c 'import queue; queue.threading.Thread(target=print)'" \
+  "scan: queue.threading"
+run_test_both ask "python3 -c 'from queue import threading
+threading.Thread()'" \
+  "scan: from queue import threading"
+run_test_both ask "python3 -c 'import xml.sax.saxutils as x
+x.urllib.request.urlopen(\"http://x\")'" \
+  "scan: xml.sax.saxutils.urllib"
+run_test_both ask "python3 -c 'from xml.sax.saxutils import urllib
+urllib.request.urlopen(\"http://x\")'" \
+  "scan: from xml.sax.saxutils import urllib"
+run_test_both ask "python3 -c 'import codecs as c
+c.open(\"/tmp/x\",\"w\")'" \
+  "scan: import codecs as alias"
+run_test_both ask "python3 -c 'from json import codecs
+codecs.open(\"/tmp/x\",\"w\")'" \
+  "scan: from json import codecs"
+run_test_both ask "python3 -c 'from collections.abc import sys'" \
+  "scan: from collections.abc import sys"
+
+# --- agent-discovered bash-level escapes (shfmt parser tricks, Apr 2026) ---
+
+# Bypass-4: xml.etree.ElementTree.write() writes arbitrary files
+run_test_both ask "python3 -c 'import xml.etree.ElementTree as ET
+ET.ElementTree(ET.Element(\"r\")).write(\"/tmp/x\")'" \
+  "agent-bash-4: ET.write to disk"
+run_test_both ask "python3 -c 'import xml.dom.minidom; xml.dom.minidom.parseString(\"<r/>\").writexml(open(\"/tmp/x\",\"w\"))'" \
+  "agent-bash-4b: xml.dom.minidom.writexml"
+
+# Bypass-5: python -m json.tool with outfile writes to disk
+run_test_both none 'python3 -m json.tool /tmp/in /tmp/out' \
+  "agent-bash-5: -m json.tool with outfile (no longer safe-listed)"
+run_test_both none 'python3 -m json.tool' \
+  "agent-bash-5b: -m json.tool standalone (also no longer safe-listed)"
+
+# Bypass-6: env-var prefix smuggles import path / preload
+run_test_both none "PYTHONPATH=/tmp python3 -c 'import json'" \
+  "agent-bash-6a: PYTHONPATH= prefix"
+run_test_both none "PYTHONSTARTUP=/tmp/evil.py python3 -c 'import json'" \
+  "agent-bash-6b: PYTHONSTARTUP= prefix"
+run_test_both none "LD_PRELOAD=/tmp/evil.so python3 -c 'import json'" \
+  "agent-bash-6c: LD_PRELOAD= prefix"
+
+# Bypass-7: env wrapper
+run_test_both none "env python3 -c 'import os; os.system(\"id\")'" \
+  "agent-bash-7a: env wraps python (must abstain)"
+run_test_both none "env VAR=val python3 -c 'import os'" \
+  "agent-bash-7b: env VAR=val wraps python"
+run_test_both none "env -i python3 -c 'import os'" \
+  "agent-bash-7c: env -i wraps python"
+
+# env alone (no program) still allowed for env inspection
+run_test_both allow "env" "env (no args) still allow"
+run_test_both allow "env -i" "env -i (no program) still allow"
+
+# ===== PASSTHROUGH: python forms classifier cannot validate =====
+echo "── python passthrough (no opinion) ──"
+run_test_both none 'python3 -c "$(cat foo.py)"' \
+  "python -c with command substitution"
+run_test_both none 'python3 -c "${CODE}"' \
+  "python -c with parameter expansion"
+run_test_both none "python3 myscript.py" \
+  "python script file"
+run_test_both none "python3 -c 'import json' && cat foo" \
+  "python -c compound"
+run_test_both none "python3 -c 'import json' | jq ." \
+  "python -c piped"
+run_test_both none "cat x.py | python3 -c 'print(1)'" \
+  "command piped to python -c"
+run_test_both none "python3 -m timeit '1+1'" \
+  "python -m unsafe module"
+run_test_both none "/usr/bin/python3 -c 'import json'" \
+  "python via absolute path"
+run_test_both none 'python3 -uc "import json"' \
+  "python combined short flags"
+# ANSI-C quoted ($'...') — bash decodes \n/\x at runtime, so what we read
+# statically may differ from what runs. Always abstain to avoid the gap.
+run_test_both none $'python3 -c $\'import json\\nprint(1)\'' \
+  "python -c with ANSI-C \$'...' quoting"
+run_test_both none $'python3 -c $\'\\x69mport os\\nos.system(\"id\")\'' \
+  "ANSI-C escape: \\x-encoded import (must abstain)"
+
 # ===== ALLOW: cargo/rust read-only =====
 echo "── cargo/rust read-only ──"
 run_test_both allow "cargo --version"


### PR DESCRIPTION
## Summary

- Auto-allow `python3 -c "..."` and `python -m <safe-module>` when the inline source statically analyses as read-only-safe — JSON parsing is ~95% of the real-world use case for inline Python; this stops the prompt-on-every-json.loads churn.
- Heuristic, not a sandbox: any unsafe construct falls back to ask, never silently allowed. Two parallel Opus 4.7 adversarial-research agents found 30+ escape vectors during development; all are blocked and locked in as regression tests.
- 360+ new test cases (1046 → 1154 total) — 30 complex JSON-parsing examples (happy path) and 240+ adversarial / sandbox-escape attempts covering subscript/dunder/aliasing/transitive-attribute/`from <mod> import <dangerous>`/etc.

## What's new

- `scripts/check-python-readonly.py` — AST-based static check with 12 defence layers (allowlisted imports, banned-builtin calls, dunder name/attribute reads, `sys.modules`/`path`/`meta_path`/`_getframe` block, `io`/`codecs` mode-check, write-wrapper ban, per-module banned from-imports for 16 modules, no-alias rule for `io`/`sys`/`codecs`, banned attribute names on any receiver `.os`/`.sys`/`.builtins`/`.codecs`/`.bltns`/etc., `operator.attrgetter`/`methodcaller` dispatch ban, `open`-aliasing pre-pass).
- `scripts/classifiers/python.sh` — invoked from `cmd-gate.sh:main()` before segmentation (parse_segments strips quoted `-c` args). Abstains on ANSI-C `$'...'` quoting, command substitution, env-var prefixes (`PYTHONPATH=`, `LD_PRELOAD=`), aliased `python` invocations, and any non-trivial form.
- `classifiers/read-only-tools.sh` — `env` no longer blanket-allowed when followed by a program (`env python3 -c "..."` was bypassing the python check). `env` alone or with only flags / `VAR=val` pairs still allow.

## Notable agent-found bypasses now blocked

- `_o = open; _o(p, "w")` — open aliasing
- `import io as _io; _io.FileIO(p, "w")` — alias defeats name-based mode-check
- `from sys import modules; modules["os"].system(...)` — from-import rebinding
- `posixpath.os.system(...)` — `os` reachable via every path module
- `codecs.open(p, "w")`, `codecs.builtins.open(...)`, `json.codecs.open(...)`
- `reprlib.builtins.open(...)`
- `import xml.etree.ElementTree as ET; ET.ElementTree(...).write(p)` — fixed by removing xml from allowlist
- `python -m json.tool <in> <out>` — outfile arg was a write capability; json.tool removed from `-m` safe list
- `PYTHONPATH=/tmp python3 -c "import json"` — env-var prefix detection via `Stmt.Cmd.Assigns`
- `env python3 -c "..."` — wrapper bypass
- `().__class__.__bases__[0].__subclasses__()` — dunder traversal
- `__builtins__["open"](p, "w")` — dunder-Name subscript backdoor
- `operator.attrgetter("os")(posixpath).system(...)` — string-based dispatch

## Test plan

- [x] All 1154 classifier tests pass (`bash tests/permission-manager/test-classify.sh`)
- [x] `validate-plugins.sh` clean (268 checks)
- [x] `validate-frontmatter.sh` clean (77 checks)
- [x] `rumdl check` clean for permission-manager
- [x] No regressions in existing python/pip read-only tests
- [x] All 360+ new tests pass on both Claude Code and Copilot CLI variants
- [ ] CI run on PR

Plugin bumped to 2.13.0 (claude + copilot).