### PR TITLE
chore: bump skillListingBudgetFraction 0.01 → 0.02

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,5 +62,5 @@
   "skillOverrides": {
     "security-review": "name-only"
   },
-  "skillListingBudgetFraction": 0.01
+  "skillListingBudgetFraction": 0.02
 }


### PR DESCRIPTION
## Summary

After the recent skill-description cleanup, `/doctor` still showed three plugin-dev skills dropped at 1.1%/1%. Doubling the budget to 2% covers the full set with headroom.

## Test plan

- [ ] After merge + `/reload-plugins`: `/doctor` shows no truncation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)