### PR TITLE
feat(git-worktree): move worktrees inside repo to avoid permission prompts

### DIFF
--- a/plugins-copilot/git-worktree/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-worktree/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-worktree",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Git worktree lifecycle management for parallel agentic work — create, list, remove worktrees with auto-whitelisting and proactive context-mismatch detection",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-worktree/commands/create.md
+++ b/plugins-copilot/git-worktree/commands/create.md
@@ -3,8 +3,11 @@ description: "Create a git worktree for parallel agentic work"
 allowed-tools: Bash
 ---
 
-Create a new linked git worktree in a sibling directory (`../<repo>-worktrees/<branch-slug>`).
-The worktree gets its own branch so work is isolated from the current checkout.
+Create a new linked git worktree under `.github/worktrees/<branch-slug>` inside
+the repo (auto-gitignored on first use). Keeping worktrees in-repo lets the
+harness's working-directory permission scope cover them, so operations against
+them don't trigger per-path approval prompts. The worktree gets its own branch
+so work is isolated from the current checkout.
 
 ## Steps
 
@@ -30,5 +33,7 @@ The worktree gets its own branch so work is isolated from the current checkout.
 ## Notes
 
 - If the branch already exists, the worktree checks it out without creating a new branch.
-- The base directory (`../<repo>-worktrees/`) is created automatically if it doesn't exist.
-- Override the base directory by setting `WORKTREE_BASE_DIR` in the environment.
+- The base directory (`.github/worktrees/`) is created automatically and added
+  to `.gitignore` on first use.
+- Override the base directory by setting `WORKTREE_BASE_DIR` in the environment
+  (skips the auto-gitignore step).

--- a/plugins-copilot/git-worktree/commands/remove.md
+++ b/plugins-copilot/git-worktree/commands/remove.md
@@ -8,7 +8,7 @@ Remove a linked git worktree. Optionally deletes the branch as well.
 ## Steps
 
 1. Determine what the user wants to remove. They can specify:
-   - A slug name (e.g. `feature-auth`) — looked up under `../<repo>-worktrees/`
+   - A slug name (e.g. `feature-auth`) — looked up under `.github/worktrees/`
    - An absolute path to the worktree directory
 
 2. Check if the worktree has uncommitted changes first:

--- a/plugins-copilot/git-worktree/scripts/worktree-create.sh
+++ b/plugins-copilot/git-worktree/scripts/worktree-create.sh
@@ -4,7 +4,13 @@
 # Usage: worktree-create.sh <branch-name> [--from <base-branch>]
 #
 # Creates a new linked worktree at:
-#   <parent-of-repo>/<repo-name>-worktrees/<slug>
+#   <main-repo-root>/.github/worktrees/<slug>
+#
+# Keeping worktrees inside the repo lets the harness's working-directory
+# permission scope cover them, avoiding per-path approval prompts. The base
+# directory is auto-added to .gitignore on first use.
+#
+# Override the base location with WORKTREE_BASE_DIR (e.g. for a sibling layout).
 #
 # If the branch already exists, attaches it. If it doesn't exist, creates it
 # from <base-branch> (defaults to current branch).
@@ -57,7 +63,10 @@ if [[ -z "$BRANCH" ]]; then
 fi
 
 # --- Validate git repo ---
-ROOT=$(git_root) || { echo "Error: not inside a git repository." >&2; exit 1; }
+ROOT=$(git_root) || {
+  echo "Error: not inside a git repository." >&2
+  exit 1
+}
 
 # --- Determine worktree path ---
 BASE_DIR=$(worktree_base_dir)
@@ -73,6 +82,19 @@ fi
 branch_exists() {
   git rev-parse --verify "refs/heads/$1" >/dev/null 2>&1
 }
+
+# --- Ensure the in-repo base dir is gitignored (skip if user overrode the location) ---
+if [[ -z "${WORKTREE_BASE_DIR:-}" ]]; then
+  MAIN_ROOT=$(main_repo_root)
+  if [[ -n "$MAIN_ROOT" ]] && ! git -C "$MAIN_ROOT" check-ignore -q ".github/worktrees/.probe" 2>/dev/null; then
+    GITIGNORE="$MAIN_ROOT/.gitignore"
+    if [[ -f "$GITIGNORE" && -n "$(tail -c1 "$GITIGNORE" 2>/dev/null)" ]]; then
+      printf '\n' >>"$GITIGNORE"
+    fi
+    printf '%s\n' '.github/worktrees/' >>"$GITIGNORE"
+    echo "→ Added '.github/worktrees/' to $GITIGNORE"
+  fi
+fi
 
 # --- Create base directory ---
 mkdir -p "$BASE_DIR"

--- a/plugins-copilot/git-worktree/scripts/worktree-lib.sh
+++ b/plugins-copilot/git-worktree/scripts/worktree-lib.sh
@@ -2,21 +2,28 @@
 # worktree-lib.sh — Shared functions for the git-worktree plugin.
 # Source this file from other scripts in the same directory.
 
-# Returns the root of the git repository (works from any linked worktree,
-# since all worktrees share the same git object store).
+# Returns the root of the *current* checkout (the linked worktree path when
+# called from inside one).
 git_root() {
   git rev-parse --show-toplevel 2>/dev/null
 }
 
-# Returns the bare repository name (basename of git root).
+# Returns the root of the *main* worktree, even when called from a linked
+# worktree. `git worktree list --porcelain` always lists the main worktree
+# first.
+main_repo_root() {
+  git worktree list --porcelain 2>/dev/null | sed -n '1s/^worktree //p'
+}
+
+# Returns the bare repository name (basename of main repo root).
 repo_name() {
   local root
-  root=$(git_root) || return 1
+  root=$(main_repo_root) || return 1
   basename "$root"
 }
 
 # Returns the base directory where worktrees for this repo are stored.
-# Default: <parent of git root>/<repo-name>-worktrees
+# Default: <main-repo-root>/.github/worktrees (in-repo; gitignored on first use)
 # Override with WORKTREE_BASE_DIR env var.
 worktree_base_dir() {
   if [[ -n "${WORKTREE_BASE_DIR:-}" ]]; then
@@ -24,8 +31,8 @@ worktree_base_dir() {
     return 0
   fi
   local root
-  root=$(git_root) || return 1
-  echo "$(dirname "$root")/$(basename "$root")-worktrees"
+  root=$(main_repo_root) || return 1
+  echo "$root/.github/worktrees"
 }
 
 # Convert a branch name to a filesystem-safe directory slug.
@@ -33,9 +40,9 @@ worktree_base_dir() {
 # Collapses consecutive - and trims leading/trailing -.
 slug_from_branch() {
   local branch="$1"
-  echo "$branch" \
-    | tr '/' '-' \
-    | sed 's/[^a-zA-Z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+  echo "$branch" |
+    tr '/' '-' |
+    sed 's/[^a-zA-Z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//'
 }
 
 # List all linked worktrees (excludes the main worktree).

--- a/plugins-copilot/git-worktree/skills/parallel-work/SKILL.md
+++ b/plugins-copilot/git-worktree/skills/parallel-work/SKILL.md
@@ -13,8 +13,10 @@ allowed-tools: Bash
 When the user wants to work on something in parallel, in isolation, or without
 touching the current branch — or when the agent detects a context mismatch
 between the current branch and the new request — a git worktree is the right
-tool. A worktree gives a second fully-functional checkout in a sibling directory:
-no stashing, no branch switching, no context loss.
+tool. A worktree gives a second fully-functional checkout under
+`.github/worktrees/<slug>` inside the repo (auto-gitignored): no stashing, no
+branch switching, no context loss, and no per-path permission prompts because
+the path is covered by the harness's working-directory scope.
 
 ## When to trigger
 

--- a/tests/git-worktree/test-lib.sh
+++ b/tests/git-worktree/test-lib.sh
@@ -89,7 +89,7 @@ assert_eq "repo_name returns dirname" "my-project" "$(repo_name)"
 
 echo "── worktree_base_dir ──"
 
-assert_eq "default base dir is sibling" "$TMPDIR_BASE/my-project-worktrees" "$(worktree_base_dir)"
+assert_eq "default base dir is .github/worktrees in main repo" "$MAIN_REPO/.github/worktrees" "$(worktree_base_dir)"
 assert_eq "WORKTREE_BASE_DIR override" "/custom/path" "$(WORKTREE_BASE_DIR=/custom/path worktree_base_dir)"
 
 # ── Tests: list_worktrees and is_worktree_path ────────────────────────────────


### PR DESCRIPTION
## Summary

The git-worktree plugin's default base dir was a sibling of the repo (`<parent>/<repo>-worktrees/`), which sits outside the harness's working-directory permission scope — every Bash/Edit/Write against a worktree triggered an approval prompt.

This change moves the default to `<main-repo-root>/.github/worktrees/<slug>`, putting worktrees inside the repo where the working-dir scope already covers them. The base dir is auto-added to `.gitignore` on first use.

## Changes

- New `main_repo_root()` helper (`git worktree list --porcelain | head -1`) so creating a worktree from inside a linked worktree resolves to the main repo root, not the current linked worktree (no nesting).
- `worktree_base_dir()` default → `<main-repo-root>/.github/worktrees`.
- `worktree-create.sh` appends `.github/worktrees/` to the repo's `.gitignore` on first use; idempotent via `git check-ignore`. Skipped when `WORKTREE_BASE_DIR` is set.
- `WORKTREE_BASE_DIR` env override unchanged.
- Updated `commands/create.md`, `commands/remove.md`, `skills/parallel-work/SKILL.md` for the new path.
- Bumped plugin version `1.0.0` → `1.1.0`.

## Test plan

- [x] `bash tests/git-worktree/test-lib.sh` (14 pass — updated default-location assertion)
- [x] `bash tests/git-worktree/test-create-remove.sh` (12 pass — uses env override, unchanged)
- [x] `bash test.sh` (1524 pass / 0 fail)
- [x] `bash .github/scripts/validate-plugins.sh` (268 checks, 0 failures)
- [x] `bash .github/scripts/validate-frontmatter.sh` (104 checks, 0 failures)
- [x] Smoke test: created a worktree in a fresh repo — landed at `.github/worktrees/feat-foo`, `.gitignore` got the rule once, `git status` stayed clean, second create didn't re-append.
- [x] Smoke test: ran `worktree-create.sh` from inside a linked worktree — second worktree landed at `<main>/.github/worktrees/feat-bar`, no nesting.