### PR TITLE
fix: replace dead skillOverrides with budget bump; correct CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,15 +60,5 @@
     "skill-creator@claude-plugins-official": true,
     "session-history-analyzer@agent-toolkit": true
   },
-  "skillOverrides": {
-    "plugin-dev:plugin-structure": "user-invocable-only",
-    "plugin-dev:plugin-settings": "user-invocable-only",
-    "plugin-dev:command-development": "user-invocable-only",
-    "plugin-dev:skill-development": "user-invocable-only",
-    "plugin-dev:agent-development": "user-invocable-only",
-    "plugin-dev:hook-development": "user-invocable-only",
-    "plugin-dev:mcp-integration": "user-invocable-only",
-    "skill-creator:skill-creator": "user-invocable-only",
-    "claude-code-setup:claude-automation-recommender": "user-invocable-only"
-  }
+  "skillListingBudgetFraction": 0.02
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ On the **Claude side** (`plugins-claude/`), every user-facing slash entry is a s
 - *Model-helper background guide* (e.g., `serena-cheatsheet`, `git-cli`, `ast-grep`): set `user-invocable: false`. Model-only.
 - *Both* (auto-trigger AND user-invocable, e.g., `session/catchup`): leave both flags off.
 
-`disable-model-invocation: true` in skill frontmatter is exactly equivalent to setting `skillOverrides[<name>] = "user-invocable-only"` in `~/.claude/settings.json` — same lever, plumbed through different config sources.
+For non-plugin skills (personal `~/.claude/skills/` or project `.claude/skills/`), `disable-model-invocation: true` in frontmatter is equivalent to setting `skillOverrides[<name>] = "user-invocable-only"` in settings.json. **`skillOverrides` does not apply to plugin-sourced skills** — per [the docs](https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings), those are managed via `/plugin` and there is no per-skill override knob. The only way to mark a plugin skill user-invocable-only is to set the flag in its `SKILL.md` frontmatter at the source. To reduce skill-listing budget pressure from plugin skills, raise [`skillListingBudgetFraction`](https://code.claude.com/docs/en/settings) instead.
 
 ## Why Claude has no `commands/` directory
 


### PR DESCRIPTION
## Summary

PR #90 added `skillOverrides` entries keyed by plugin skill names (`plugin-dev:*`, `skill-creator:skill-creator`, `claude-code-setup:claude-automation-recommender`). After it merged, `/doctor` still reported the same skills having their descriptions dropped. The reason is that **`skillOverrides` does not apply to plugin-sourced skills** — per the canonical docs:

> "Plugin skills are not affected by `skillOverrides`. Manage those through `/plugin` instead."
> — https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings

There is no per-skill override knob for plugin skills. To reduce description-budget pressure, the docs and `/doctor` both point at `skillListingBudgetFraction` instead.

- Drop the inert `skillOverrides` block from `.claude/settings.json`.
- Add `"skillListingBudgetFraction": 0.02` (2% instead of the 1% default). Costs ~2k extra tokens per session, but keeps full skill descriptions visible.
- Correct the CLAUDE.md paragraph that asserted frontmatter `disable-model-invocation: true` is "exactly equivalent" to `skillOverrides[<name>] = "user-invocable-only"`. That holds only for non-plugin skills; for plugin skills the frontmatter flag is the only path.

## Test plan

- [ ] After merge + reload, run `/doctor` and confirm the "skill listing will be truncated" warning is gone.
- [ ] Confirm `/plugin-dev:hook-development` (and other plugin-dev skills) still auto-complete and still auto-trigger as before — we didn't change their visibility, just the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)