### PR TITLE
chore: switch auto-merge bot to merge commits

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Enable auto-merge
-        run: gh pr merge "$PR_NUMBER" --auto --squash --repo "$REPO"
+        run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$REPO"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ The `master` branch is protected — never commit directly to it. For all change
    - **Bullet list**: specific changes made
 4. Push the branch and open a PR via `gh pr create`
 5. Monitor the GitHub Actions run (`gh run list`, `gh run view`) — fix any failures and push follow-up commits
-6. **Do not manually merge PRs.** A CI bot (`st0nefish-ci`) automatically enables auto-merge (squash) on new PRs. Once CI passes, the PR merges on its own.
+6. **Do not manually merge PRs.** A CI bot (`st0nefish-ci`) automatically enables auto-merge (merge commit) on new PRs. Once CI passes, the PR merges on its own.
 7. After the PR merges, check out `master` and pull to stay current:
 
    ```bash


### PR DESCRIPTION
## Summary

Switch the `st0nefish-ci` auto-merge bot from `--squash` to `--merge` so squash-merged-then-deleted feature branches stop accumulating as `[gone]` local branches that `git branch -d` won't clean up.

**Why merge commits, not rebase or status quo?**
- Squash and rebase both rewrite commit SHAs → local branch tip never appears in master's ancestry → `git branch -d` always declines, requires `git branch -D` or the `clean_gone` skill.
- Merge commits preserve SHAs → local cleanup works without ceremony.
- Matches the pattern used in the maintainer's enterprise projects.

The cost is a slightly noisier `git log` (each PR adds a merge commit + the original branch commits). Mitigated by setting `merge_commit_title=PR_TITLE` and `merge_commit_message=BLANK` after this PR merges, so `git log --first-parent` stays one-line-per-PR like it is today.

## Changes

- `.github/workflows/auto-merge.yml`: `gh pr merge --auto --squash` → `--auto --merge`
- `CLAUDE.md`: update the "auto-merge (squash)" note to "(merge commit)"

## Follow-up after merge

This is the last PR that will be squash-merged (the bot uses the workflow on master, which is still `--squash` until this lands). After it merges, repo settings get flipped via `gh api`:

- `allow_squash_merge=false`
- `merge_commit_title=PR_TITLE`
- `merge_commit_message=BLANK`

`delete_branch_on_merge=true` and `fetch.prune=true` (global) are already set; they continue to work with merge commits.

## Test plan

- [x] `bash .github/scripts/validate-plugins.sh` — 268/0
- [ ] Bot enables auto-merge on this PR (still using `--squash` from current master workflow)
- [ ] CI passes, PR squash-merges (last one)
- [ ] After merge: flip repo settings, verify next PR gets a merge commit titled `<PR title> (#<PR#>)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)