### PR TITLE
fix(git-tools): aggregate per-job CI status on Gitea

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -279,6 +279,22 @@ detect_current_user() {
 }
 
 # ---------------------------------------------------------------------------
+# Run helpers
+# ---------------------------------------------------------------------------
+
+# Return comma-separated names of any jobs in <run_id> whose status is
+# "failure", or empty if none. Used by run watch to detect job-level failures
+# even when the run-level status reports success — Gitea sets run.status to
+# "success" on a multi-job workflow if at least one job ran successfully,
+# masking failures in earlier jobs (see issue #87). Calls "run show" to
+# normalize per-platform JSON, so it works for both gh and tea paths.
+_run_failed_jobs() {
+  local run_id="$1" show_json
+  show_json=$("$0" run show "$run_id" 2>/dev/null) || return 0
+  echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")'
+}
+
+# ---------------------------------------------------------------------------
 # Command routing
 # ---------------------------------------------------------------------------
 
@@ -714,6 +730,7 @@ case "$cmd:$sub" in
       gitea)
         args=(--output json --limit "$limit")
         [[ -n "$status" ]] && args+=(--status "$status")
+        [[ -n "$branch" ]] && args+=(--branch "$branch")
         cli_json '[.[] | {id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}]' \
           env NO_COLOR=1 tea actions runs list "${args[@]}"
         ;;
@@ -731,9 +748,41 @@ case "$cmd:$sub" in
           --json "databaseId,status,conclusion,workflowName,headBranch,event,createdAt,jobs,url"
         ;;
       gitea)
-        cli_json \
-          '{id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}' \
-          env NO_COLOR=1 tea actions runs view "$run_id" --output json
+        view_json=$(NO_COLOR=1 tea actions runs view "$run_id" --output json 2>/dev/null) \
+          || die "tea actions runs view failed for run $run_id"
+
+        # Fetch per-job data via the actions API so callers (run watch) can
+        # detect job-level failures masked by run-level status=success on
+        # Gitea (see _run_failed_jobs). tea api substitutes {owner}/{repo}.
+        jobs_array='[]'
+        jobs_json=$(NO_COLOR=1 tea api "repos/{owner}/{repo}/actions/runs/$run_id/jobs" 2>/dev/null || true)
+        if [[ -n "$jobs_json" ]]; then
+          jobs_array=$(echo "$jobs_json" | jq -c '
+            def to_status:
+              if (.conclusion // "") != "" then (.conclusion | ascii_downcase)
+              elif .status == "completed" then "success"
+              else (.status // "unknown" | ascii_downcase)
+              end;
+            [(.jobs // .) | (if type == "array" then .[]? else empty end) |
+              {id: ((.id // 0) | tostring), name: (.name // ""), status: to_status}]
+          ' 2>/dev/null) || jobs_array='[]'
+        fi
+
+        # Older Gitea versions may not expose the jobs API; fall back to
+        # scanning the run logs for "Job '<name>' failed" lines.
+        if [[ "$jobs_array" == '[]' ]]; then
+          failed_log=$(NO_COLOR=1 tea actions runs logs "$run_id" 2>/dev/null \
+            | grep -oE "Job '[^']+' failed" \
+            | sed -E "s/Job '(.+)' failed/\1/" \
+            | sort -u || true)
+          if [[ -n "$failed_log" ]]; then
+            jobs_array=$(printf '%s\n' "$failed_log" \
+              | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({id: "", name: ., status: "failure"})')
+          fi
+        fi
+
+        echo "$view_json" | jq --argjson jobs "$jobs_array" \
+          '{id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // ""), jobs: $jobs}'
         ;;
     esac
     ;;
@@ -872,6 +921,19 @@ case "$cmd:$sub" in
         _pre_id=$(echo "$_pre_latest" | jq -r '.id')
         case "$_pre_status" in
           success|completed)
+            # Run-level status can read "success" on Gitea even when a
+            # job inside the run failed (issue #87). Aggregate per-job
+            # status before declaring pass.
+            failed_jobs=$(_run_failed_jobs "$_pre_id")
+            if [[ -n "$failed_jobs" ]]; then
+              echo "status: fail"
+              [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
+              echo "duration: 0s"
+              echo "failed_jobs: $failed_jobs"
+              echo "--- Failed job logs (last 80 lines) ---" >&2
+              "$0" run logs "$_pre_id" --failed-only 2>/dev/null | tail -80 >&2 || true
+              exit 0
+            fi
             echo "status: pass"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
@@ -879,9 +941,7 @@ case "$cmd:$sub" in
             exit 0
             ;;
           failure|timed_out)
-            failed_jobs=""
-            show_json=$("$0" run show "$_pre_id" 2>/dev/null) && \
-              failed_jobs=$(echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")') || true
+            failed_jobs=$(_run_failed_jobs "$_pre_id")
             echo "status: fail"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
@@ -890,6 +950,17 @@ case "$cmd:$sub" in
               echo "--- Failed job logs (last 80 lines) ---" >&2
               "$0" run logs "$_pre_id" --failed-only 2>/dev/null | tail -80 >&2 || true
             fi
+            exit 0
+            ;;
+          cancelled|canceled|skipped)
+            # Distinct terminal states — surface them as fail with a
+            # reason so consumers (ship/session-end) gating on
+            # status: pass stop instead of advancing.
+            echo "status: fail"
+            [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
+            echo "duration: 0s"
+            echo "reason: $_pre_status"
+            echo "CI run $_pre_status for branch '$branch'" >&2
             exit 0
             ;;
         esac
@@ -1048,10 +1119,7 @@ case "$cmd:$sub" in
           # Non-terminal — keep polling
           ;;
         failure|timed_out)
-          # Best-effort single run show for failed job names (not in a loop)
-          failed_jobs=""
-          show_json=$("$0" run show "$run_id" 2>/dev/null) && \
-            failed_jobs=$(echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")') || true
+          failed_jobs=$(_run_failed_jobs "$run_id")
           echo "status: fail"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"
@@ -1062,11 +1130,32 @@ case "$cmd:$sub" in
           fi
           exit 0
           ;;
+        cancelled|canceled|skipped)
+          # Distinct terminal states — surface them as fail with a reason
+          # so consumers gating on status: pass stop instead of advancing.
+          echo "status: fail"
+          [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
+          echo "duration: ${elapsed}s"
+          echo "reason: $run_status"
+          echo "CI run $run_status on branch '$branch'" >&2
+          exit 0
+          ;;
         *)
-          # Terminal — covers success, completed, cancelled, skipped, neutral,
-          # and any future/unexpected status.  Exiting here is intentional:
-          # a false-positive "pass" is recoverable, a false-negative "keep
-          # polling" wastes 5 minutes and blocks the caller.
+          # Terminal — covers success and any future/unexpected status.
+          # Even when the run-level status reports success, an individual
+          # job may have failed (Gitea reports run.status=success on a
+          # multi-job run if any job succeeded; see #87). Aggregate
+          # per-job status before declaring pass.
+          failed_jobs=$(_run_failed_jobs "$run_id")
+          if [[ -n "$failed_jobs" ]]; then
+            echo "status: fail"
+            [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
+            echo "duration: ${elapsed}s"
+            echo "failed_jobs: $failed_jobs"
+            echo "--- Failed job logs (last 80 lines) ---" >&2
+            "$0" run logs "$run_id" --failed-only 2>/dev/null | tail -80 >&2 || true
+            exit 0
+          fi
           echo "status: pass"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"

--- a/plugins-claude/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-tools/skills/git-cli/SKILL.md
@@ -102,6 +102,11 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run logs <run-id> --failed-only
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run watch --branch NAME [--initial-delay S] [--timeout S] [--interval S]
 # Outputs: status (pass|fail|closed|timeout|no-workflow), url, duration
 # On fail: also emits failed_jobs: <comma-separated names> and dumps failed job logs to stderr
+# Cancelled/skipped runs report status: fail with a reason: line so callers
+# gating on status: pass stop instead of advancing.
+# Per-job status is aggregated on both gh and tea — a run-level "success" with
+# any failed job still yields status: fail (Gitea masks job failures behind a
+# run-level success, see issue #87).
 # On GitHub with a PR: uses statusCheckRollup for reliable CI + merge state detection
 # Without a PR: falls back to run list polling
 ```

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Work session management — start, end, checkpoint, status, catchup, handoff, resume, orchestrate, plus summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -279,6 +279,22 @@ detect_current_user() {
 }
 
 # ---------------------------------------------------------------------------
+# Run helpers
+# ---------------------------------------------------------------------------
+
+# Return comma-separated names of any jobs in <run_id> whose status is
+# "failure", or empty if none. Used by run watch to detect job-level failures
+# even when the run-level status reports success — Gitea sets run.status to
+# "success" on a multi-job workflow if at least one job ran successfully,
+# masking failures in earlier jobs (see issue #87). Calls "run show" to
+# normalize per-platform JSON, so it works for both gh and tea paths.
+_run_failed_jobs() {
+  local run_id="$1" show_json
+  show_json=$("$0" run show "$run_id" 2>/dev/null) || return 0
+  echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")'
+}
+
+# ---------------------------------------------------------------------------
 # Command routing
 # ---------------------------------------------------------------------------
 
@@ -714,6 +730,7 @@ case "$cmd:$sub" in
       gitea)
         args=(--output json --limit "$limit")
         [[ -n "$status" ]] && args+=(--status "$status")
+        [[ -n "$branch" ]] && args+=(--branch "$branch")
         cli_json '[.[] | {id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}]' \
           env NO_COLOR=1 tea actions runs list "${args[@]}"
         ;;
@@ -731,9 +748,41 @@ case "$cmd:$sub" in
           --json "databaseId,status,conclusion,workflowName,headBranch,event,createdAt,jobs,url"
         ;;
       gitea)
-        cli_json \
-          '{id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}' \
-          env NO_COLOR=1 tea actions runs view "$run_id" --output json
+        view_json=$(NO_COLOR=1 tea actions runs view "$run_id" --output json 2>/dev/null) \
+          || die "tea actions runs view failed for run $run_id"
+
+        # Fetch per-job data via the actions API so callers (run watch) can
+        # detect job-level failures masked by run-level status=success on
+        # Gitea (see _run_failed_jobs). tea api substitutes {owner}/{repo}.
+        jobs_array='[]'
+        jobs_json=$(NO_COLOR=1 tea api "repos/{owner}/{repo}/actions/runs/$run_id/jobs" 2>/dev/null || true)
+        if [[ -n "$jobs_json" ]]; then
+          jobs_array=$(echo "$jobs_json" | jq -c '
+            def to_status:
+              if (.conclusion // "") != "" then (.conclusion | ascii_downcase)
+              elif .status == "completed" then "success"
+              else (.status // "unknown" | ascii_downcase)
+              end;
+            [(.jobs // .) | (if type == "array" then .[]? else empty end) |
+              {id: ((.id // 0) | tostring), name: (.name // ""), status: to_status}]
+          ' 2>/dev/null) || jobs_array='[]'
+        fi
+
+        # Older Gitea versions may not expose the jobs API; fall back to
+        # scanning the run logs for "Job '<name>' failed" lines.
+        if [[ "$jobs_array" == '[]' ]]; then
+          failed_log=$(NO_COLOR=1 tea actions runs logs "$run_id" 2>/dev/null \
+            | grep -oE "Job '[^']+' failed" \
+            | sed -E "s/Job '(.+)' failed/\1/" \
+            | sort -u || true)
+          if [[ -n "$failed_log" ]]; then
+            jobs_array=$(printf '%s\n' "$failed_log" \
+              | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({id: "", name: ., status: "failure"})')
+          fi
+        fi
+
+        echo "$view_json" | jq --argjson jobs "$jobs_array" \
+          '{id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // ""), jobs: $jobs}'
         ;;
     esac
     ;;
@@ -872,6 +921,19 @@ case "$cmd:$sub" in
         _pre_id=$(echo "$_pre_latest" | jq -r '.id')
         case "$_pre_status" in
           success|completed)
+            # Run-level status can read "success" on Gitea even when a
+            # job inside the run failed (issue #87). Aggregate per-job
+            # status before declaring pass.
+            failed_jobs=$(_run_failed_jobs "$_pre_id")
+            if [[ -n "$failed_jobs" ]]; then
+              echo "status: fail"
+              [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
+              echo "duration: 0s"
+              echo "failed_jobs: $failed_jobs"
+              echo "--- Failed job logs (last 80 lines) ---" >&2
+              "$0" run logs "$_pre_id" --failed-only 2>/dev/null | tail -80 >&2 || true
+              exit 0
+            fi
             echo "status: pass"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
@@ -879,9 +941,7 @@ case "$cmd:$sub" in
             exit 0
             ;;
           failure|timed_out)
-            failed_jobs=""
-            show_json=$("$0" run show "$_pre_id" 2>/dev/null) && \
-              failed_jobs=$(echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")') || true
+            failed_jobs=$(_run_failed_jobs "$_pre_id")
             echo "status: fail"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
@@ -890,6 +950,17 @@ case "$cmd:$sub" in
               echo "--- Failed job logs (last 80 lines) ---" >&2
               "$0" run logs "$_pre_id" --failed-only 2>/dev/null | tail -80 >&2 || true
             fi
+            exit 0
+            ;;
+          cancelled|canceled|skipped)
+            # Distinct terminal states — surface them as fail with a
+            # reason so consumers (ship/session-end) gating on
+            # status: pass stop instead of advancing.
+            echo "status: fail"
+            [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
+            echo "duration: 0s"
+            echo "reason: $_pre_status"
+            echo "CI run $_pre_status for branch '$branch'" >&2
             exit 0
             ;;
         esac
@@ -1048,10 +1119,7 @@ case "$cmd:$sub" in
           # Non-terminal — keep polling
           ;;
         failure|timed_out)
-          # Best-effort single run show for failed job names (not in a loop)
-          failed_jobs=""
-          show_json=$("$0" run show "$run_id" 2>/dev/null) && \
-            failed_jobs=$(echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")') || true
+          failed_jobs=$(_run_failed_jobs "$run_id")
           echo "status: fail"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"
@@ -1062,11 +1130,32 @@ case "$cmd:$sub" in
           fi
           exit 0
           ;;
+        cancelled|canceled|skipped)
+          # Distinct terminal states — surface them as fail with a reason
+          # so consumers gating on status: pass stop instead of advancing.
+          echo "status: fail"
+          [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
+          echo "duration: ${elapsed}s"
+          echo "reason: $run_status"
+          echo "CI run $run_status on branch '$branch'" >&2
+          exit 0
+          ;;
         *)
-          # Terminal — covers success, completed, cancelled, skipped, neutral,
-          # and any future/unexpected status.  Exiting here is intentional:
-          # a false-positive "pass" is recoverable, a false-negative "keep
-          # polling" wastes 5 minutes and blocks the caller.
+          # Terminal — covers success and any future/unexpected status.
+          # Even when the run-level status reports success, an individual
+          # job may have failed (Gitea reports run.status=success on a
+          # multi-job run if any job succeeded; see #87). Aggregate
+          # per-job status before declaring pass.
+          failed_jobs=$(_run_failed_jobs "$run_id")
+          if [[ -n "$failed_jobs" ]]; then
+            echo "status: fail"
+            [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
+            echo "duration: ${elapsed}s"
+            echo "failed_jobs: $failed_jobs"
+            echo "--- Failed job logs (last 80 lines) ---" >&2
+            "$0" run logs "$run_id" --failed-only 2>/dev/null | tail -80 >&2 || true
+            exit 0
+          fi
           echo "status: pass"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Work session management — start, end, checkpoint, status, catchup, handoff, resume, plus summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/tests/session/test-ci-poll.sh
+++ b/tests/session/test-ci-poll.sh
@@ -156,7 +156,10 @@ EOF
 run_test "pass" "0" "completed (null conclusion) → status: pass, exit 0"
 
 # ---------------------------------------------------------------------------
-# Test: cancelled → treated as pass
+# Test: cancelled → fail (with reason: cancelled)
+# Issue #87: cancelled/skipped runs must NOT be reported as pass — the ship
+# and session/end skills gate on `status: pass` and would otherwise advance
+# onto an aborted CI run.
 # ---------------------------------------------------------------------------
 
 write_mock_gh <<'EOF'
@@ -173,7 +176,19 @@ case "$1:$2" in
 esac
 EOF
 
-run_test "pass" "0" "cancelled → status: pass, exit 0"
+run_test "fail" "0" "cancelled → status: fail, exit 0"
+
+# Verify the cancelled run also emits `reason: cancelled`
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch "test-branch" --initial-delay 0 --timeout 3 --interval 1 2>/dev/null) || true
+got_reason=$(echo "$output" | grep '^reason:' | sed 's/^reason: *//')
+if [[ "$got_reason" == "cancelled" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "cancelled → reason: cancelled"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (got: '%s')\n" "cancelled → reason: cancelled" "$got_reason"
+  ((FAIL++)) || true
+fi
 
 # ---------------------------------------------------------------------------
 # Test: no-workflow — no runs found
@@ -582,6 +597,336 @@ else
     "no runs yet → pre-check does not exit, falls through to poll" "$got_status" "$exit_code"
   ((FAIL++)) || true
 fi
+
+# ===========================================================================
+# Gitea path tests (issue #87 — job-level failure aggregation)
+#
+# These tests swap the git mock to a Gitea remote and add a tea mock so
+# detect_platform picks the gitea code path. They cover:
+#   - run-level success masking a failed job → status: fail (the #87 repro)
+#   - run-level failure → status: fail
+#   - cancelled → status: fail with reason: cancelled
+#   - log-grep fallback when the jobs API is unavailable
+#   - --branch flag is forwarded to `tea actions runs list`
+#   - pre-check path (completed run already present) catches a failed job
+# ===========================================================================
+
+echo "── run watch: Gitea outcomes ──"
+
+# Switch the git mock to a Gitea-style remote so detect_platform takes the
+# gitea branch. Restored at the end of the section.
+cat >"$MOCK_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") echo "https://gitea.example.com/owner/repo.git" ;;
+  *) command git "$@" ;;
+esac
+EOF
+chmod +x "$MOCK_DIR/git"
+
+# tea login list — the wrapper matches a configured login host against the
+# remote host to identify the platform. Return a single login matching the
+# git mock host.
+cat >"$MOCK_DIR/tea" <<'TEA_HEADER'
+#!/usr/bin/env bash
+# Mock tea — dispatches on subcommand. Per-test bodies appended below.
+TEA_HEADER
+
+write_mock_tea() {
+  cat >"$MOCK_DIR/tea" <<'TEA_HEADER'
+#!/usr/bin/env bash
+# Mock tea — dispatches on subcommand.
+case "$1 $2 $3" in
+  "login list "*)
+    echo '[{"name":"example","url":"https://gitea.example.com","user":"owner"}]'
+    exit 0
+    ;;
+esac
+TEA_HEADER
+  cat >>"$MOCK_DIR/tea"
+  chmod +x "$MOCK_DIR/tea"
+}
+
+# Run a watch invocation against the gitea mocks. Mirrors run_test but
+# leaves the gh mock alone (it is unused on the gitea path; the wrapper
+# does not invoke gh when PLATFORM == "gitea").
+gitea_run_test() {
+  local expected_status="$1" expected_exit="$2" label="$3"
+
+  if [[ -n "$FILTER" ]] && ! echo "$label" | grep -qi "$FILTER"; then
+    ((SKIP++)) || true
+    return 0
+  fi
+
+  local output exit_code
+  exit_code=0
+  output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+    --branch "test-branch" --initial-delay 0 --timeout 3 --interval 1 2>/dev/null) || exit_code=$?
+
+  local got_status
+  got_status=$(echo "$output" | grep '^status:' | head -1 | sed 's/^status: *//')
+
+  if [[ "$got_status" == "$expected_status" && "$exit_code" == "$expected_exit" ]]; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s  (expected status=%s exit=%s, got status=%s exit=%s)\n" \
+      "$label" "$expected_status" "$expected_exit" "$got_status" "$exit_code"
+    ((FAIL++)) || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: top-level success, all jobs success → status: pass (sanity baseline)
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        echo '[{"id":900,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/900"}]'
+        ;;
+      view)
+        echo '{"id":900,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/900"}'
+        ;;
+      logs)
+        echo "all green"
+        ;;
+    esac
+    ;;
+  "api ")
+    # tea api repos/{owner}/{repo}/actions/runs/<id>/jobs
+    echo '{"jobs":[{"id":1,"name":"build","status":"completed","conclusion":"success"}],"total_count":1}'
+    ;;
+esac
+EOF
+
+gitea_run_test "pass" "0" "[gitea] all jobs success → status: pass"
+
+# ---------------------------------------------------------------------------
+# Test: #87 repro — top-level success, one job failure → status: fail
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        # Gitea bug: top-level status reads "success" even with a failed job
+        echo '[{"id":879,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/879"}]'
+        ;;
+      view)
+        echo '{"id":879,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/879"}'
+        ;;
+      logs)
+        echo "Job 'lint' failed"
+        ;;
+    esac
+    ;;
+  "api ")
+    echo '{"jobs":[{"id":2,"name":"lint","status":"completed","conclusion":"failure"},{"id":3,"name":"merge","status":"completed","conclusion":"skipped"}],"total_count":2}'
+    ;;
+esac
+EOF
+
+gitea_run_test "fail" "0" "[gitea] #87 — run success masks job failure → status: fail"
+
+# Verify the failed_jobs field names the failed job
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch "test-branch" --initial-delay 0 --timeout 3 --interval 1 2>/dev/null) || true
+got_failed=$(echo "$output" | grep '^failed_jobs:' | sed 's/^failed_jobs: *//')
+if [[ "$got_failed" == "lint" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] #87 — failed_jobs includes 'lint'"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (got: '%s')\n" "[gitea] #87 — failed_jobs includes 'lint'" "$got_failed"
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Test: top-level failure → status: fail
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        echo '[{"id":880,"status":"failure","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":20,"url":"https://gitea.example.com/owner/repo/actions/runs/880"}]'
+        ;;
+      view)
+        echo '{"id":880,"status":"failure","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":20,"url":"https://gitea.example.com/owner/repo/actions/runs/880"}'
+        ;;
+      logs)
+        echo "Job 'build' failed"
+        ;;
+    esac
+    ;;
+  "api ")
+    echo '{"jobs":[{"id":4,"name":"build","status":"completed","conclusion":"failure"}],"total_count":1}'
+    ;;
+esac
+EOF
+
+gitea_run_test "fail" "0" "[gitea] top-level failure → status: fail"
+
+# ---------------------------------------------------------------------------
+# Test: cancelled → status: fail with reason: cancelled
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        echo '[{"id":881,"status":"cancelled","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":5,"url":"https://gitea.example.com/owner/repo/actions/runs/881"}]'
+        ;;
+      view)
+        echo '{"id":881,"status":"cancelled","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":5,"url":"https://gitea.example.com/owner/repo/actions/runs/881"}'
+        ;;
+      logs) echo "" ;;
+    esac
+    ;;
+  "api ")
+    echo '{"jobs":[],"total_count":0}'
+    ;;
+esac
+EOF
+
+gitea_run_test "fail" "0" "[gitea] cancelled run → status: fail"
+
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch "test-branch" --initial-delay 0 --timeout 3 --interval 1 2>/dev/null) || true
+got_reason=$(echo "$output" | grep '^reason:' | sed 's/^reason: *//')
+if [[ "$got_reason" == "cancelled" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] cancelled → reason: cancelled"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (got: '%s')\n" "[gitea] cancelled → reason: cancelled" "$got_reason"
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Test: jobs API unavailable, log-grep fallback finds "Job 'lint' failed"
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        echo '[{"id":882,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/882"}]'
+        ;;
+      view)
+        echo '{"id":882,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/882"}'
+        ;;
+      logs)
+        # Older Gitea: jobs API absent; the log dump is the only signal.
+        printf "step output...\nJob 'lint' failed\nmore output\n"
+        ;;
+    esac
+    ;;
+  "api ")
+    # Older Gitea: endpoint not implemented — return empty/non-JSON.
+    exit 1
+    ;;
+esac
+EOF
+
+gitea_run_test "fail" "0" "[gitea] log-grep fallback → status: fail"
+
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch "test-branch" --initial-delay 0 --timeout 3 --interval 1 2>/dev/null) || true
+got_failed=$(echo "$output" | grep '^failed_jobs:' | sed 's/^failed_jobs: *//')
+if [[ "$got_failed" == "lint" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] log-grep fallback → failed_jobs includes 'lint'"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (got: '%s')\n" "[gitea] log-grep fallback → failed_jobs includes 'lint'" "$got_failed"
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Test: --branch is forwarded to `tea actions runs list`
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        # Fail loudly if the wrapper drops --branch (this was the bug).
+        if [[ "$*" != *"--branch test-branch"* ]]; then
+          echo "MOCK ERROR: --branch flag missing from tea actions runs list" >&2
+          echo '[]'
+          exit 1
+        fi
+        echo '[{"id":883,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/883"}]'
+        ;;
+      view)
+        echo '{"id":883,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/883"}'
+        ;;
+      logs) echo "" ;;
+    esac
+    ;;
+  "api ")
+    echo '{"jobs":[{"id":7,"name":"build","status":"completed","conclusion":"success"}],"total_count":1}'
+    ;;
+esac
+EOF
+
+gitea_run_test "pass" "0" "[gitea] --branch is forwarded to tea actions runs list"
+
+# ---------------------------------------------------------------------------
+# Test: pre-check path — completed run with failed job present before loop
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1 $2" in
+  "actions runs")
+    case "$3" in
+      list)
+        echo '[{"id":884,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/884"}]'
+        ;;
+      view)
+        echo '{"id":884,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/884"}'
+        ;;
+      logs) echo "Job 'lint' failed" ;;
+    esac
+    ;;
+  "api ")
+    echo '{"jobs":[{"id":8,"name":"lint","status":"completed","conclusion":"failure"}],"total_count":1}'
+    ;;
+esac
+EOF
+
+# initial-delay 60 forces use of the pre-check path: if it doesn't catch the
+# failed job, the test would hang on the initial sleep.
+exit_code=0
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch "test-branch" --initial-delay 60 --timeout 3 --interval 1 2>/dev/null) || exit_code=$?
+got_status=$(echo "$output" | grep '^status:' | head -1 | sed 's/^status: *//')
+got_duration=$(echo "$output" | grep '^duration:' | sed 's/^duration: *//')
+if [[ "$got_status" == "fail" && "$exit_code" == "0" && "$got_duration" == "0s" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] pre-check catches failed job → instant exit"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (status=%s exit=%s duration=%s)\n" \
+    "[gitea] pre-check catches failed job → instant exit" "$got_status" "$exit_code" "$got_duration"
+  ((FAIL++)) || true
+fi
+
+# Restore the GitHub git mock so any future tests added below still see github.
+cat >"$MOCK_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") echo "https://github.com/test/repo.git" ;;
+  *) command git "$@" ;;
+esac
+EOF
+chmod +x "$MOCK_DIR/git"
+rm -f "$MOCK_DIR/tea"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -279,6 +279,22 @@ detect_current_user() {
 }
 
 # ---------------------------------------------------------------------------
+# Run helpers
+# ---------------------------------------------------------------------------
+
+# Return comma-separated names of any jobs in <run_id> whose status is
+# "failure", or empty if none. Used by run watch to detect job-level failures
+# even when the run-level status reports success — Gitea sets run.status to
+# "success" on a multi-job workflow if at least one job ran successfully,
+# masking failures in earlier jobs (see issue #87). Calls "run show" to
+# normalize per-platform JSON, so it works for both gh and tea paths.
+_run_failed_jobs() {
+  local run_id="$1" show_json
+  show_json=$("$0" run show "$run_id" 2>/dev/null) || return 0
+  echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")'
+}
+
+# ---------------------------------------------------------------------------
 # Command routing
 # ---------------------------------------------------------------------------
 
@@ -714,6 +730,7 @@ case "$cmd:$sub" in
       gitea)
         args=(--output json --limit "$limit")
         [[ -n "$status" ]] && args+=(--status "$status")
+        [[ -n "$branch" ]] && args+=(--branch "$branch")
         cli_json '[.[] | {id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}]' \
           env NO_COLOR=1 tea actions runs list "${args[@]}"
         ;;
@@ -731,9 +748,41 @@ case "$cmd:$sub" in
           --json "databaseId,status,conclusion,workflowName,headBranch,event,createdAt,jobs,url"
         ;;
       gitea)
-        cli_json \
-          '{id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}' \
-          env NO_COLOR=1 tea actions runs view "$run_id" --output json
+        view_json=$(NO_COLOR=1 tea actions runs view "$run_id" --output json 2>/dev/null) \
+          || die "tea actions runs view failed for run $run_id"
+
+        # Fetch per-job data via the actions API so callers (run watch) can
+        # detect job-level failures masked by run-level status=success on
+        # Gitea (see _run_failed_jobs). tea api substitutes {owner}/{repo}.
+        jobs_array='[]'
+        jobs_json=$(NO_COLOR=1 tea api "repos/{owner}/{repo}/actions/runs/$run_id/jobs" 2>/dev/null || true)
+        if [[ -n "$jobs_json" ]]; then
+          jobs_array=$(echo "$jobs_json" | jq -c '
+            def to_status:
+              if (.conclusion // "") != "" then (.conclusion | ascii_downcase)
+              elif .status == "completed" then "success"
+              else (.status // "unknown" | ascii_downcase)
+              end;
+            [(.jobs // .) | (if type == "array" then .[]? else empty end) |
+              {id: ((.id // 0) | tostring), name: (.name // ""), status: to_status}]
+          ' 2>/dev/null) || jobs_array='[]'
+        fi
+
+        # Older Gitea versions may not expose the jobs API; fall back to
+        # scanning the run logs for "Job '<name>' failed" lines.
+        if [[ "$jobs_array" == '[]' ]]; then
+          failed_log=$(NO_COLOR=1 tea actions runs logs "$run_id" 2>/dev/null \
+            | grep -oE "Job '[^']+' failed" \
+            | sed -E "s/Job '(.+)' failed/\1/" \
+            | sort -u || true)
+          if [[ -n "$failed_log" ]]; then
+            jobs_array=$(printf '%s\n' "$failed_log" \
+              | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({id: "", name: ., status: "failure"})')
+          fi
+        fi
+
+        echo "$view_json" | jq --argjson jobs "$jobs_array" \
+          '{id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // ""), jobs: $jobs}'
         ;;
     esac
     ;;
@@ -872,6 +921,19 @@ case "$cmd:$sub" in
         _pre_id=$(echo "$_pre_latest" | jq -r '.id')
         case "$_pre_status" in
           success|completed)
+            # Run-level status can read "success" on Gitea even when a
+            # job inside the run failed (issue #87). Aggregate per-job
+            # status before declaring pass.
+            failed_jobs=$(_run_failed_jobs "$_pre_id")
+            if [[ -n "$failed_jobs" ]]; then
+              echo "status: fail"
+              [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
+              echo "duration: 0s"
+              echo "failed_jobs: $failed_jobs"
+              echo "--- Failed job logs (last 80 lines) ---" >&2
+              "$0" run logs "$_pre_id" --failed-only 2>/dev/null | tail -80 >&2 || true
+              exit 0
+            fi
             echo "status: pass"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
@@ -879,9 +941,7 @@ case "$cmd:$sub" in
             exit 0
             ;;
           failure|timed_out)
-            failed_jobs=""
-            show_json=$("$0" run show "$_pre_id" 2>/dev/null) && \
-              failed_jobs=$(echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")') || true
+            failed_jobs=$(_run_failed_jobs "$_pre_id")
             echo "status: fail"
             [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
             echo "duration: 0s"
@@ -890,6 +950,17 @@ case "$cmd:$sub" in
               echo "--- Failed job logs (last 80 lines) ---" >&2
               "$0" run logs "$_pre_id" --failed-only 2>/dev/null | tail -80 >&2 || true
             fi
+            exit 0
+            ;;
+          cancelled|canceled|skipped)
+            # Distinct terminal states — surface them as fail with a
+            # reason so consumers (ship/session-end) gating on
+            # status: pass stop instead of advancing.
+            echo "status: fail"
+            [[ -n "$_pre_url" && "$_pre_url" != "null" ]] && echo "url: $_pre_url"
+            echo "duration: 0s"
+            echo "reason: $_pre_status"
+            echo "CI run $_pre_status for branch '$branch'" >&2
             exit 0
             ;;
         esac
@@ -1048,10 +1119,7 @@ case "$cmd:$sub" in
           # Non-terminal — keep polling
           ;;
         failure|timed_out)
-          # Best-effort single run show for failed job names (not in a loop)
-          failed_jobs=""
-          show_json=$("$0" run show "$run_id" 2>/dev/null) && \
-            failed_jobs=$(echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")') || true
+          failed_jobs=$(_run_failed_jobs "$run_id")
           echo "status: fail"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"
@@ -1062,11 +1130,32 @@ case "$cmd:$sub" in
           fi
           exit 0
           ;;
+        cancelled|canceled|skipped)
+          # Distinct terminal states — surface them as fail with a reason
+          # so consumers gating on status: pass stop instead of advancing.
+          echo "status: fail"
+          [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
+          echo "duration: ${elapsed}s"
+          echo "reason: $run_status"
+          echo "CI run $run_status on branch '$branch'" >&2
+          exit 0
+          ;;
         *)
-          # Terminal — covers success, completed, cancelled, skipped, neutral,
-          # and any future/unexpected status.  Exiting here is intentional:
-          # a false-positive "pass" is recoverable, a false-negative "keep
-          # polling" wastes 5 minutes and blocks the caller.
+          # Terminal — covers success and any future/unexpected status.
+          # Even when the run-level status reports success, an individual
+          # job may have failed (Gitea reports run.status=success on a
+          # multi-job run if any job succeeded; see #87). Aggregate
+          # per-job status before declaring pass.
+          failed_jobs=$(_run_failed_jobs "$run_id")
+          if [[ -n "$failed_jobs" ]]; then
+            echo "status: fail"
+            [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
+            echo "duration: ${elapsed}s"
+            echo "failed_jobs: $failed_jobs"
+            echo "--- Failed job logs (last 80 lines) ---" >&2
+            "$0" run logs "$run_id" --failed-only 2>/dev/null | tail -80 >&2 || true
+            exit 0
+          fi
           echo "status: pass"
           [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
           echo "duration: ${elapsed}s"


### PR DESCRIPTION
## Summary

`git-cli run watch` trusted Gitea's run-level `status` field, which can read
`success` even when a job in the run failed. The `ship` and `session/end`
skills gate on `status: pass`, so a red Gitea build silently advanced the
workflow onto the merge step. Two adjacent Gitea bugs in the same code path
also surfaced and are fixed here.

## Changes

- Add a `_run_failed_jobs` helper that pulls per-job status from `run show`.
  The pre-check and main poll loop in `run watch` consult it before exiting
  `pass`, so a run-level success with any failed job correctly yields
  `status: fail`.
- Enrich Gitea `run show` with a `jobs[]` field via
  `tea api repos/{owner}/{repo}/actions/runs/<id>/jobs`. Falls back to
  scanning `tea actions runs logs` for `Job '<name>' failed` lines on
  older Gitea instances that lack the jobs API.
- Forward `--branch` from `git-cli run list` to `tea actions runs list`
  (was parsed and silently dropped, so the watcher could pick up a run
  from the wrong branch).
- Distinguish `cancelled`/`skipped` runs from `success`: emit
  `status: fail` with a `reason:` line so consumers gating on
  `status: pass` stop instead of advancing.
- Bump versions: git-tools 2.0.3 → 2.0.4, session 3.8.1 → 3.8.2 (both
  Claude and Copilot manifests). Re-sync vendored `git-cli` via
  `utils/sync.sh`.
- Document the new contract in `git-tools/skills/git-cli/SKILL.md`.

## Test plan

- [x] `bash test.sh` — 1535 tests pass, including 10 new Gitea cases in
  `tests/session/test-ci-poll.sh` covering the #87 repro, log-grep
  fallback, `--branch` forwarding, pre-check, and cancelled handling.
- [x] `bash .github/scripts/validate-plugins.sh` — 252 checks, no failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 120 checks, no failures
- [x] `rumdl check .` — clean
- [x] `bash utils/sync.sh --check` — no drift
- [ ] Verify against a live Gitea repo once available — the jobs API
  endpoint shape is best-effort; the log-grep fallback covers older
  Gitea instances.

Fixes #87