### PR TITLE
fix(statusline): isolate git cache per repo and coalesce usage refresh

### DIFF
--- a/plugins-claude/statusline/.claude-plugin/plugin.json
+++ b/plugins-claude/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Configurable status line for Claude Code — git status, model, context, API usage, cost segments with ANSI colors",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/statusline/scripts/statusline.sh
+++ b/plugins-claude/statusline/scripts/statusline.sh
@@ -33,7 +33,6 @@ CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline"
 CONFIG_FILE="$CONFIG_DIR/config.json"
 CREDS_FILE="$HOME/.claude/.credentials.json"
 USAGE_CACHE="$CACHE_DIR/usage.json"
-GIT_CACHE="$CACHE_DIR/git.cache"
 PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]') # "darwin" or "linux"
 
 # Populated by load_config / read_stdin
@@ -424,14 +423,19 @@ get_primary_branch() {
 get_git_status() {
   local cwd="$1"
 
-  # Not a git repo? Skip
-  git -C "$cwd" rev-parse --is-inside-work-tree &>/dev/null || return 1
+  # Resolve repo toplevel; failure means we're not in a git work tree.
+  # Per-repo cache file keeps concurrent tabs in different projects from
+  # bleeding branch/status into each other.
+  local toplevel
+  toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || return 1
+  local safe_key="${toplevel//\//_}"
+  local cache_file="$CACHE_DIR/git${safe_key}.cache"
 
   # Check cache freshness
   local age
-  age=$(file_age "$GIT_CACHE")
-  if ((age < GIT_CACHE_TTL)) && [[ -s "$GIT_CACHE" ]]; then
-    cat "$GIT_CACHE"
+  age=$(file_age "$cache_file")
+  if ((age < GIT_CACHE_TTL)) && [[ -s "$cache_file" ]]; then
+    cat "$cache_file"
     return 0
   fi
 
@@ -449,14 +453,14 @@ get_git_status() {
 
   # Write cache if we got a result
   if [[ -n "$result" ]]; then
-    echo "$result" >"$GIT_CACHE"
+    echo "$result" >"$cache_file"
     echo "$result"
     return 0
   fi
 
   # Use stale cache if available
-  if [[ -s "$GIT_CACHE" ]]; then
-    cat "$GIT_CACHE"
+  if [[ -s "$cache_file" ]]; then
+    cat "$cache_file"
     return 0
   fi
 
@@ -482,12 +486,25 @@ fetch_usage() {
   local token
   token=$(get_access_token) || return 1
 
-  # Check cache freshness
+  # Fast path: serve from cache if fresh.
   local age
   age=$(file_age "$USAGE_CACHE")
   if ((age < CACHE_TTL)) && [[ -s "$USAGE_CACHE" ]]; then
     cat "$USAGE_CACHE"
     return 0
+  fi
+
+  # Slow path: serialize concurrent refreshes across tabs so only one
+  # actually hits the API per CACHE_TTL window. flock auto-releases when
+  # this subshell exits; fall through silently if flock isn't installed.
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$USAGE_CACHE.lock"
+    flock -w 5 9 || true
+    age=$(file_age "$USAGE_CACHE")
+    if ((age < CACHE_TTL)) && [[ -s "$USAGE_CACHE" ]]; then
+      cat "$USAGE_CACHE"
+      return 0
+    fi
   fi
 
   # Fetch from API


### PR DESCRIPTION
## Summary

Two bugs in the `statusline` plugin's caching layer:

1. **Git status bleeds across tabs in different projects.** The plugin wrote git branch/status to a single shared `$CACHE_DIR/git.cache` file, so whichever Claude Code tab refreshed most recently won and other tabs read its data — `master` from project A would show up in project B's statusline.
2. **Concurrent tabs all hit the OAuth usage endpoint on cold cache.** With many tabs open, every render that landed in a cold-cache window fired its own API call instead of serializing on the file cache.

## Changes

- **`get_git_status`** now keys its cache file by `git rev-parse --show-toplevel` (e.g. `git_data_workspace_agent-toolkit.cache`), matching the scheme `get_primary_branch` already uses. Folds the `is-inside-work-tree` check into the same git invocation so we don't run two `git` calls per render.
- **`fetch_usage`** wraps the slow path in best-effort `flock` on `usage.json.lock` with a re-check after acquiring the lock, so only one tab actually hits the API per `cache_ttl` window. Falls through silently when `flock` isn't installed (older macOS without brew).
- Bumped plugin version `1.0.2 → 1.0.3` so installed clients pick up the fix. No `plugins-copilot/` variant exists for this plugin.

The three-tier model is preserved:
- Context %: live (stdin)
- Git status: per-repo cache, default `git_cache_ttl=5s`
- Session/week/extra usage: shared cache across all sessions, default `cache_ttl=300s`, single API call returns all three segments

## Test plan

- [x] `bash -n plugins-claude/statusline/scripts/statusline.sh` — syntax ok
- [x] `bash .github/scripts/validate-plugins.sh` — 268/0
- [x] Smoke-rendered with a synthetic stdin payload; verified `git_data_workspace_agent-toolkit.cache` was created (old shared `git.cache` is orphaned and harmless)
- [ ] Open two Claude Code tabs in different repos and confirm each shows its own branch/status

🤖 Generated with [Claude Code](https://claude.com/claude-code)