### PR TITLE
refactor(permission-manager): rename permissions skill to config

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.14.2",
+  "version": "2.15.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/README.md
+++ b/plugins-claude/permission-manager/README.md
@@ -65,7 +65,7 @@ Dependency setup is its own top-level command:
 |---------|-------------|
 | `/permission-manager:setup` | Install `shfmt` and `jq` (allowed through the hook via a bootstrap bypass) |
 
-All other management is through `/permission-manager:permissions [action]`:
+All other management is through `/permission-manager:config [action]`:
 
 | Action | Description |
 |--------|-------------|
@@ -80,7 +80,7 @@ All other management is through `/permission-manager:permissions [action]`:
 Add glob patterns to auto-allow commands you run frequently:
 
 ```bash
-/permission-manager:permissions commands add --scope project
+/permission-manager:config commands add --scope project
 # Then provide patterns like: docker exec myapp cat *
 ```
 
@@ -93,10 +93,10 @@ Both are merged. Patterns use bash glob matching against the full command string
 
 ### Learning From History
 
-The `/permission-manager:permissions learn` action analyzes your audit log to find commands that are frequently prompted and suggests glob patterns:
+The `/permission-manager:config learn` action analyzes your audit log to find commands that are frequently prompted and suggests glob patterns:
 
 ```bash
-/permission-manager:permissions learn
+/permission-manager:config learn
 # Scans ~/.claude/permission-audit.jsonl
 # Groups by command prefix, computes glob patterns
 # Offers to add them to your config
@@ -109,7 +109,7 @@ When Claude Code is in `acceptEdits` permission mode, the allow-edit classifier 
 Customize the command list:
 
 ```bash
-/permission-manager:permissions allow-edit
+/permission-manager:config allow-edit
 ```
 
 Config files: `~/.claude/allow-edit-permissions.json` (global), `.claude/allow-edit-permissions.json` (project).
@@ -125,7 +125,7 @@ Separately from Bash commands, the plugin gates web access with three modes:
 | `domains` | Per-domain allow-list with subdomain matching (e.g. `github.com` matches `api.github.com`) |
 
 ```bash
-/permission-manager:permissions web
+/permission-manager:config web
 ```
 
 Config files: `~/.claude/web-permissions.json` (global), `.claude/web-permissions.json` (project). Project mode overrides global; domain lists are merged.
@@ -135,7 +135,7 @@ Config files: `~/.claude/web-permissions.json` (global), `.claude/web-permission
 Trace exactly how any command would be classified:
 
 ```bash
-/permission-manager:permissions explain 'git push origin feature/42-export && docker exec app cat /etc/nginx.conf'
+/permission-manager:config explain 'git push origin feature/42-export && docker exec app cat /etc/nginx.conf'
 ```
 
 This runs the full pipeline with instrumented output showing each classifier's decision per segment.

--- a/plugins-claude/permission-manager/skills/config/SKILL.md
+++ b/plugins-claude/permission-manager/skills/config/SKILL.md
@@ -1,15 +1,15 @@
 ---
 disable-model-invocation: true
-name: permissions
-description: "Permission management — commands, allow-edit, setup, web, explain, learn"
+name: config
+description: "Configure permission-manager — commands, allow-edit, web, explain, learn"
 argument-hint: "[action]"
 allowed-tools: Bash, Read, AskUserQuestion
 ---
 
-# Permissions
+# Config
 
 $IF($1, Run the **$1** action below.)
-$IF(!$1, Available actions: `commands`, `allow-edit`, `web`, `explain`, `learn`. Usage: `/permission-manager:permissions [action]`. To install dependencies, use `/permission-manager:setup`.)
+$IF(!$1, Available actions: `commands`, `allow-edit`, `web`, `explain`, `learn`. Usage: `/permission-manager:config [action]`. To install dependencies, use `/permission-manager:setup`.)
 
 ## commands
 

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.14.2",
+  "version": "2.15.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/permission-manager/commands/config.md
+++ b/plugins-copilot/permission-manager/commands/config.md
@@ -1,14 +1,14 @@
 ---
-description: "Permission management — commands, allow-edit, setup, web, explain, learn"
+description: "Configure permission-manager — commands, allow-edit, web, explain, learn"
 argument-hint: "[action]"
 allowed-tools: Bash, Read, AskUserQuestion
 disable-model-invocation: true
 ---
 
-# Permissions
+# Config
 
 $IF($1, Run the **$1** action below.)
-$IF(!$1, Available actions: `commands`, `allow-edit`, `web`, `explain`, `learn`. Usage: `/permission-manager:permissions [action]`. To install dependencies, use `/permission-manager:setup`.)
+$IF(!$1, Available actions: `commands`, `allow-edit`, `web`, `explain`, `learn`. Usage: `/permission-manager:config [action]`. To install dependencies, use `/permission-manager:setup`.)
 
 ---
 


### PR DESCRIPTION
## Summary

- Rename the `permissions` skill/command to `config` in `permission-manager` (Claude + Copilot variants) to avoid collision with Claude Code's built-in `/permissions` slash command, which broke autocomplete discoverability.
- Update frontmatter (`name`, `description`), body heading, and the usage line. Refresh six README invocation examples.
- Bump plugin version `2.14.2 → 2.15.0` on both variants (minor — visible slash command rename).

New invocation: `/permission-manager:config [action]` (actions unchanged: `commands`, `allow-edit`, `web`, `explain`, `learn`).

## Test plan

- [x] `bash .github/scripts/validate-plugins.sh` — 201 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 102 checks, 0 failures
- [x] `bash utils/sync.sh --check` — no drift
- [x] `grep -rn "permission-manager:permissions"` — no stale references remain
- [ ] After install: `/permission-manager:config` autocompletes; `/permission-manager:config web` still drives the web-permissions interactive flow