### PR TITLE
chore: mark first-party plugin-dev skills as user-invocable-only

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,5 +59,16 @@
     "plugin-dev@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "session-history-analyzer@agent-toolkit": true
+  },
+  "skillOverrides": {
+    "plugin-dev:plugin-structure": "user-invocable-only",
+    "plugin-dev:plugin-settings": "user-invocable-only",
+    "plugin-dev:command-development": "user-invocable-only",
+    "plugin-dev:skill-development": "user-invocable-only",
+    "plugin-dev:agent-development": "user-invocable-only",
+    "plugin-dev:hook-development": "user-invocable-only",
+    "plugin-dev:mcp-integration": "user-invocable-only",
+    "skill-creator:skill-creator": "user-invocable-only",
+    "claude-code-setup:claude-automation-recommender": "user-invocable-only"
   }
 }


### PR DESCRIPTION
## Summary

- Adds project-level `skillOverrides` to `.claude/settings.json` marking all 7 `plugin-dev:*` skills, `skill-creator:skill-creator`, and `claude-code-setup:claude-automation-recommender` as `user-invocable-only`.
- Reclaims ~3.6KB of skill-description budget that was being burned on verbose `"This skill should be used when…"` keyword lists — the descriptions of other plugins' skills were getting truncated.
- Skills remain reachable via `/` autocomplete; only auto-triggering and the description-byte cost are suppressed.

Rationale: anyone working in this repo is by definition doing plugin development, so these meta-tooling skills don't need to auto-fire on every "create a hook" / "add a command" -shaped prompt.

## Test plan

- [ ] After merge + `/reload-plugins`, confirm the listed skills no longer appear in the available-skills system reminder
- [ ] Confirm `/plugin-dev:hook-development` etc. still complete in slash autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)