### PR TITLE
docs: add missing plugin READMEs + scrub personal references

### DIFF
--- a/plugins-claude/agentic-ide/.claude-plugin/plugin.json
+++ b/plugins-claude/agentic-ide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-ide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/agentic-ide/README.md
+++ b/plugins-claude/agentic-ide/README.md
@@ -1,0 +1,61 @@
+# Agentic IDE
+
+IDE-grade code intelligence for agents — Serena (LSP symbol navigation and refactoring), ast-grep (AST structural search and rewrite), and Semgrep (security and dataflow analysis) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent.
+
+## Installation
+
+```bash
+claude plugin install St0nefish/agent-toolkit/agentic-ide
+```
+
+Then install the required tools:
+
+```bash
+/agentic-ide:setup
+```
+
+## Tools Bundled
+
+| Tool | What it does |
+|------|-------------|
+| **Serena** | LSP-backed symbol navigation, cross-file rename, and symbol-level read/write. Understands what a name *means*. |
+| **ast-grep** | Structural search and bulk rewrite by AST shape. Understands the *shape* of code. |
+| **Semgrep** | Security audits and taint-flow analysis. Understands *types and dataflow*. |
+
+The three tools are orthogonal. The `code-intel` skill (auto-triggered) routes between them by intent and documents tool-specific pitfalls.
+
+## Skills
+
+| Skill | Type | Description |
+|-------|------|-------------|
+| `code-intel` | Model-triggered | Routing guide — picks the right tool for symbol nav, rename, structural search, security audit, or dataflow; documents Serena pitfalls, ast-grep wildcards, and Semgrep rule patterns |
+| `/agentic-ide:setup` | User-invoked | Status check and install instructions for all three tools |
+
+## Agent
+
+`serena-explorer` is a context-isolated subagent (model: Haiku) for heavy Serena meta-analysis. Use it for queries where Serena's verbose JSON output would consume significant context in the parent — call graphs, blast-radius analysis for renames, cross-module dependency mapping, dead-code candidates. The agent absorbs the JSON in its own context and returns a concise synthesis. Read-only — it never modifies the codebase.
+
+The parent agent spawns it automatically via the `serena-explorer` subagent type.
+
+## Setup
+
+Run `/agentic-ide:setup` to check what's installed and get per-tool instructions. Both Serena and Semgrep are MCP servers installed via `uv`; ast-grep is a plain CLI.
+
+### Quick reference
+
+| Tool | Install | MCP registration |
+|------|---------|-----------------|
+| Serena | `uv tool install --from git+https://github.com/oraios/serena serena` | Required — see `/agentic-ide:setup` |
+| ast-grep | `cargo install ast-grep --locked` or `brew install ast-grep` | None (plain CLI) |
+| Semgrep | `uv tool install semgrep-mcp` | Required — see `/agentic-ide:setup` |
+
+`uv` itself installs via `curl -LsSf https://astral.sh/uv/install.sh | sh` or `brew install uv`.
+
+## Dependencies
+
+| Tool | Required | Purpose |
+|------|----------|---------|
+| `uv` | Yes | Install Serena and Semgrep MCP servers |
+| `serena` | Yes | LSP symbol intelligence (`mcp__serena__*` tools) |
+| `semgrep-mcp` | Yes | Security and dataflow scanning (`mcp__semgrep__*` tools) |
+| `ast-grep` | Yes | Structural search and rewrite CLI |

--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/skills/ship/SKILL.md
+++ b/plugins-claude/git-tools/skills/ship/SKILL.md
@@ -110,7 +110,7 @@ This polls until CI passes, fails, or merges. Output includes `status` (`pass|fa
 
 ### 6. Wait for merge
 
-If the repo has an auto-merge bot (this repo's `st0nefish-ci` enables auto-merge on PR open), wait for the merge to complete:
+If the repo has an auto-merge bot (some repos enable auto-merge on PR open), wait for the merge to complete:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr wait --branch "$(git rev-parse --abbrev-ref HEAD)" --timeout 300 --interval 15

--- a/plugins-claude/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-claude/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-claude/java-toolkit/README.md
+++ b/plugins-claude/java-toolkit/README.md
@@ -1,0 +1,77 @@
+# Java Toolkit
+
+Java/JVM tooling — Maven Central intelligence and class search/decompilation via an MCP server running in Docker, plus a `jar-explore` script for raw JAR content inspection.
+
+## Installation
+
+```bash
+claude plugin install St0nefish/agent-toolkit/java-toolkit
+```
+
+Then start the Docker stack before using the MCP servers:
+
+```bash
+/java-toolkit:setup start
+```
+
+## How It Works
+
+Two MCP servers run as persistent Docker containers and communicate with Claude Code over `docker exec -i`:
+
+| Server | Container | Purpose |
+|--------|-----------|---------|
+| `maven-tools` | `mcp-maven-tools` | Maven Central artifact search, dependency resolution, and version intelligence |
+| `maven-indexer` | `mcp-maven-indexer` | Class search by name, source decompilation via CFR, interface implementation lookup |
+
+`maven-indexer` mounts your local Gradle and Maven caches read-only so it can index and decompile JARs you've already downloaded without re-fetching them. A SQLite index persists between restarts in a named Docker volume.
+
+## Skills
+
+| Skill | Type | Description |
+|-------|------|-------------|
+| `jar-explore` | Model-triggered | List, search, and read files inside JARs (manifests, `.properties`, XML, resources) without extracting to disk — use instead of `jar tf` / `unzip` |
+| `/java-toolkit:setup` | User-invoked | Start or stop the Docker Compose stack (`start` / `stop`) |
+| `/java-toolkit:java-toolkit` | User-invoked | Alias for managing the Docker stack |
+
+## jar-explore
+
+The `jar-explore` script covers what the MCP server doesn't: listing raw JAR entries, regex search within a JAR, and reading arbitrary non-class files. Use the MCP server for class-level work (search, decompile, find implementations).
+
+```bash
+# List all entries
+${CLAUDE_PLUGIN_ROOT}/scripts/jar-explore list /path/to/file.jar
+
+# Search for entries matching a pattern (case-insensitive extended regex)
+${CLAUDE_PLUGIN_ROOT}/scripts/jar-explore search /path/to/file.jar "META-INF.*\.properties"
+
+# Read a file from a JAR without extracting to disk
+${CLAUDE_PLUGIN_ROOT}/scripts/jar-explore read /path/to/file.jar META-INF/MANIFEST.MF
+```
+
+## Docker Stack Management
+
+```bash
+/java-toolkit:setup start   # docker compose up -d (both containers)
+/java-toolkit:setup stop    # docker compose down -v (removes volumes)
+```
+
+The `docker-compose.yml` is bundled in the plugin. On first start it pulls `arvindand/maven-tools-mcp:2.0.2-noc7` and `node:22-slim`. Subsequent starts are instant.
+
+### Volume mounts
+
+`maven-indexer` mounts the following paths read-only at startup:
+
+| Host path | Purpose |
+|-----------|---------|
+| `~/.gradle/caches/modules-2/files-2.1` | Gradle artifact cache |
+| `~/.m2/repository` | Maven local repository |
+| `~/.sdkman/candidates/java/current` | SDKMAN-managed JDK for CFR decompilation |
+
+Override any of these with `GRADLE_CACHE`, `MAVEN_REPO`, or `SDKMAN_DIR` environment variables.
+
+## Dependencies
+
+| Tool | Required | Purpose |
+|------|----------|---------|
+| `docker` | Yes | Run the MCP server containers |
+| Docker Compose | Yes | Manage the multi-container stack (bundled with Docker Desktop; `docker compose` plugin for standalone) |

--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/crush-hook.sh
+++ b/plugins-claude/permission-manager/scripts/crush-hook.sh
@@ -22,15 +22,15 @@ mkdir -p "$(dirname "$LOG_FILE")"
   echo "Command: ${CRUSH_TOOL_INPUT_COMMAND:-N/A}"
   echo "CWD: $CRUSH_CWD"
   echo ""
-} >> "$LOG_FILE"
+} >>"$LOG_FILE"
 
 # For bash tools, run our classifier
 if [[ "$CRUSH_TOOL_NAME" == "Bash" ]]; then
   COMMAND="$CRUSH_TOOL_INPUT_COMMAND"
-  
+
   # Run the test wrapper (will be replaced with real cmd-gate later)
-  decision=$(/Users/stonefish/Workspace/agent-toolkit/plugins-claude/permission-manager/scripts/crush-wrapper.sh "$COMMAND" "Crush hook" "$CRUSH_CWD")
-  
+  decision=$("$(dirname "$0")/crush-wrapper.sh" "$COMMAND" "Crush hook" "$CRUSH_CWD")
+
   # Output decision in Crush format
   case "$decision" in
     allow)

--- a/plugins-claude/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-claude/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/stl-game-config/skills/stl-game-config/SKILL.md
+++ b/plugins-claude/stl-game-config/skills/stl-game-config/SKILL.md
@@ -63,7 +63,7 @@ Gather all required data before configuration:
 | Graphics API | PCGamingWiki "API" section | ProtonDB comments |
 | RT/DLSS/HDR | PCGamingWiki "Features" | In-game settings |
 | Linux issues | ProtonDB reports | - |
-| Existing config | `/gaming/games/` | Create new |
+| Existing config | personal game-notes KB (if any) | Create new |
 
 **Web research workflow:**
 
@@ -76,7 +76,7 @@ Gather all required data before configuration:
    - Exact graphics API (look for "API" row in specs table)
    - Ray tracing support and type
    - Known Linux/Proton issues
-4. **Knowledge base**: `Glob: /gaming/games/*{game-name}*.md`
+4. **Knowledge base** (optional): if you keep game notes, glob your KB for `*{game-name}*.md`
 
 **Anti-cheat note:** If ProtonDB mentions EAC/BattlEye issues, check [areweanticheatyet.com](https://areweanticheatyet.com/) - some games require developer opt-in for Linux support.
 
@@ -135,7 +135,7 @@ Write to `~/.config/steamtinkerlaunch/gamecfgs/id/{APPID}.conf`
    - `API: VK` = DX11/Vulkan mode (DXVK translating)
    - GPU name visible = NVAPI working
 
-4. **If issues**: See troubleshooting in `/gaming/tools/steamtinkerlaunch.md`
+4. **If issues**: consult the SteamTinkerLaunch wiki or your own troubleshooting notes
 
 ### Step 8: Provide Summary
 

--- a/plugins-claude/stl-game-config/templates/customvars.conf
+++ b/plugins-claude/stl-game-config/templates/customvars.conf
@@ -8,7 +8,7 @@
 
 # VKD3D shader cache (DX12 games - reduces compilation stutters)
 # VKD3D_SHADER_CACHE="1"
-# VKD3D_SHADER_CACHE_PATH="/home/stonefish/.cache/vkd3d-proton"
+# VKD3D_SHADER_CACHE_PATH="$HOME/.cache/vkd3d-proton"
 
 # Retro game settings
 # PULSE_LATENCY_MSEC="60"

--- a/plugins-claude/stl-game-config/templates/gpu.conf
+++ b/plugins-claude/stl-game-config/templates/gpu.conf
@@ -7,13 +7,13 @@
 # DXVK_FILTER_DEVICE_NAME="NVIDIA"
 # VKD3D_FILTER_DEVICE_NAME="NVIDIA"
 # VKD3D_SHADER_CACHE="1"
-# VKD3D_SHADER_CACHE_PATH="/home/stonefish/.cache/vkd3d-proton"
+# VKD3D_SHADER_CACHE_PATH="$HOME/.cache/vkd3d-proton"
 
 # === AMD ===
 # DXVK_FILTER_DEVICE_NAME="AMD"
 # VKD3D_FILTER_DEVICE_NAME="AMD"
 # VKD3D_SHADER_CACHE="1"
-# VKD3D_SHADER_CACHE_PATH="/home/stonefish/.cache/vkd3d-proton"
+# VKD3D_SHADER_CACHE_PATH="$HOME/.cache/vkd3d-proton"
 
 # === Intel ===
 # DXVK_FILTER_DEVICE_NAME="Intel"

--- a/plugins-copilot/agentic-ide/.claude-plugin/plugin.json
+++ b/plugins-copilot/agentic-ide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-ide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/agentic-ide/README.md
+++ b/plugins-copilot/agentic-ide/README.md
@@ -1,0 +1,1 @@
+../../plugins-claude/agentic-ide/README.md

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-worktree/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-worktree/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-worktree",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Git worktree lifecycle management for parallel agentic work — create, list, remove worktrees with auto-whitelisting and proactive context-mismatch detection",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-worktree/README.md
+++ b/plugins-copilot/git-worktree/README.md
@@ -1,0 +1,66 @@
+# Git Worktree
+
+Git worktree lifecycle management for parallel agentic work — create, list, and remove worktrees with auto-whitelisting and proactive context-mismatch detection.
+
+> **Copilot CLI only.** Claude Code has built-in worktree management; this plugin is not listed in the Claude Code marketplace.
+
+## Installation
+
+Install from the Copilot CLI plugin marketplace:
+
+```text
+git-worktree plugin from St0nefish/agent-toolkit
+```
+
+## How It Works
+
+Worktrees are created under `.github/worktrees/<branch-slug>` inside the repo root (auto-added to `.gitignore` on first use). Keeping them in-repo means the harness's working-directory permission scope already covers them — operations against worktree paths don't trigger per-path approval prompts.
+
+A `preToolUse` hook (`worktree-whitelist.sh`) auto-allows:
+
+1. All `git worktree` management commands (`add`, `remove`, `prune`, `move`, `lock`, `unlock`)
+2. Bash commands that reference a registered worktree path
+3. Edit/Write file operations targeting a registered worktree path
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/worktree:create <branch>` | Create a new linked worktree on the given branch (creates the branch if it doesn't exist) |
+| `/worktree:list` | List all active worktrees — path, branch, and working-tree status |
+| `/worktree:remove <name>` | Remove a worktree by slug or path; optionally delete the branch |
+
+### create options
+
+```bash
+# Create from the current HEAD
+/worktree:create feature-auth
+
+# Create from a specific base branch
+/worktree:create feature-auth --from main
+```
+
+### remove options
+
+Pass `--delete-branch` to also delete the branch (safe delete — fails if unmerged). Pass `--force` to remove a worktree that has uncommitted changes.
+
+## Skill (Model-Triggered)
+
+The `parallel-work` skill fires automatically when the model detects that the user's new request is unrelated to the current branch's uncommitted changes, or when the user explicitly asks for parallel/isolated work. It surfaces a worktree suggestion before starting the new work so the user can keep both contexts clean.
+
+Trigger phrases include: "work on this in parallel", "without touching my current branch", "run tests in a clean checkout", "separate branch for this".
+
+## Typical Workflow
+
+```text
+/worktree:create feature-auth     # creates .github/worktrees/feature-auth/
+cd .github/worktrees/feature-auth
+  ... implement feature-auth ...
+/worktree:remove feature-auth     # prunes metadata; optionally deletes branch
+```
+
+## Dependencies
+
+| Tool | Required | Purpose |
+|------|----------|---------|
+| `git` | Yes | All worktree operations |

--- a/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-copilot/java-toolkit/README.md
+++ b/plugins-copilot/java-toolkit/README.md
@@ -1,0 +1,1 @@
+../../plugins-claude/java-toolkit/README.md

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/tests/cross-platform-paths/test-paths.sh
+++ b/tests/cross-platform-paths/test-paths.sh
@@ -78,7 +78,7 @@ assert_eq "project settings path" ".claude/settings.json" "$(claude_project_sett
 echo "── encode_project_path ──"
 assert_eq "standard path" "-Users-foo-project" "$(encode_project_path "/Users/foo/project")"
 assert_eq "dotfile path (double dash)" "-Users-foo--bar" "$(encode_project_path "/Users/foo/.bar")"
-assert_eq "deep dotfile path" "-Users-stonefish--local-share-chezmoi" "$(encode_project_path "/Users/stonefish/.local/share/chezmoi")"
+assert_eq "deep dotfile path" "-Users-foo--local-share-chezmoi" "$(encode_project_path "/Users/foo/.local/share/chezmoi")"
 assert_eq "trailing slash stripped" "-Users-foo-project" "$(encode_project_path "/Users/foo/project/")"
 assert_eq "empty input" "" "$(encode_project_path "")"
 assert_eq "root path (trailing slash stripped to empty)" "" "$(encode_project_path "/")"


### PR DESCRIPTION
Prep for sharing the repo more widely.

## READMEs

The three plugins that were missing a README now have one:

- `agentic-ide` and `java-toolkit` — new `README.md` on the Claude side, Copilot symlink alongside.
- `git-worktree` — new real `README.md` (Copilot-only plugin, no Claude source to symlink from).

## Working-tree scrub

Removed owner-specific paths/references from distributed plugin files so installed copies work for anyone:

- **permission-manager** — `crush-hook.sh` called its sibling script via a hardcoded absolute path; now uses `$(dirname "$0")` so it resolves at any install location.
- **stl-game-config** — `/home/stonefish` cache paths in templates → `$HOME`; hardcoded `/gaming` knowledge-base paths in the skill genericized.
- **git-tools** — genericized the `st0nefish-ci` auto-merge-bot reference in the ship skill.
- **tests/cross-platform-paths** — replaced a `stonefish` username in a fixture with the generic `foo` used by sibling cases.

## Versions

Patch bumps on both Claude and Copilot sides: permission-manager 2.14.2, stl-game-config 1.0.2, git-tools 2.0.5, agentic-ide 1.0.1, java-toolkit 2.0.1, git-worktree 1.1.1.

## Validation

`test.sh` (1535), `validate-plugins.sh` (201), `validate-frontmatter.sh` (102), `rumdl` (84 files), cross-platform-paths (28) — all pass locally.

> Note: this addresses the *working-tree* portion of the pre-sharing review. Employer-context leakage that lives in **git history** (a deleted `.claude/settings.local.json`, `logan.gagne@pega.com` author email, `AGILE-ID:` commit prefixes) is being handled separately via a history rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)