### PR TITLE
chore: revert skillListingBudgetFraction back to 0.01

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,5 +62,5 @@
   "skillOverrides": {
     "security-review": "name-only"
   },
-  "skillListingBudgetFraction": 0.02
+  "skillListingBudgetFraction": 0.01
 }


### PR DESCRIPTION
## Summary

Local testing across budgets `0.01`, `0.02`, `0.04`, `0.10` confirmed that `/doctor`'s reported usage is broken — it always reports ~110% of the budget cap, with the same three skills (`plugin-dev:command-development`, `plugin-dev:mcp-integration`, `security-review`) dropped regardless of how much room is provided. Bumping the budget just inflates the misleading metric without including any additional descriptions.

A direct audit of all 26 loaded skill descriptions sums to ~7,899 bytes ≈ ~1,975 tokens ≈ **0.2% of the 1M context window**. The truncation warning is cosmetic; the real cost is invisible.

| Source | Bytes | % | Controllable? |
|---|---:|---:|---|
| plugin-dev (1st-party) | 3,291 | 42% | Disable plugin |
| Built into binary | 2,856 | 36% | No |
| This repo's plugins | 1,401 | 18% | Yes (already lean) |
| skill-creator (1st-party) | 351 | 4% | Disable plugin |

## Test plan

- [ ] After merge + `/reload-plugins`, `/doctor` still shows the same 3-skill truncation warning, but at the cheapest 1.1%/1% cost instead of inflated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)