### PR TITLE
feat(git-tools): add --branch flag to git-cli pr show

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -13,7 +13,7 @@
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
-#   git-tools pr show      <N>
+#   git-tools pr show      <N> | --branch NAME
 #   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
 #   git-tools pr comment   <N> [--body | --body-file FILE]
 #
@@ -435,8 +435,23 @@ case "$cmd:$sub" in
     ;;
 
   pr:show)
-    [[ $# -ge 1 ]] || die_usage "usage: git-tools pr show <N>"
-    num="$1"
+    num=""; branch=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --branch) [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
+        --*)      die_usage "unknown flag: $1" ;;
+        *)        [[ -z "$num" ]] || die_usage "pr show takes a single number argument"; num="$1" ;;
+      esac
+      shift
+    done
+    [[ -z "$num" || -z "$branch" ]] || die_usage "pr show: pass <N> or --branch NAME, not both"
+    if [[ -n "$branch" ]]; then
+      pr_json=$("$0" pr list --state all --limit 100 2>/dev/null) || pr_json="[]"
+      num=$(echo "$pr_json" | jq -r --arg b "$branch" \
+        '[.[] | select(.head == $b or (.head | split(":") | last) == $b)] | sort_by(.number) | last | .number // empty')
+      [[ -n "$num" ]] || die "no PR found for branch '$branch'"
+    fi
+    [[ -n "$num" ]] || die_usage "usage: git-tools pr show <N> | --branch NAME"
     case "$PLATFORM" in
       github)
         cli_json '{number, title, body: (.body // ""), state: (.state | ascii_downcase), merged: ((.state | ascii_downcase) == "merged"), author: .author.login, head: .headRefName, base: .baseRefName, labels: [.labels[].name], assignees: [.assignees[].login], mergeable: (.mergeable | ascii_downcase? // null), created_at: .createdAt, updated_at: .updatedAt, url, comments: [.comments[] | {author: .author.login, body, created_at: .createdAt}]}' \
@@ -1139,7 +1154,7 @@ ISSUE COMMANDS
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
-  git-tools pr show      <N>
+  git-tools pr show      <N> | --branch NAME
   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
   git-tools pr comment   <N> [--body | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]

--- a/plugins-claude/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-tools/skills/git-cli/SKILL.md
@@ -62,8 +62,10 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue reopen <number>
 # List PRs
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr list [--state open|closed|merged|all] [--limit N]
 
-# Show a single PR with details
+# Show a single PR with details — by number, or by branch name
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show <number>
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show --branch <branch>      # resolves to most-recent PR for that branch
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show --branch "$(git rev-parse --abbrev-ref HEAD)"
 
 # Create a PR (auto-assigns to current user; --base defaults to repo's primary branch)
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch [--base main] --body <<'EOF'

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Work session management — start, end, checkpoint, status, catchup, handoff, resume, plus summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -13,7 +13,7 @@
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
-#   git-tools pr show      <N>
+#   git-tools pr show      <N> | --branch NAME
 #   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
 #   git-tools pr comment   <N> [--body | --body-file FILE]
 #
@@ -435,8 +435,23 @@ case "$cmd:$sub" in
     ;;
 
   pr:show)
-    [[ $# -ge 1 ]] || die_usage "usage: git-tools pr show <N>"
-    num="$1"
+    num=""; branch=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --branch) [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
+        --*)      die_usage "unknown flag: $1" ;;
+        *)        [[ -z "$num" ]] || die_usage "pr show takes a single number argument"; num="$1" ;;
+      esac
+      shift
+    done
+    [[ -z "$num" || -z "$branch" ]] || die_usage "pr show: pass <N> or --branch NAME, not both"
+    if [[ -n "$branch" ]]; then
+      pr_json=$("$0" pr list --state all --limit 100 2>/dev/null) || pr_json="[]"
+      num=$(echo "$pr_json" | jq -r --arg b "$branch" \
+        '[.[] | select(.head == $b or (.head | split(":") | last) == $b)] | sort_by(.number) | last | .number // empty')
+      [[ -n "$num" ]] || die "no PR found for branch '$branch'"
+    fi
+    [[ -n "$num" ]] || die_usage "usage: git-tools pr show <N> | --branch NAME"
     case "$PLATFORM" in
       github)
         cli_json '{number, title, body: (.body // ""), state: (.state | ascii_downcase), merged: ((.state | ascii_downcase) == "merged"), author: .author.login, head: .headRefName, base: .baseRefName, labels: [.labels[].name], assignees: [.assignees[].login], mergeable: (.mergeable | ascii_downcase? // null), created_at: .createdAt, updated_at: .updatedAt, url, comments: [.comments[] | {author: .author.login, body, created_at: .createdAt}]}' \
@@ -1139,7 +1154,7 @@ ISSUE COMMANDS
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
-  git-tools pr show      <N>
+  git-tools pr show      <N> | --branch NAME
   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
   git-tools pr comment   <N> [--body | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Work session management — start, end, checkpoint, status, catchup, handoff, resume, plus summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -13,7 +13,7 @@
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
-#   git-tools pr show      <N>
+#   git-tools pr show      <N> | --branch NAME
 #   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
 #   git-tools pr comment   <N> [--body | --body-file FILE]
 #
@@ -435,8 +435,23 @@ case "$cmd:$sub" in
     ;;
 
   pr:show)
-    [[ $# -ge 1 ]] || die_usage "usage: git-tools pr show <N>"
-    num="$1"
+    num=""; branch=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --branch) [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
+        --*)      die_usage "unknown flag: $1" ;;
+        *)        [[ -z "$num" ]] || die_usage "pr show takes a single number argument"; num="$1" ;;
+      esac
+      shift
+    done
+    [[ -z "$num" || -z "$branch" ]] || die_usage "pr show: pass <N> or --branch NAME, not both"
+    if [[ -n "$branch" ]]; then
+      pr_json=$("$0" pr list --state all --limit 100 2>/dev/null) || pr_json="[]"
+      num=$(echo "$pr_json" | jq -r --arg b "$branch" \
+        '[.[] | select(.head == $b or (.head | split(":") | last) == $b)] | sort_by(.number) | last | .number // empty')
+      [[ -n "$num" ]] || die "no PR found for branch '$branch'"
+    fi
+    [[ -n "$num" ]] || die_usage "usage: git-tools pr show <N> | --branch NAME"
     case "$PLATFORM" in
       github)
         cli_json '{number, title, body: (.body // ""), state: (.state | ascii_downcase), merged: ((.state | ascii_downcase) == "merged"), author: .author.login, head: .headRefName, base: .baseRefName, labels: [.labels[].name], assignees: [.assignees[].login], mergeable: (.mergeable | ascii_downcase? // null), created_at: .createdAt, updated_at: .updatedAt, url, comments: [.comments[] | {author: .author.login, body, created_at: .createdAt}]}' \
@@ -1139,7 +1154,7 @@ ISSUE COMMANDS
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
-  git-tools pr show      <N>
+  git-tools pr show      <N> | --branch NAME
   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
   git-tools pr comment   <N> [--body | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]


### PR DESCRIPTION
## Summary

`pr show` now accepts `--branch NAME` in addition to the existing positional `<N>`, mirroring the pattern already used by `pr wait`, `pr auto-merge-status`, and `run watch`. The natural agent instinct after pushing a branch — "is there a PR for this branch?" — now just works instead of bouncing off `unknown flag: --branch` and falling back to `--help`. The ship skill hit exactly that on a real session, which is what motivated the fix.

## Changes

- `utils/git-cli` — `pr show` parses both `<N>` and `--branch NAME`. When `--branch` is given, resolves to the most-recent PR for that branch via `pr list --state all` (matches both raw `branch` and Gitea's `owner:branch` format). Rejects combining positional `<N>` and `--branch` in the same call. Header comment + `--help` text updated.
- `plugins-claude/git-tools/skills/git-cli/SKILL.md` — documents the new form alongside the existing positional, with a `git rev-parse --abbrev-ref HEAD` example for "current branch" so the agent has a copy-paste pattern.
- `utils/sync.sh` propagated to `git-tools` and `session` (both vendor `git-cli`).
- Versions: `git-tools` 2.0.0 → 2.0.1, `session` 3.7.3 → 3.7.4 (both Claude and Copilot variants).

## Test plan

- [x] `git-cli pr show --branch <existing>` returns full PR JSON
- [x] `git-cli pr show --branch nonexistent-xyz` → `git-tools: no PR found for branch '...'`, exit 1
- [x] `git-cli pr show` (no args) → usage error, exit 1
- [x] `git-cli pr show 83 --branch foo` → `pass <N> or --branch NAME, not both`, exit 1
- [x] `git-cli pr show 83` (positional, unchanged) still works
- [x] `bash test.sh` — 1524 pass, 0 fail
- [x] `bash .github/scripts/validate-plugins.sh` — 268 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 104 checks, 0 failures
- [x] `bash utils/sync.sh --check` — no drift
- [x] `rumdl check` — clean on touched files (14 pre-existing MD005 errors in `session-history-analyzer/commands/analyze.md` are unrelated)