### PR TITLE
fix(permission-manager): match versioned cache path in bootstrap bypass

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/cmd-gate.sh
+++ b/plugins-claude/permission-manager/scripts/cmd-gate.sh
@@ -55,8 +55,10 @@ fi
 # Allow this plugin's own dep-install script through without classification so the
 # user can recover from a missing-deps state (otherwise /permission-manager:setup
 # would itself be blocked by the dep check below — chicken and egg).
+# Claude Code installs plugins under a versioned path (.../permission-manager/<version>/scripts/...),
+# so the pattern accepts any path segment between "permission-manager" and "setup-deps.sh".
 case "$command" in
-  *permission-manager/scripts/setup-deps.sh*)
+  *permission-manager/*setup-deps.sh*)
     hook_allow "permission-manager: bootstrap (installing dependencies)"
     exit 0
     ;;

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -1349,6 +1349,16 @@ run_test_both none "wget https://example.com" "wget (passthrough)"
 run_test_both none "make build" "make (passthrough)"
 run_test_both none "rm -rf /tmp/test" "rm (passthrough)"
 
+# ===== BOOTSTRAP BYPASS: setup-deps.sh allowed regardless of install path =====
+# The dep check would otherwise block the very script that installs the deps.
+# Claude Code installs plugins under a versioned path
+# (.../permission-manager/<version>/scripts/setup-deps.sh), so the bypass must
+# tolerate any path segment between "permission-manager" and the script name.
+echo "── Bootstrap bypass: setup-deps.sh ──"
+run_test_both allow "bash /home/u/.claude/plugins/cache/agent-toolkit/permission-manager/2.13.1/scripts/setup-deps.sh" "bootstrap: versioned cache path (Claude Code)"
+run_test_both allow "bash ~/dev/agent-toolkit/plugins-claude/permission-manager/scripts/setup-deps.sh" "bootstrap: unversioned dev path"
+run_test_both allow "bash /opt/copilot/plugins/permission-manager/scripts/setup-deps.sh" "bootstrap: copilot install path"
+
 # ===== ALLOW-EDIT MODE TESTS =====
 # Helper to construct payloads with permission_mode: acceptEdits
 run_test_allow_edit() {


### PR DESCRIPTION
## Problem

Running `/permission-manager:setup` was blocked by the very dep check it exists to recover from. The bootstrap bypass at `cmd-gate.sh` line 58 used the literal pattern `*permission-manager/scripts/setup-deps.sh*`, but Claude Code installs plugins under a versioned cache path (`.../permission-manager/<version>/scripts/setup-deps.sh`), so the `<version>` segment defeated the match. The hook then hit `check_dependencies`, denied the command, and surfaced the same "missing required dependencies: shfmt. Run /permission-manager:setup to install." message that the user was trying to act on — chicken-and-egg deadlock for any user without `shfmt`/`jq` already installed.

## Fix

- Loosen the bypass pattern to `*permission-manager/*setup-deps.sh*`, which tolerates any path segment between the plugin name and the script name (versioned cache, dev install, or Copilot install path).
- Add `test-classify.sh` cases covering all three install paths so this can't regress.
- Bump `permission-manager` to `2.13.1` in both Claude Code and Copilot CLI variants so installed clients pick up the fix.

## Test plan

- [x] `bash test.sh` — 1524 passed, 0 failed (6 new bootstrap tests included)
- [x] `bash .github/scripts/validate-plugins.sh` — 267 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 98 checks, 0 failures
- [x] `rumdl check .` — clean