### PR TITLE
feat(permission-manager): change ask verdict to passthrough

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/cmd-gate.sh
+++ b/plugins-claude/permission-manager/scripts/cmd-gate.sh
@@ -8,8 +8,8 @@
 #
 # Classification buckets:
 #   allow — read-only command; auto-approved on both CLIs.
-#   ask   — write/modifying command; prompts user on Claude Code.
-#           (Copilot CLI has no "ask" — falls through with no opinion.)
+#   ask   — write/modifying command; hook passes through, letting Claude Code's
+#           own permission mode decide (auto mode runs it, interactive prompts).
 #   deny  — genuinely destructive pattern; hard-blocked everywhere.
 #
 # Classifiers cover:
@@ -171,10 +171,6 @@ main() {
         ;;
       1)
         log_decision "ask" "$CLASSIFY_REASON" "$command"
-        if [[ "$HOOK_FORMAT" == "claude" ]]; then
-          hook_ask "$CLASSIFY_REASON"
-          exit 0
-        fi
         exit 0
         ;;
       2)
@@ -236,11 +232,7 @@ main() {
       ;;
     1)
       log_decision "ask" "$worst_reason" "$command"
-      if [[ "$HOOK_FORMAT" == "claude" ]]; then
-        hook_ask "$worst_reason"
-        exit 0
-      fi
-      # Copilot CLI: no ask equivalent — passthrough (let Copilot's own permissions handle it)
+      # passthrough — let Claude Code's (or Copilot's) own permission mode decide
       exit 0
       ;;
     2)

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -41,9 +41,10 @@ run_test() {
     result=$(echo "$raw" | jq -r '.hookSpecificOutput.permissionDecision // "none"')
   fi
 
-  # Copilot CLI has no "ask" — it passes through (no opinion) to let Copilot handle it
+  # "ask" is now passthrough on all formats — hook exits 0 with no output and lets
+  # the CLI's own permission mode decide (auto mode runs it, interactive mode prompts)
   local effective_expected="$expected"
-  if [[ "$format" == "copilot" && "$expected" == "ask" ]]; then
+  if [[ "$expected" == "ask" ]]; then
     effective_expected="none"
   fi
 
@@ -1409,11 +1410,11 @@ run_test_allow_edit allow "git rebase main" "allow-edit: git rebase"
 run_test_allow_edit allow "git stash" "allow-edit: git stash"
 run_test_allow_edit allow "git stash pop" "allow-edit: git stash pop"
 
-# ===== ALLOW-EDIT: still ask (not promoted) =====
-echo "── Allow-edit: still ask ──"
-run_test_allow_edit ask "git cherry-pick abc123" "allow-edit: git cherry-pick (still ask)"
-run_test_allow_edit ask "git clone https://github.com/foo/bar" "allow-edit: git clone (still ask)"
-run_test_allow_edit ask "git rm file.txt" "allow-edit: git rm (still ask)"
+# ===== ALLOW-EDIT: not promoted (passthrough) =====
+echo "── Allow-edit: not promoted (passthrough) ──"
+run_test_allow_edit none "git cherry-pick abc123" "allow-edit: git cherry-pick (not promoted)"
+run_test_allow_edit none "git clone https://github.com/foo/bar" "allow-edit: git clone (not promoted)"
+run_test_allow_edit none "git rm file.txt" "allow-edit: git rm (not promoted)"
 
 # ===== ALLOW-EDIT: still deny =====
 echo "── Allow-edit: still deny ──"


### PR DESCRIPTION
## Summary

- `ask` verdicts now exit 0 with no output (passthrough) instead of emitting `hook_ask`, letting Claude Code's own permission mode decide whether to prompt
- In auto/bypass mode this means write commands run unimpeded; in interactive mode Claude Code still prompts as before
- `deny` still hard-blocks genuinely destructive operations (output redirects, `rm -rf`, etc.)

## Motivation

The `hook_ask` output was forcing approval prompts even in auto mode, which led to disabling the plugin entirely — defeating the purpose of having the hook. The `deny` bucket already covers operations that must never run unattended; `ask` was over-broad.

## Changes

- Remove both `hook_ask` call sites from `cmd-gate.sh` (python inline path + main segment loop)
- Update `test-classify.sh`: map `ask` → `none` for all formats (previously only Copilot), update allow-edit section labels
- Bump version `2.13.0` → `2.14.0`

## Test plan

- [ ] `bash test.sh` passes (1518 tests, 0 failures)
- [ ] `docker --context atlas ps` and similar read-only docker commands auto-allow when plugin is enabled
- [ ] `docker run`, `gh pr create`, etc. pass through to Claude Code's built-in permission system in interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)