### PR TITLE
chore: align Copilot plugins for compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
         "name": "Logan Gagne"
       },
       "category": "formatting",
-      "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, rustfmt, ruff)",
+      "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
       "name": "format-on-save",
       "source": "./plugins-claude/format-on-save"
     },
@@ -19,7 +19,7 @@
         "name": "Logan Gagne"
       },
       "category": "productivity",
-      "description": "Desktop notification when Claude finishes a long-running task (configurable threshold)",
+      "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
       "name": "notify-on-stop",
       "source": "./plugins-claude/notify-on-stop"
     },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -10,7 +10,7 @@
         "name": "Logan Gagne"
       },
       "category": "formatting",
-      "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, rustfmt, ruff)",
+      "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
       "name": "format-on-save",
       "source": "./plugins-copilot/format-on-save"
     },
@@ -19,7 +19,7 @@
         "name": "Logan Gagne"
       },
       "category": "productivity",
-      "description": "Desktop notification when Claude finishes a long-running task (configurable threshold)",
+      "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
       "name": "notify-on-stop",
       "source": "./plugins-copilot/notify-on-stop"
     },
@@ -100,7 +100,7 @@
         "name": "Logan Gagne"
       },
       "category": "productivity",
-      "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
+      "description": "Analyze Copilot CLI session history for workflow patterns, friction hotspots, and automation candidates",
       "name": "session-history-analyzer",
       "source": "./plugins-copilot/session-history-analyzer"
     },

--- a/.github/scripts/validate-plugins.sh
+++ b/.github/scripts/validate-plugins.sh
@@ -4,13 +4,17 @@
 # Checks:
 #   1. JSON validity           — all .json files parse cleanly
 #   2. plugin.json fields      — required fields present in every plugin.json
-#   3. Claude hooks.json       — PascalCase events, "command" key, no top-level "version"
-#   4. Copilot hooks.json      — camelCase events, "bash" key, top-level "version": 1
-#   5. Plugin root variables   — correct ${..._PLUGIN_ROOT} per CLI variant
-#   6. Hook script existence   — referenced scripts resolve to real files
-#   7. Symlink integrity       — all symlinks in plugins-copilot/ resolve
-#   8. Version sync            — copilot plugin.json version matches claude counterpart
-#   9. Vendored utils drift    — plugins-claude/*/scripts/ copies match utils/
+#   3. Marketplace coverage    — every plugin dir is listed in the matching marketplace with the expected source path
+#   4. Claude hooks.json       — PascalCase events, "command" key, no top-level "version"
+#   5. Copilot hooks.json      — camelCase events, "bash" key, top-level "version": 1
+#   6. Plugin root variables   — correct ${..._PLUGIN_ROOT} per CLI variant
+#   7. Hook script existence   — referenced scripts resolve to real files
+#   8. Copilot docs paths      — Copilot commands/skills do not reference ${COPILOT_PLUGIN_ROOT}
+#   9. Script auto-approval    — Copilot plugins with scripts register approve-own-scripts.sh
+#  10. Compose assets          — docker-compose-backed setup scripts have docker-compose.yml beside them
+#  11. Symlink integrity       — all symlinks in plugins-copilot/ resolve
+#  12. Version sync            — copilot plugin.json version matches claude counterpart
+#  13. Vendored utils drift    — plugins-claude/*/scripts/ copies match utils/
 #
 # Exit codes: 0 = all passed, 1 = one or more failures.
 
@@ -66,7 +70,36 @@ while IFS= read -r f; do
 done < <(find . -name 'plugin.json' -path '*/.claude-plugin/*' -not -path './.git/*' | sort)
 
 # ---------------------------------------------------------------------------
-# 3 & 4. hooks.json structure
+# 3. Marketplace coverage
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Marketplace coverage ==="
+
+validate_marketplace_entries() {
+  local marketplace="$1" plugin_root_prefix="$2" plugin_dirs_root="$3"
+  while IFS= read -r plugin_root; do
+    local plugin_json plugin_name expected_source actual_source
+    plugin_json="$plugin_root/.claude-plugin/plugin.json"
+    [[ -f "$plugin_json" ]] || continue
+    plugin_name=$(jq -r '.name' "$plugin_json")
+    expected_source="$plugin_root_prefix/$plugin_name"
+    actual_source=$(jq -r --arg n "$plugin_name" '.plugins[] | select(.name == $n) | .source' "$marketplace" 2>/dev/null)
+
+    if [[ -z "$actual_source" ]]; then
+      fail "$marketplace — missing plugin entry for $plugin_name"
+    elif [[ "$actual_source" != "$expected_source" ]]; then
+      fail "$marketplace — $plugin_name source is $actual_source (expected $expected_source)"
+    else
+      pass "$marketplace — $plugin_name"
+    fi
+  done < <(find "$plugin_dirs_root" -mindepth 1 -maxdepth 1 -type d | sort)
+}
+
+validate_marketplace_entries "./.claude-plugin/marketplace.json" "./plugins-claude" "./plugins-claude"
+validate_marketplace_entries "./.github/plugin/marketplace.json" "./plugins-copilot" "./plugins-copilot"
+
+# ---------------------------------------------------------------------------
+# 4 & 5. hooks.json structure
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== hooks.json structure ==="
@@ -82,6 +115,28 @@ validate_claude_hooks() {
   bad_events=$(jq -r '.hooks | keys[] | select(test("^[a-z]"))' "$f" 2>/dev/null)
   if [[ -n "$bad_events" ]]; then
     fail "$f — non-PascalCase events: $bad_events"
+    return
+  fi
+  # Hook entries must use the wrapped Claude shape:
+  # .hooks.Event[] => { hooks: [{ type: "command", command: "..." }], matcher?: "..." }
+  bad_shape=$(jq -r '
+    [
+      .hooks[] | .[] |
+      select(((.hooks | type) != "array"))
+    ] | length
+  ' "$f" 2>/dev/null)
+  if [[ "${bad_shape:-0}" -gt 0 ]]; then
+    fail "$f — Claude hooks must use wrapped entries with hooks[] arrays"
+    return
+  fi
+  bad_inner=$(jq -r '
+    [
+      .hooks[] | .[] | .hooks[] |
+      select((.type // "") != "command" or ((.command // "") | length == 0))
+    ] | length
+  ' "$f" 2>/dev/null)
+  if [[ "${bad_inner:-0}" -gt 0 ]]; then
+    fail "$f — Claude hooks must contain command hook entries with type=command"
     return
   fi
   # Hook entries must use "command" key (not "bash")
@@ -102,27 +157,19 @@ validate_copilot_hooks() {
     return
   fi
 
-  # Copilot accepts two shapes for .hooks:
-  #   object: {"preToolUse": [{"bash": "..."}]}
-  #   array:  [{"event": "preToolUse", "bash": "..."}]
+  # Copilot hooks must use the flat array shape:
+  #   [{"event": "preToolUse", "bash": "..."}]
   local shape
   shape=$(jq -r '.hooks | type' "$f" 2>/dev/null)
+  if [[ "$shape" != "array" ]]; then
+    fail "$f — Copilot hooks.json must use flat array .hooks entries"
+    return
+  fi
 
-  local bad_events has_command
-  case "$shape" in
-    object)
-      bad_events=$(jq -r '.hooks | keys[] | select(test("^[A-Z]"))' "$f" 2>/dev/null)
-      has_command=$(jq -r '[.hooks[][] | objects | select(has("command"))] | length' "$f" 2>/dev/null)
-      ;;
-    array)
-      bad_events=$(jq -r '.hooks[].event | select(test("^[A-Z]"))' "$f" 2>/dev/null)
-      has_command=$(jq -r '[.hooks[] | objects | select(has("command"))] | length' "$f" 2>/dev/null)
-      ;;
-    *)
-      fail "$f — .hooks must be object or array (got: $shape)"
-      return
-      ;;
-  esac
+  local bad_events has_command missing_bash
+  bad_events=$(jq -r '.hooks[].event | select(test("^[A-Z]"))' "$f" 2>/dev/null)
+  has_command=$(jq -r '[.hooks[] | objects | select(has("command"))] | length' "$f" 2>/dev/null)
+  missing_bash=$(jq -r '[.hooks[] | objects | select(((.bash // "") | length) == 0)] | length' "$f" 2>/dev/null)
 
   if [[ -n "$bad_events" ]]; then
     fail "$f — non-camelCase events: $bad_events"
@@ -130,6 +177,10 @@ validate_copilot_hooks() {
   fi
   if [[ "${has_command:-0}" -gt 0 ]]; then
     fail "$f — Copilot hooks must use \"bash\" key, not \"command\""
+    return
+  fi
+  if [[ "${missing_bash:-0}" -gt 0 ]]; then
+    fail "$f — Copilot hooks must provide a non-empty \"bash\" command"
     return
   fi
   pass "$f"
@@ -144,7 +195,7 @@ while IFS= read -r f; do
 done < <(find . -name 'hooks.json' -path '*/hooks/*' -not -path './.git/*' | sort)
 
 # ---------------------------------------------------------------------------
-# 5. Plugin root variables
+# 6. Plugin root variables
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Plugin root variable correctness ==="
@@ -165,7 +216,7 @@ while IFS= read -r f; do
 done < <(find . -name 'hooks.json' -path '*/hooks/*' -not -path './.git/*' | sort)
 
 # ---------------------------------------------------------------------------
-# 6. Hook script existence
+# 7. Hook script existence
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Hook script existence ==="
@@ -196,7 +247,64 @@ while IFS= read -r f; do
 done < <(find . -name 'hooks.json' -path '*/hooks/*' -not -path './.git/*' | sort)
 
 # ---------------------------------------------------------------------------
-# 7. Symlink integrity
+# 8. Copilot docs avoid plugin-root paths
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Copilot docs avoid plugin-root paths ==="
+while IFS= read -r f; do
+  if grep -Fq '${COPILOT_PLUGIN_ROOT}' "$f"; then
+    fail "$f — Copilot command/skill docs must not reference \${COPILOT_PLUGIN_ROOT}"
+  else
+    pass "$f"
+  fi
+done < <(find ./plugins-copilot \( -path '*/commands/*.md' -o -path '*/skills/*/SKILL.md' \) -type f | sort)
+
+# ---------------------------------------------------------------------------
+# 9. Copilot script auto-approval
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Copilot script auto-approval ==="
+while IFS= read -r plugin_root; do
+  scripts_dir="$plugin_root/scripts"
+  hooks_file="$plugin_root/hooks/hooks.json"
+
+  [[ -d "$scripts_dir" ]] || continue
+
+  shopt -s nullglob dotglob
+  script_entries=("$scripts_dir"/*)
+  shopt -u nullglob dotglob
+  [[ ${#script_entries[@]} -gt 0 ]] || continue
+
+  if [[ ! -f "$hooks_file" ]]; then
+    fail "$plugin_root — scripts/ exists but hooks/hooks.json is missing"
+    continue
+  fi
+
+  if grep -Fq 'approve-own-scripts.sh' "$hooks_file"; then
+    pass "$plugin_root"
+  else
+    fail "$plugin_root — scripts/ exists but hooks.json does not register approve-own-scripts.sh"
+  fi
+done < <(find ./plugins-copilot -mindepth 1 -maxdepth 1 -type d | sort)
+
+# ---------------------------------------------------------------------------
+# 10. Compose assets
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Compose assets ==="
+while IFS= read -r setup_script; do
+  plugin_root=$(dirname "$(dirname "$setup_script")")
+  if grep -Fq 'docker compose' "$setup_script"; then
+    if [[ -f "$plugin_root/docker-compose.yml" ]]; then
+      pass "$plugin_root"
+    else
+      fail "$plugin_root — setup script uses docker compose but docker-compose.yml is missing"
+    fi
+  fi
+done < <(find ./plugins-claude ./plugins-copilot -path '*/scripts/setup.sh' -type f | sort)
+
+# ---------------------------------------------------------------------------
+# 11. Symlink integrity
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Symlink integrity ==="
@@ -209,7 +317,7 @@ while IFS= read -r link; do
 done < <(find ./plugins-copilot -type l 2>/dev/null | sort)
 
 # ---------------------------------------------------------------------------
-# 8. Version sync (claude vs copilot)
+# 12. Version sync (claude vs copilot)
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Version sync (claude ↔ copilot) ==="
@@ -227,7 +335,7 @@ for claude_pj in ./plugins-claude/*/.claude-plugin/plugin.json; do
 done
 
 # ---------------------------------------------------------------------------
-# 9. Vendored utils drift
+# 13. Vendored utils drift
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Vendored utils drift ==="

--- a/plugins-claude/convert-doc/.claude-plugin/plugin.json
+++ b/plugins-claude/convert-doc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-doc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Convert documents to/from markdown using pandoc (DOCX, HTML, RST, EPUB, ODT, RTF, LaTeX)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-claude/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/format-on-save/.claude-plugin/plugin.json
+++ b/plugins-claude/format-on-save/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "format-on-save",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/image/.claude-plugin/plugin.json
+++ b/plugins-claude/image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Clipboard paste and screenshot capture for macOS, WSL, and Linux",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-claude/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-claude/java-toolkit/hooks/hooks.json
+++ b/plugins-claude/java-toolkit/hooks/hooks.json
@@ -1,10 +1,15 @@
 {
+  "description": "Auto-approve this plugin's own scripts",
   "hooks": {
     "PreToolUse": [
       {
-        "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-        "description": "Allow running scripts in this plugin",
-        "when": "tool_name == 'Bash' && starts_with(tool_input, 'bash ${CLAUDE_PLUGIN_ROOT}/scripts/')"
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+          }
+        ]
       }
     ]
   }

--- a/plugins-claude/kb-capture/.claude-plugin/plugin.json
+++ b/plugins-claude/kb-capture/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-capture",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Research-to-document automation — capture conversation findings as schema-valid markdown with frontmatter, linting, and optional commit",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/markdown/.claude-plugin/plugin.json
+++ b/plugins-claude/markdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Markdown linting and formatting — check, format, setup",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/notify-on-stop/.claude-plugin/plugin.json
+++ b/plugins-claude/notify-on-stop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-on-stop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session-history-analyzer/.claude-plugin/plugin.json
+++ b/plugins-claude/session-history-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-history-analyzer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Work session management — start, end, checkpoint, handoff, resume, issue, reset, orchestrate, plus a model-triggered summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-claude/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/convert-doc/.claude-plugin/plugin.json
+++ b/plugins-copilot/convert-doc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-doc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Convert documents to/from markdown using pandoc (DOCX, HTML, RST, EPUB, ODT, RTF, LaTeX)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/convert-doc/hooks/hooks.json
+++ b/plugins-copilot/convert-doc/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/elevated-edit/hooks/hooks.json
+++ b/plugins-copilot/elevated-edit/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/format-on-save/.claude-plugin/plugin.json
+++ b/plugins-copilot/format-on-save/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "format-on-save",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/format-on-save/hooks/hooks.json
+++ b/plugins-copilot/format-on-save/hooks/hooks.json
@@ -1,17 +1,15 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ],
-    "postToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/format-on-save.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    },
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/format-on-save.sh",
+      "event": "postToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-tools/commands/ship.md
+++ b/plugins-copilot/git-tools/commands/ship.md
@@ -5,17 +5,17 @@ allowed-tools: Bash, Read, AskUserQuestion
 
 Take whatever in-progress work exists in this repo and drive it through the canonical merge lifecycle. Skip any step that is already complete instead of redoing it.
 
-This command invokes the `ship` skill — see `${COPILOT_PLUGIN_ROOT}/skills/ship/SKILL.md` for the full procedure. The summary:
+This command invokes the `ship` skill — see the sibling `ship` skill for the full procedure. The summary:
 
 1. **Stage and commit** any uncommitted changes (specific files only — never `git add -A`/`.`).
 2. **Ensure a feature branch** with a conventional prefix (`feat/`, `fix/`, `chore/`, `docs/`, …); create one if currently on the default branch.
 3. **Push** to origin (`-u` on first push).
-4. **Create the PR** via `git-cli pr create` if one is not already open for the branch.
-5. **Watch CI** via `git-cli run watch` until it passes, fails, or merges. On failure, stop and surface the failure; do not push fixes silently.
-6. **Wait for merge** via `git-cli pr wait` if the repo has an auto-merge bot. Never invoke `git-cli pr merge` to merge manually unless the user explicitly asks.
-7. **Return to the default branch** (`git-cli repo default-branch`) and `git pull`.
+4. **Create the PR** via `gh pr create` (or the host-native equivalent on Gitea) if one is not already open for the branch.
+5. **Watch CI** until it passes, fails, or merges. On failure, stop and surface the failure; do not push fixes silently.
+6. **Wait for merge** if the repo has an auto-merge bot. Never invoke `gh pr merge` to merge manually unless the user explicitly asks.
+7. **Return to the default branch** and `git pull`.
 
-Use the `git-cli` wrapper at `${COPILOT_PLUGIN_ROOT}/scripts/git-cli` for every GitHub/Gitea call. Never invoke raw `gh` or `tea` directly.
+On GitHub repos, prefer `gh` for every PR, run, and repo call. On Gitea or other hosts, use the equivalent host-native tooling or API.
 
 When done, report a one-line summary: PR number + URL, CI status, final state, and confirmation that the workspace is back on the default branch.
 

--- a/plugins-copilot/git-tools/hooks/hooks.json
+++ b/plugins-copilot/git-tools/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-copilot/git-tools/skills/git-cli/SKILL.md
@@ -10,9 +10,9 @@ allowed-tools: Bash
 
 # git-cli
 
-Use `${COPILOT_PLUGIN_ROOT}/scripts/git-cli` to interact with the issue tracker and CI
-system for the current repository. Platform (GitHub or Gitea) is auto-detected from the
-git remote — no configuration needed.
+Use native host tooling to interact with the issue tracker and CI system for the
+current repository. On GitHub repos, prefer `gh`. On Gitea or other hosts, use
+the equivalent host-native CLI or API tooling if it is available.
 
 ## When to use this skill
 
@@ -27,40 +27,40 @@ git remote — no configuration needed.
 ### Issues
 
 ```bash
-# List open issues (returns normalized JSON array)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue list [--limit N] [--state open|closed|all] [--label LABEL] [--assignee USER]
+# List open issues
+gh issue list --limit N --state open --json number,title,state,labels,assignees,url
 
 # Show a single issue with full body and comments
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue show <number>
+gh issue view <number> --json number,title,body,state,author,labels,assignees,comments,url
 
-# Create an issue (pipe body to --body via heredoc)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body [--label bug] <<'EOF'
+# Create an issue (pipe body via heredoc)
+gh issue create --title "Title" --label bug --body-file - <<'EOF'
 ## Problem
 ...
 EOF
 
-# Add a comment (heredoc for multi-line, printf for short)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body <<'EOF'
+# Add a comment
+gh issue comment <number> --body-file - <<'EOF'
 Progress update...
 EOF
-printf 'LGTM' | ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body
+gh issue comment <number> --body 'LGTM'
 
 # Close or reopen
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue close <number>
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue reopen <number>
+gh issue close <number>
+gh issue reopen <number>
 ```
 
 ### Pull Requests
 
 ```bash
 # List PRs
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr list [--state open|closed|merged|all] [--limit N]
+gh pr list --state open --limit N --json number,title,state,headRefName,baseRefName,url
 
 # Show a single PR with details
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr show <number>
+gh pr view <number> --json number,title,body,state,headRefName,baseRefName,author,reviewRequests,comments,url
 
-# Create a PR (auto-assigns to current user)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch --base main --body <<'EOF'
+# Create a PR
+gh pr create --title "Title" --head branch --base main --body-file - <<'EOF'
 ## Summary
 ...
 
@@ -69,40 +69,39 @@ ${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch -
 EOF
 
 # Comment on a PR
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body <<'EOF'
+gh pr comment <number> --body-file - <<'EOF'
 Review follow-up...
 EOF
 
 # Merge or close
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr merge <number> [--squash | --rebase]
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr close <number>
+gh pr merge <number> [--squash | --rebase]
+gh pr close <number>
 ```
 
 ### CI Runs
 
 ```bash
-# List recent runs (JSON with id, status, workflow, branch, event, started_at)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli run list [--limit N] [--status failure|success|pending] [--branch BRANCH]
+# List recent runs
+gh run list --limit N --json databaseId,status,workflowName,headBranch,event,startedAt,url
 
 # Show details of a specific run
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli run show <run-id>
+gh run view <run-id> --json databaseId,status,conclusion,workflowName,headBranch,url,jobs
 
-# Fetch logs (--failed-only shows only failing steps on GitHub)
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli run logs <run-id>
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli run logs <run-id> --failed-only
+# Fetch logs
+gh run view <run-id> --log
+gh run view <run-id> --log-failed
 ```
 
 ### Repo / User
 
 ```bash
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo default-branch   # e.g. "main" or "master"
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo info             # name, description, stars, etc.
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli user whoami           # {"login": "username"}
+gh repo view --json defaultBranchRef,name,description,url
+gh api user --jq '{login: .login}'
 ```
 
 ## Output format
 
-All commands return JSON. Issue and PR objects use a normalized schema:
+Prefer JSON-shaped output when scripting:
 
 ```json
 {
@@ -120,12 +119,16 @@ All commands return JSON. Issue and PR objects use a normalized schema:
 }
 ```
 
+Use `--json ...` plus `jq` to normalize the fields you need for the current task.
+If the remote is not GitHub, use the equivalent host-native tooling and shape the
+output into a similarly small JSON object before reasoning over it.
+
 ## Writing issue/PR bodies
 
-Pipe the body to `--body` via a heredoc. No temp file, no cleanup:
+Pipe the body via a heredoc. No temp file, no cleanup:
 
 ```bash
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body <<'EOF'
+gh issue create --title "Bug: ..." --label bug --body-file - <<'EOF'
 ## Problem
 ...
 
@@ -134,7 +137,5 @@ ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label b
 EOF
 ```
 
-`--body-file FILE` remains available when the body is already on disk, and
-`--body-file -` is equivalent to `--body` (reads stdin). There is no
-`--body TEXT` form — stdin handles every size from one-liners to full PR
-descriptions.
+If the host is not GitHub, use the equivalent host-native command or API call
+and preserve the same heredoc/stdin pattern where possible.

--- a/plugins-copilot/git-tools/skills/ship/SKILL.md
+++ b/plugins-copilot/git-tools/skills/ship/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   "send it", "ship it", "merge it", or terse single words "watch", "merge",
   "pull" when the context implies finishing a PR. Drives staging → commit →
   push → PR create → CI watch → merge wait → checkout master → pull, using
-  the git-cli wrapper for every GitHub/Gitea call. Skips steps that are
-  already complete instead of redoing them.
+  native host tooling (gh on GitHub, host-native equivalent on Gitea) for
+  every call. Skips steps that are already complete instead of redoing them.
 allowed-tools: Bash
 ---
 
@@ -18,7 +18,7 @@ allowed-tools: Bash
 
 **Purpose.** Take whatever in-progress work exists and drive it through the canonical lifecycle: stage → commit → push → PR → watch CI → wait for merge → return to default branch → pull. Skip any step that's already done.
 
-**Always use the `git-cli` wrapper** at `${COPILOT_PLUGIN_ROOT}/scripts/git-cli` for every GitHub/Gitea call. Never invoke raw `gh` or `tea` directly — the wrapper auto-detects the platform from the git remote so the same procedure works on both. See the sibling `git-cli` skill for full command reference.
+Use native host tooling for every GitHub/Gitea call. On GitHub repos, prefer `gh`. On Gitea or other hosts, use the equivalent host-native CLI or API tooling. See the sibling `git-cli` skill for the full command reference.
 
 ## When to use
 
@@ -45,7 +45,7 @@ git status --porcelain=v1 -b
 git rev-parse --abbrev-ref HEAD
 ```
 
-Establish: dirty working tree? on default branch or feature branch? upstream set? Determine the default branch via `${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo default-branch`.
+Establish: dirty working tree? on default branch or feature branch? upstream set? Determine the default branch via `git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||'`.
 
 ### 1. Stage and commit
 
@@ -77,17 +77,18 @@ git push -u origin HEAD
 
 ### 4. Create PR (if not already open)
 
-Check first:
+Check first (on GitHub):
 
 ```bash
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr list --state open --limit 50 \
-  | jq -r --arg b "$(git rev-parse --abbrev-ref HEAD)" '.[] | select(.head==$b) | .number'
+gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json number,url
 ```
 
-If no PR exists for the current branch:
+On Gitea or other hosts, use the equivalent host-native PR listing command.
+
+If no PR exists for the current branch, create one (on GitHub):
 
 ```bash
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr create --title "..." --head "$(git rev-parse --abbrev-ref HEAD)" --body <<'EOF'
+gh pr create --title "..." --head "$(git rev-parse --abbrev-ref HEAD)" --body-file - <<'EOF'
 ## Summary
 ...
 
@@ -100,28 +101,33 @@ Pull a concise title from the most recent commit message; pull the body from the
 
 ### 5. Watch CI
 
+Poll the run associated with the current branch until it passes, fails, or the PR merges. On GitHub:
+
 ```bash
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli run watch --branch "$(git rev-parse --abbrev-ref HEAD)" --timeout 600 --interval 30
+gh run list --branch "$(git rev-parse --abbrev-ref HEAD)" --limit 1 --json databaseId,status,conclusion,url
+gh run watch <run-id> --exit-status
 ```
 
-This polls until CI passes, fails, or merges. Output includes `status` (`pass|fail|closed|timeout|no-workflow`), `url`, `duration`, and on fail `failed_jobs` with logs piped to stderr.
+On Gitea or other hosts, use the host-native CI listing/watching command. Time-box polling (e.g. 600s overall, 30s interval) and surface the failure or timeout clearly. Output should include `status` (`pass|fail|closed|timeout|no-workflow`), `url`, `duration`, and on fail the failing job names with logs.
 
 **On failure:** stop the orchestrator and surface the failure to the user. Do not push fixes silently — let them decide.
 
 ### 6. Wait for merge
 
-If the repo has an auto-merge bot (this repo's `st0nefish-ci` enables auto-merge on PR open), wait for the merge to complete:
+If the repo has an auto-merge bot (this repo's `st0nefish-ci` enables auto-merge on PR open), poll the PR until merged:
 
 ```bash
-${COPILOT_PLUGIN_ROOT}/scripts/git-cli pr wait --branch "$(git rev-parse --abbrev-ref HEAD)" --timeout 300 --interval 15
+gh pr view <number> --json state,mergedAt
 ```
 
-Skip this step if the repo does not auto-merge. **Never call `git-cli pr merge` to merge manually unless the user explicitly asks** — that bypasses CI gating and the auto-merge workflow.
+Stop when `mergedAt` is non-null (status: merged) or `state` becomes `CLOSED` without merge. Time-box this poll (e.g. 300s overall, 15s interval). On Gitea, use the host-native PR view command.
+
+Skip this step if the repo does not auto-merge. **Never call `gh pr merge` to merge manually unless the user explicitly asks** — that bypasses CI gating and the auto-merge workflow.
 
 ### 7. Return to default branch
 
 ```bash
-default=$(${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo default-branch)
+default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||')
 git checkout "$default"
 git pull
 ```
@@ -134,11 +140,11 @@ Each step probes state first and skips when there's nothing to do. Re-running th
 
 ## What NOT to do
 
-- Do **not** invoke raw `gh` or `tea` — always go through `git-cli`.
+- Do **not** invoke `tea` directly on Gitea — use the host-native CLI through its own canonical entry point or the API.
 - Do **not** force-push without explicit user approval (and even then, only `--force-with-lease`).
 - Do **not** call `gh pr merge` / `tea pr merge` to manually merge unless the user asked — the auto-merge bot handles this.
 - Do **not** end the session on a feature branch after a merge — return to the default branch and pull.
-- Do **not** invent your own polling loop (`until gh pr view ... | grep MERGED; do sleep`) — `git-cli pr wait` and `git-cli run watch` already handle this with proper timeouts and failure detection.
+- Do **not** invent your own polling loop without time-boxing — bound every wait with a sensible timeout and a clear "no decision yet" exit.
 
 ## Reporting back
 

--- a/plugins-copilot/git-worktree/hooks/hooks.json
+++ b/plugins-copilot/git-worktree/hooks/hooks.json
@@ -1,11 +1,15 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-whitelist.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    },
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-whitelist.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/git-worktree/skills/worktree-create/SKILL.md
+++ b/plugins-copilot/git-worktree/skills/worktree-create/SKILL.md
@@ -15,21 +15,31 @@ against them inside the session's CWD scope.
 
 ## Steps
 
-1. Run the create script with the branch name the user provided:
+1. Use direct `git worktree` commands rather than plugin helper-script paths;
+   the plugin-root environment variable is not guaranteed to exist inside Bash
+   tool invocations.
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-create.sh <branch-name>
-   ```
+2. Resolve the repo root with `git rev-parse --show-toplevel`, then set the
+   base directory to `${WORKTREE_BASE_DIR:-<repo-root>/.github/worktrees}`.
+   On first use, create the directory and ensure it is gitignored (skip the
+   gitignore step if `WORKTREE_BASE_DIR` is overridden).
 
-   If the user specified a base branch ("from main"), pass it:
+3. Convert the requested branch name into a directory slug by:
+   - replacing `/` with `-`
+   - replacing remaining non-`[A-Za-z0-9._-]` characters with `-`
+   - collapsing repeated `-`
+   - trimming leading and trailing `-`
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-create.sh <branch-name> --from <base-branch>
-   ```
+4. Set the worktree path to `<base-dir>/<slug>` and stop with a clear error
+   if that directory already exists.
 
-2. Report the worktree path and branch back to the user.
+5. If the branch already exists locally, run `git worktree add <path> <branch>`.
+   Otherwise create it with `git worktree add <path> -b <branch> [<base-branch>]`,
+   defaulting the base branch to the current branch when the user did not specify one.
 
-3. Remind them to run `/worktree-remove <name>` when finished.
+6. Report the worktree path and branch back to the user.
+
+7. Remind them to run `/worktree-remove <name>` when finished.
 
 ## Notes
 

--- a/plugins-copilot/git-worktree/skills/worktree-list/SKILL.md
+++ b/plugins-copilot/git-worktree/skills/worktree-list/SKILL.md
@@ -8,11 +8,20 @@ description: >-
 allowed-tools: shell
 ---
 
-Run the list script and present its output verbatim. The script formats a
-table with PATH, BRANCH, and STATUS columns.
+Use direct `git worktree` commands rather than plugin helper-script paths;
+the plugin-root environment variable is not guaranteed to exist inside Bash
+tool invocations.
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-list.sh
-```
+## Steps
 
-If no worktrees exist, suggest `/worktree-create <branch-name>` to create one.
+1. Run `git worktree list --porcelain` and parse the records into PATH,
+   BRANCH, and STATUS columns:
+   - PATH — the worktree directory
+   - BRANCH — the checked-out branch (mark detached HEAD as `(detached)`)
+   - STATUS — `clean` when the worktree has no uncommitted/staged changes,
+     or a short marker otherwise (e.g. `dirty`)
+
+2. Present the table verbatim to the user.
+
+3. If only the main worktree is listed, suggest `/worktree-create <branch-name>`
+   to create one.

--- a/plugins-copilot/git-worktree/skills/worktree-parallel-work/SKILL.md
+++ b/plugins-copilot/git-worktree/skills/worktree-parallel-work/SKILL.md
@@ -38,19 +38,17 @@ In implicit cases, pause and surface the worktree suggestion first.
 1. One-sentence observation: "I see uncommitted changes on this branch
    related to X — your new request looks unrelated."
 
-2. Offer to create the worktree:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-create.sh <suggested-branch-name>
-   ```
+2. Offer to create the worktree using the direct `git worktree add` flow
+   described by the worktree-create skill: derive the worktree base
+   directory from the repo root, slug the suggested branch name, and
+   create the worktree without relying on plugin-root environment
+   variables inside Bash.
 
 3. Once created, run commands in the worktree via `cd <path> && ...`.
 
-4. After the work is done, suggest cleanup:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-remove.sh <name> --delete-branch
-   ```
+4. After the work is done, suggest cleanup: remove the worktree with the
+   same direct `git worktree remove` flow described by the worktree-remove
+   skill, and optionally delete the branch with `git branch -d`.
 
 ## Rules
 

--- a/plugins-copilot/git-worktree/skills/worktree-remove/SKILL.md
+++ b/plugins-copilot/git-worktree/skills/worktree-remove/SKILL.md
@@ -9,39 +9,33 @@ description: >-
 allowed-tools: shell
 ---
 
-Remove a linked git worktree. Optionally delete its branch.
+Remove a linked git worktree. Optionally delete its branch. Use direct
+`git worktree` commands rather than plugin helper-script paths; the
+plugin-root environment variable is not guaranteed to exist inside Bash
+tool invocations.
 
 ## Steps
 
 1. Identify the target. The user can pass:
-   - A slug name (e.g. `feature-auth`) — resolved under `.github/worktrees/`
+   - A slug name (e.g. `feature-auth`) — resolved against the entries in
+     `git worktree list --porcelain` (match the leaf directory under
+     `${WORKTREE_BASE_DIR:-<repo-root>/.github/worktrees}`)
    - An absolute path to the worktree directory
 
-2. Check for uncommitted changes first:
+2. Check for uncommitted changes by inspecting the matching record from
+   `git worktree list --porcelain`. If the worktree is dirty and the user
+   did not request `--force`, refuse and explain.
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-list.sh
-   ```
+3. Remove the worktree with `git worktree remove <path>`. Pass `--force`
+   when the user explicitly requested it for a dirty worktree.
 
-3. If clean (or the user explicitly confirms), run:
+4. If the user passed `--delete-branch`, run `git branch -d <branch>` after
+   removal. Use `git branch -D <branch>` only when the user explicitly
+   confirms a force-delete (branch unmerged).
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-remove.sh <path-or-name>
-   ```
+5. Run `git worktree prune` to clean up stale administrative state.
 
-   To also delete the branch:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-remove.sh <path-or-name> --delete-branch
-   ```
-
-   To force-remove when uncommitted changes exist:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/worktree-remove.sh <path-or-name> --force
-   ```
-
-4. Confirm removal to the user.
+6. Confirm removal to the user.
 
 ## Notes
 

--- a/plugins-copilot/image/.claude-plugin/plugin.json
+++ b/plugins-copilot/image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Clipboard paste and screenshot capture for macOS, WSL, and Linux",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/image/hooks/hooks.json
+++ b/plugins-copilot/image/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-copilot/java-toolkit/commands/java-toolkit.md
+++ b/plugins-copilot/java-toolkit/commands/java-toolkit.md
@@ -14,18 +14,20 @@ $IF(!$1, Available actions: `start`, `stop`. Usage: `/java-toolkit [action]`)
 
 ## start
 
-Start the Docker Compose stack for both maven-tools and maven-indexer MCP servers.
+Start the bundled Docker Compose stack for both `maven-tools` and `maven-indexer`
+MCP servers.
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/setup.sh
-```
+Do not construct plugin-root Bash paths manually. Use the plugin's
+normal command flow to trigger the bundled setup action, or explain clearly if
+the current Copilot CLI session cannot resolve the installed plugin path.
 
 ---
 
 ## stop
 
-Stop the Docker Compose stack and remove volumes. Use when done with MCP server usage or to free resources.
+Stop the bundled Docker Compose stack and remove volumes when you are done with
+the Maven MCP servers or want to free resources.
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/setup.sh --teardown
-```
+Do not construct plugin-root Bash paths manually. Use the plugin's
+normal command flow to trigger the bundled teardown action, or explain clearly
+if the current Copilot CLI session cannot resolve the installed plugin path.

--- a/plugins-copilot/java-toolkit/docker-compose.yml
+++ b/plugins-copilot/java-toolkit/docker-compose.yml
@@ -1,0 +1,1 @@
+../../plugins-claude/java-toolkit/docker-compose.yml

--- a/plugins-copilot/java-toolkit/skills/jar-explore/SKILL.md
+++ b/plugins-copilot/java-toolkit/skills/jar-explore/SKILL.md
@@ -10,48 +10,40 @@ allowed-tools: Bash, Read
 
 # JAR Content Inspection
 
-Use `${COPILOT_PLUGIN_ROOT}/scripts/jar-explore` for reading raw JAR contents. Do NOT use `unzip`, `jar tf`, or `jar xf` directly.
+Use the plugin's bundled `jar-explore` tool for reading raw JAR contents
+rather than `unzip`, `jar tf`, or `jar xf`. Do not construct plugin-root
+Bash paths manually; if the current Copilot CLI session cannot resolve
+the installed plugin path, say so plainly instead of guessing.
 
-For **class search and decompilation**, use the **maven-indexer** MCP server bundled with this plugin (run `/java-toolkit:java-toolkit start` first if the Docker stack isn't running):
+For **class search and decompilation**, use the **maven-indexer** MCP server
+bundled with this plugin (run `/java-toolkit:java-toolkit start` first if
+the Docker stack isn't running):
 
 - Finding classes by name → `search_classes`
 - Decompiling classes to source → `get_class_details` (type: `"source"`)
 - Finding JARs by coordinates → `search_artifacts`
 - Finding interface implementations → `search_implementations`
 
-This tool covers what the MCP server doesn't: listing raw entries, regex search within a JAR, and reading arbitrary non-class files.
+This tool covers what the MCP server doesn't: listing raw entries, regex
+search within a JAR, and reading arbitrary non-class files.
 
 ## Subcommands
 
-### List all entries
+The tool exposes three subcommands:
 
-```bash
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore list /path/to/file.jar
-```
-
-### Search for entries matching a pattern
-
-```bash
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore search /path/to/file.jar "ClassName"
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore search /path/to/file.jar "META-INF.*\.properties"
-```
-
-Pattern is a case-insensitive extended regex.
-
-### Read a file from a JAR (no extraction to disk)
-
-```bash
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore read /path/to/file.jar com/example/MyClass.java
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore read /path/to/file.jar META-INF/MANIFEST.MF
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore read /path/to/file.jar META-INF/spring.factories
-${COPILOT_PLUGIN_ROOT}/scripts/jar-explore read /path/to/file.jar application.properties
-```
+- **list `<jar>`** — list every entry in the JAR.
+- **search `<jar> <pattern>`** — list entries matching a case-insensitive
+  extended regex (e.g. `ClassName`, `META-INF.*\.properties`).
+- **read `<jar> <entry>`** — print the entry's contents to stdout (no
+  extraction to disk). Use for `META-INF/MANIFEST.MF`,
+  `META-INF/spring.factories`, `application.properties`, or any embedded
+  source file.
 
 ## Typical workflow
 
-1. Get the JAR path from maven-indexer (`search_artifacts`) or the project build output
-2. Browse contents: `${COPILOT_PLUGIN_ROOT}/scripts/jar-explore list <jar>` or `${COPILOT_PLUGIN_ROOT}/scripts/jar-explore search <jar> <pattern>`
-3. Read a specific file: `${COPILOT_PLUGIN_ROOT}/scripts/jar-explore read <jar> <entry>`
+1. Get the JAR path from maven-indexer (`search_artifacts`) or the project build output.
+2. Browse contents: `list <jar>` or `search <jar> <pattern>`.
+3. Read a specific file: `read <jar> <entry>`.
 
 ## Exit codes
 
@@ -59,7 +51,3 @@ ${COPILOT_PLUGIN_ROOT}/scripts/jar-explore read /path/to/file.jar application.pr
 - 1: Bad usage / invalid arguments
 - 2: File or path not found
 - 3: Entry not found in JAR
-
-## Hook auto-approval
-
-Commands using `${COPILOT_PLUGIN_ROOT}/scripts/jar-explore` can be auto-approved in Copilot hooks by matching the command prefix `${COPILOT_PLUGIN_ROOT}/scripts/jar-explore`. This is safe because the script is read-only (stdout output only, no disk writes).

--- a/plugins-copilot/java-toolkit/skills/setup/SKILL.md
+++ b/plugins-copilot/java-toolkit/skills/setup/SKILL.md
@@ -9,16 +9,18 @@ allowed-tools: Bash
 
 # Java Toolkit Setup
 
-Manage the Docker Compose stack for the java-toolkit MCP servers.
+Manage the Docker Compose stack for the `java-toolkit` MCP servers.
 
 ## Start
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/setup.sh
-```
+Start the bundled Docker Compose stack using the plugin's normal setup flow.
+Do not construct plugin-root Bash paths manually; if the current
+Copilot CLI session cannot resolve the installed plugin path, say so plainly
+instead of guessing.
 
 ## Stop
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/setup.sh --teardown
-```
+Stop the bundled Docker Compose stack using the plugin's normal teardown flow.
+Do not construct plugin-root Bash paths manually; if the current
+Copilot CLI session cannot resolve the installed plugin path, say so plainly
+instead of guessing.

--- a/plugins-copilot/kb-capture/.claude-plugin/plugin.json
+++ b/plugins-copilot/kb-capture/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-capture",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Research-to-document automation — capture conversation findings as schema-valid markdown with frontmatter, linting, and optional commit",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/kb-capture/commands/capture.md
+++ b/plugins-copilot/kb-capture/commands/capture.md
@@ -18,11 +18,17 @@ Capture conversation findings or research as a markdown document with schema-val
 
 ### 1. Detect schema
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/detect-schema.sh
-```
+Inspect the repository for frontmatter constraints without relying on plugin helper-script paths:
 
-Returns JSON with valid frontmatter field values. Empty fields if no schema found.
+- look for nearby markdown files with similar frontmatter
+- search for frontmatter schema or taxonomy files
+- search for existing validation commands or scripts already tracked in the repo
+
+Build a compact summary of:
+
+- required fields
+- constrained values (type, domain, status, tags, etc.)
+- the most likely target directory and filename pattern
 
 ### 2. Confirm with user
 
@@ -31,20 +37,20 @@ Use `AskUserQuestion` to confirm:
 - **Create mode**: proposed filename, location, title, and document type
 - **Update mode**: the target file and what changes to make
 
-Show the detected schema file (if any) so the user can verify it is correct.
+Show the discovered schema source (if any) so the user can verify it is correct.
 
 ### 3. Write the document
 
-- **Create**: Write a new markdown file with YAML frontmatter. Required fields: `title`, `date` (YYYY-MM-DD). Include constrained fields from schema output.
+- **Create**: Write a new markdown file with YAML frontmatter. Required fields: `title`, `date` (YYYY-MM-DD). Include constrained fields from the discovered schema.
 - **Update**: Read the existing file, apply changes, preserve existing frontmatter.
 
 ### 4. Validate frontmatter
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/validate-frontmatter.sh <file>
-```
+If the repository already has a frontmatter validation command or script, run it.
+Otherwise, manually verify that the frontmatter is valid YAML and that constrained
+fields match the discovered schema or local conventions.
 
-Fix any issues (exit 1) and re-validate until clean (exit 0).
+Fix any issues and re-check until clean.
 
 ### 5. Lint
 
@@ -54,7 +60,7 @@ If `rumdl` is available, run it with auto-fix:
 rumdl check --fix <file>
 ```
 
-If the file was modified, re-validate frontmatter. If `rumdl` is not installed, skip and inform the user.
+If the file was modified, re-check frontmatter. If `rumdl` is not installed, skip and inform the user.
 
 ### 6. Offer to commit
 

--- a/plugins-copilot/kb-capture/hooks/hooks.json
+++ b/plugins-copilot/kb-capture/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/kb-capture/skills/kb-capture/SKILL.md
+++ b/plugins-copilot/kb-capture/skills/kb-capture/SKILL.md
@@ -12,7 +12,8 @@ allowed-tools: Bash, Read, Write, AskUserQuestion
 
 # KB Capture
 
-Automate the research-to-document workflow: detect the knowledge base schema, write schema-valid markdown with frontmatter, lint, and optionally commit.
+Automate the research-to-document workflow: discover local frontmatter conventions,
+write schema-valid markdown with frontmatter, lint, and optionally commit.
 
 ## Mode Detection
 
@@ -23,13 +24,17 @@ Automate the research-to-document workflow: detect the knowledge base schema, wr
 
 ### 1. Detect schema
 
-Run the schema detection script to discover valid frontmatter field values:
+Inspect the repository for frontmatter constraints without relying on plugin helper-script paths:
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/detect-schema.sh
-```
+- look for nearby markdown files with similar frontmatter
+- search for frontmatter schema or taxonomy files
+- search for existing validation commands or scripts already tracked in the repo
 
-This returns JSON with the schema file path and valid field values (e.g., valid `type`, `domain`, `tags` values). If no schema is found, the output will have empty fields — proceed without constrained values.
+Build a compact summary of:
+
+- required fields
+- constrained values (type, domain, status, tags, etc.)
+- the most likely target directory and filename pattern
 
 ### 2. Confirm with user
 
@@ -38,20 +43,20 @@ Use `AskUserQuestion` to confirm:
 - **Create mode**: proposed filename, location, title, and document type
 - **Update mode**: the target file and what changes to make
 
-Show the detected schema file (if any) so the user can verify it is the right one.
+Show the discovered schema source (if any) so the user can verify it is the right one.
 
 ### 3. Write the document
 
-- **Create**: Write a new markdown file with YAML frontmatter containing all required fields (`title`, `date` in YYYY-MM-DD format) and any constrained fields from the schema. Use the conversation context to populate the document body.
+- **Create**: Write a new markdown file with YAML frontmatter containing all required fields (`title`, `date` in YYYY-MM-DD format) and any constrained fields from the discovered schema. Use the conversation context to populate the document body.
 - **Update**: Read the existing file, apply the requested changes, and preserve existing frontmatter fields.
 
 ### 4. Validate frontmatter
 
-```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/validate-frontmatter.sh <file>
-```
+If the repository already has a frontmatter validation command or script, run it.
+Otherwise, manually verify that the frontmatter is valid YAML and that constrained
+fields match the discovered schema or local conventions.
 
-If validation fails (exit 1), fix the reported issues and re-validate.
+If validation fails, fix the reported issues and re-check.
 
 ### 5. Lint
 
@@ -61,7 +66,7 @@ If `rumdl` is available, run it with auto-fix:
 rumdl check --fix <file>
 ```
 
-If the file was modified by the linter, re-run `validate-frontmatter.sh` to ensure fixes didn't break frontmatter. If `rumdl` is not installed, skip linting and inform the user.
+If the file was modified by the linter, re-check frontmatter to ensure fixes did not break it. If `rumdl` is not installed, skip linting and inform the user.
 
 ### 6. Offer to commit
 
@@ -69,8 +74,7 @@ Use `AskUserQuestion` to ask whether to commit and push the changes. **Never aut
 
 ## Rules
 
-- Always use `detect-schema.sh` output to constrain frontmatter values — do not guess valid values.
+- Always derive constrained frontmatter values from the repository's actual schema files, validators, or nearby examples — do not guess.
 - Date fields must use YYYY-MM-DD format.
 - Tags should be YAML flow sequences: `tags: [tag1, tag2]`.
-- If the schema defines constrained fields (type, domain, status, tags), only use values from the schema output.
 - Run validation and linting on every write, even updates.

--- a/plugins-copilot/markdown/.claude-plugin/plugin.json
+++ b/plugins-copilot/markdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Markdown linting and formatting — check, format, setup",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/markdown/commands/markdown.md
+++ b/plugins-copilot/markdown/commands/markdown.md
@@ -21,19 +21,19 @@ Lint markdown files for style violations using [rumdl](https://github.com/sysid/
 Check a single file:
 
 ```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/rumdl-wrap check README.md
+rumdl check README.md
 ```
 
 Check all markdown in a directory:
 
 ```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/rumdl-wrap check docs/
+rumdl check docs/
 ```
 
 Check everything in the repo:
 
 ```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/rumdl-wrap check .
+rumdl check .
 ```
 
 ### Notes
@@ -55,19 +55,19 @@ Auto-fix markdown lint violations using [rumdl](https://github.com/sysid/rumdl).
 Fix a single file:
 
 ```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/rumdl-wrap check --fix README.md
+rumdl check --fix README.md
 ```
 
 Fix all markdown in a directory:
 
 ```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/rumdl-wrap check --fix docs/
+rumdl check --fix docs/
 ```
 
 Fix everything in the repo:
 
 ```bash
-bash ${COPILOT_PLUGIN_ROOT}/scripts/rumdl-wrap check --fix .
+rumdl check --fix .
 ```
 
 ### Notes

--- a/plugins-copilot/markdown/hooks/hooks.json
+++ b/plugins-copilot/markdown/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/notify-on-stop/.claude-plugin/plugin.json
+++ b/plugins-copilot/notify-on-stop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-on-stop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/notify-on-stop/hooks/hooks.json
+++ b/plugins-copilot/notify-on-stop/hooks/hooks.json
@@ -1,23 +1,20 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ],
-    "userPromptSubmit": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh"
-      }
-    ],
-    "stop": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    },
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh",
+      "event": "userPromptSubmit"
+    },
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh",
+      "event": "stop"
+    }
+  ]
 }

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/permission-manager/hooks/hooks.json
+++ b/plugins-copilot/permission-manager/hooks/hooks.json
@@ -1,19 +1,20 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      },
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/cmd-gate.sh"
-      },
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/web-gate.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    },
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/cmd-gate.sh",
+      "event": "preToolUse"
+    },
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/web-gate.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/session-history-analyzer/.claude-plugin/plugin.json
+++ b/plugins-copilot/session-history-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-history-analyzer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session-history-analyzer/commands/analyze.md
+++ b/plugins-copilot/session-history-analyzer/commands/analyze.md
@@ -1,79 +1,50 @@
 ---
-description: "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates"
-argument-hint: "[--since <date>] [--project <name>] [--force]"
-allowed-tools: Bash, Agent, Read, AskUserQuestion
+description: "Analyze Copilot CLI session history for workflow patterns, friction hotspots, and automation candidates"
+argument-hint: "[--since <date>] [--project <name>]"
+allowed-tools: SQL, Task, AskUserQuestion
 ---
 
 # Analyze Session History
 
-Analyze Claude Code session JSONL files to identify workflow patterns, friction hotspots, and automation candidates.
+Analyze Copilot CLI session history from the built-in session store to identify workflow patterns, friction hotspots, and automation candidates.
 
 ## Arguments
 
 - `--since <date>` — only analyze sessions modified after this date (ISO 8601)
-- `--project <name>` — only analyze sessions for projects matching this name
-- `--force` — re-analyze previously analyzed sessions
+- `--project <name>` — only analyze sessions for repositories or working directories matching this name
 
 ## Steps
 
-1. **Discover sessions** — run the discovery script to enumerate available sessions:
+1. **Scope the history** — query `session_store` to enumerate matching sessions, turns, checkpoints, and edited files using the supplied filters.
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/discover-sessions.sh [--since <date>] [--project <name>]
-   ```
-
-2. **Filter already-analyzed** — for each discovered session, check incremental state (unless `--force`):
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/state-manager.sh is-analyzed <session_id>
-   ```
-
-   Skip sessions that return exit 0 (already analyzed).
-
-3. **Present summary and confirm** — show the user:
-   - Number of projects with pending sessions
-   - Total pending session count
-   - Estimated scope
+2. **Present summary and confirm** — show the user:
+   - number of matching projects
+   - total matching session count
+   - rough depth (turns, checkpoints, edited files)
 
    Use `AskUserQuestion` to confirm before dispatching analysis agents.
 
-4. **Dispatch per-project agents** — group pending sessions by `project_slug`. For each project cluster, launch an Agent subagent that:
-   - Calls `parse-session.sh` on each session in the cluster
-   - Aggregates results into a project-level summary: total sessions, total turns, top tools, common workflows, friction indicators, notable patterns
-   - Returns the summary as structured JSON
+3. **Group by project** — cluster matching sessions by repository when available, otherwise by cwd.
 
-   Use parallel Agent calls for independent project clusters.
+4. **Dispatch per-project agents** — for each project cluster, launch a Task subagent that receives the relevant session-store rows and returns a structured summary:
+   - total sessions
+   - total turns
+   - top tools and recurring workflows
+   - friction indicators
+   - notable patterns and recommendations
 
-   Example agent prompt:
-   > Parse these session files and return a JSON summary:
-   > - Run: `bash <plugin_root>/scripts/parse-session.sh <jsonl_path>` for each file
-   > - Aggregate: total sessions, total turns, tool frequency, friction counts, workflow patterns
-   > - Return a single JSON object with the project summary
+   Use parallel Task calls for independent project clusters when the scope is large enough to justify it.
 
-5. **Mark analyzed** — for each processed session:
+5. **Synthesize report** — combine all project summaries into a consolidated analysis:
+   - cross-project patterns
+   - friction hotspots
+   - automation candidates
+   - recommendations ranked by impact
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/state-manager.sh mark-analyzed <session_id> <project_slug> <started_at>
-   ```
-
-6. **Synthesize report** — combine all project summaries into a consolidated analysis:
-   - Cross-project patterns (common tools, shared workflows)
-   - Friction hotspots (hook blocks, compactions, long sessions)
-   - Automation candidates (repetitive tool patterns, manual steps)
-   - Recommendations ranked by impact
-
-7. **Present report** — display the consolidated report to the user. Offer to save it:
-
-   ```bash
-   mkdir -p ~/.claude/session-analysis/reports
-   ```
-
-   Save to `~/.claude/session-analysis/reports/YYYY-MM-DD.md` if the user agrees.
+6. **Present report** — display the consolidated report to the user. Offer to save it to a markdown file if they want a persistent copy.
 
 ## Rules
 
-- Always confirm with the user before dispatching analysis agents (step 3)
-- Use Agent subagents for parallelism — one per project cluster
-- The model synthesizes insights; scripts only extract raw data
-- Mark sessions as analyzed only after successful parsing
-- Reports should be actionable — prioritize concrete automation recommendations
+- Always confirm with the user before dispatching analysis agents.
+- Prefer the built-in `session_store` over plugin-private JSONL parsing when running inside Copilot CLI.
+- Keep recommendations concrete and actionable.

--- a/plugins-copilot/session-history-analyzer/commands/status.md
+++ b/plugins-copilot/session-history-analyzer/commands/status.md
@@ -1,36 +1,31 @@
 ---
-description: "Show analysis state — analyzed vs pending session counts per project"
-allowed-tools: Bash
+description: "Show session-history coverage and recent activity by project"
+allowed-tools: SQL
 ---
 
 # Analysis Status
 
-Show the current state of session history analysis.
+Show the current state of session history available through Copilot CLI's session store.
 
 ## Steps
 
-1. Get analysis state summary:
+1. Query `session_store` for recent sessions and last-seen timestamps grouped by repository or cwd.
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/state-manager.sh summary
-   ```
-
-2. Discover all available sessions:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/discover-sessions.sh
-   ```
-
-3. Cross-reference to compute pending counts per project. Present a status card:
+2. Present a status card:
 
    ```text
-   Last analysis: <date or "never">
-   Total analyzed: <N> sessions
-   Pending: <N> sessions across <N> projects
+   Last session seen: <date or "none">
+   Total sessions: <N>
+   Recent sessions (30d): <N>
 
    Per project:
-     <slug>: <analyzed>/<total> sessions
+     <repo-or-path>: <count> sessions
      ...
    ```
 
-4. If there are pending sessions, suggest running `/session-history-analyzer:analyze`.
+3. If there is enough history to analyze, suggest running `/session-history-analyzer:analyze`.
+
+## Notes
+
+- In Copilot CLI, prefer the built-in session store over plugin-private state files.
+- There is no separate analyzed vs pending registry here; report available history instead.

--- a/plugins-copilot/session-history-analyzer/hooks/hooks.json
+++ b/plugins-copilot/session-history-analyzer/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/session-history-analyzer/skills/analyze/SKILL.md
+++ b/plugins-copilot/session-history-analyzer/skills/analyze/SKILL.md
@@ -3,9 +3,9 @@ user-invocable: false
 name: analyze-sessions
 description: >-
   Detect when the user asks about workflow patterns, friction points, automation
-  opportunities, or time loss in their Claude Code usage. Checks session analysis
-  state and routes to /session-history-analyzer:analyze for full analysis.
-allowed-tools: Bash
+  opportunities, or time loss in their Copilot CLI usage. Checks session-store
+  coverage and routes to /session-history-analyzer:analyze for full analysis.
+allowed-tools: SQL
 ---
 
 # Session History Analysis
@@ -19,25 +19,18 @@ Triggered when the user asks about workflow patterns, friction, or automation op
 - "where am I losing time"
 - "what should I automate"
 - "review my session history"
-- "how do I use Claude Code"
+- "how do I use Copilot CLI"
 
 ## Steps
 
-1. Check current analysis state:
+1. Check available history in `session_store`:
+   - how many sessions exist across how many repos or working directories
+   - when the most recent matching session was recorded
+   - whether there is enough history to justify a deeper analysis
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/state-manager.sh summary
-   ```
+2. Summarize what's available:
+   - session counts
+   - project spread
+   - recency
 
-2. Discover available sessions:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/discover-sessions.sh
-   ```
-
-3. Summarize what's available:
-   - How many sessions exist across how many projects
-   - How many have already been analyzed
-   - When the last analysis was run
-
-4. Route to `/session-history-analyzer:analyze` for a full analysis run. Do not attempt to parse sessions directly from this skill.
+3. Route to `/session-history-analyzer:analyze` for a full analysis run. Do not attempt to synthesize the full workflow report from this skill alone.

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Work session management — start, end, checkpoint, handoff, resume, issue, reset, orchestrate, plus a model-triggered summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/commands/checkpoint.md
+++ b/plugins-copilot/session/commands/checkpoint.md
@@ -10,10 +10,8 @@ Commits staged/unstaged changes and posts structured context to the linked issue
 ### Steps
 
 1. Gather current state:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup
-   ```
+   inspect the current branch, default branch, recent commits, changed files,
+   and any linked issue directly with `git` and native host tooling.
 
 2. Infer what's in progress and what should come next from conversation context. When auto-triggering, do NOT ask — infer from the conversation. Only use AskUserQuestion if explicitly invoked and progress is genuinely unclear.
 
@@ -36,19 +34,15 @@ Commits staged/unstaged changes and posts structured context to the linked issue
    ```bash
    git add -A
    git commit --no-verify -m "checkpoint: <brief description of progress>"
-   git push
    ```
 
    If there are no changes to commit, skip the commit step but still post the issue comment.
+   Only push if the user explicitly asked to publish the checkpoint or has already
+   approved pushing in this session.
 
 5. If the current branch matches `type/NNN-*`, post the checkpoint as an issue comment:
-
-   ```bash
-   cat > /tmp/checkpoint-comment.md << 'EOF'
-   <checkpoint content from step 3>
-   EOF
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <N> --body-file /tmp/checkpoint-comment.md
-   rm -f /tmp/checkpoint-comment.md
-   ```
+   - on GitHub repos, prefer `gh issue comment <N>` with the body from step 3
+   - otherwise use the equivalent host-native issue-comment command if available
+   - use stdin or a heredoc rather than relying on plugin helper-script paths
 
 6. Briefly confirm: checkpoint committed and (if applicable) posted to issue #N. When auto-triggering, keep to one line. When user-invoked, mention `/session:resume` to continue from this point.

--- a/plugins-copilot/session/commands/end.md
+++ b/plugins-copilot/session/commands/end.md
@@ -9,48 +9,31 @@ watch CI, and return to the default branch.
 ### Steps
 
 1. Gather current state:
+   inspect the current repo directly with `git`:
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup
-   ```
-
-   Extract from the output:
    - `CURRENT` — the current branch name
-   - `DEFAULT` — the default branch name
-     (e.g. `master` or `main`)
-   - `ON_BASE` — true if the current branch IS the
-     default branch with no diverging commits
+   - `DEFAULT` — the default branch name (prefer `origin/HEAD`; fall back to `main` or `master`)
+   - `ON_BASE` — true if the current branch is the default branch with no diverging commits
+   - uncommitted changes
+   - commits ahead of the default branch
 
-   If `ON_BASE` is true and there are no uncommitted
-   changes, tell the user there is nothing to finalize
-   and stop.
+   If `ON_BASE` is true and there are no uncommitted changes, tell the user there is nothing to finalize and stop.
 
 1b. Check for an existing open PR for the current branch:
 
-   ```bash
-   PR_JSON=$(bash \
-     ${COPILOT_PLUGIN_ROOT}/scripts/git-cli \
-     pr list --state open \
-     | jq --arg b "$CURRENT" \
-       '.[] | select(.head == $b)')
-   ```
+   - on GitHub repos, prefer `gh pr list --head "$CURRENT" --state open --json number,url,headRefName`
+   - otherwise use the equivalent host-native PR listing command if available
 
-   If found, extract the PR URL and number, skip
-   steps 3-7, and jump directly to step 8 (CI watch)
-   using the existing PR info.
+   If found, extract the PR URL and number, skip steps 3-7, and jump directly to step 8 (CI watch) using the existing PR info.
 
-2. Check for uncommitted work. If found, ask the user
-   via AskUserQuestion:
+2. Check for uncommitted work. If found, ask the user via AskUserQuestion:
    - **Commit it** — stage and commit before proceeding
    - **Discard it** — `git restore .`
    - **Cancel** — abort the `end` flow
 
-   If `ON_BASE` is true (working directly on the default
-   branch), push the commit and skip to step 8 (CI watch).
-   Steps 3-7 only apply to feature branches.
+   If `ON_BASE` is true (working directly on the default branch), ask before pushing, then skip to step 8 (CI watch). Steps 3-7 only apply to feature branches.
 
-3. **Agent review** — use the Task tool to spawn a review
-   agent with this prompt:
+3. **Agent review** — use the Task tool to spawn a review agent with this prompt:
 
    > Review the changes on the current branch compared
    > to the default branch. Focus on:
@@ -63,19 +46,14 @@ watch CI, and return to the default branch.
    > Report findings concisely. Do not make changes —
    > report only.
 
-   Use `bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup`
-   output and `git diff <default>..<branch>` as context
-   for the review agent.
+   Use the direct git state from step 1 plus `git diff <default>..<branch>` as context for the review agent.
 
-4. Present the review findings to the user. Ask via
-   AskUserQuestion:
+4. Present the review findings to the user. Ask via AskUserQuestion:
    - **Looks good, open PR** — proceed
-   - **I'll fix the issues first** — pause the `end`
-     flow; user will re-invoke when ready
+   - **I'll fix the issues first** — pause the `end` flow; user will re-invoke when ready
    - **Open PR anyway** — skip fixes and proceed
 
-5. Determine the linked issue number from the branch
-   name (`type/NNN-*`). Build the PR body:
+5. Determine the linked issue number from the branch name (`type/NNN-*`). Build the PR body:
 
    ```markdown
    ## Summary
@@ -91,115 +69,66 @@ watch CI, and return to the default branch.
    <how this was tested or why no tests were needed>
    ```
 
-   If a linked issue exists, append `Resolves #N`
-   to the summary.
+   If a linked issue exists, append `Resolves #N` to the summary.
 
 6. Create the PR:
+   - on GitHub repos, prefer `gh pr create` with the title, base branch, head branch, and PR body from step 5
+   - otherwise use the equivalent host-native PR creation command if available
+   - ask before pushing if the branch is not yet on the remote
 
-   ```bash
-   DEFAULT=$(bash \
-     ${COPILOT_PLUGIN_ROOT}/scripts/git-cli \
-     repo default-branch)
-   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-   cat > /tmp/pr-body.md << 'EOF'
-   <PR body from step 5>
-   EOF
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli \
-     pr create \
-     --title "<concise PR title>" \
-     --head "$BRANCH" \
-     --base "$DEFAULT" \
-     --body-file /tmp/pr-body.md
-   rm -f /tmp/pr-body.md
-   ```
-
-7. Confirm to the user: PR URL, linked issue (if any),
-   and note that CI is being watched next.
+7. Confirm to the user: PR URL, linked issue (if any), and note that CI is being watched next.
 
 8. **Watch CI** — poll the CI run for the current branch:
+   - on GitHub repos, prefer `gh pr checks --watch` for the PR created or found above
+   - otherwise use the equivalent host-native CI status command if available
+   - normalize the result into `pass`, `fail`, `no-workflow`, or `timeout`, then:
+     - **`pass`** — continue to step 8b
+     - **`fail`** — show the failed jobs and log excerpt if available. Ask via AskUserQuestion:
+       - **Fix it** — pause the `end` flow; user will address failures and re-invoke
+       - **Ignore** — continue to step 8b
+     - **`no-workflow`** — note that no CI workflow was found; continue to step 8b
+     - **`timeout`** — ask via AskUserQuestion:
+       - **Wait longer** — keep watching
+       - **Continue** — proceed to step 8b
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli \
-     run watch --branch "$BRANCH"
-   ```
+8a. **Check auto-merge** — only when step 8 returned `pass` and `ON_BASE` is false:
+   inspect the PR directly (for example with `gh pr view --json autoMergeRequest,state,mergeStateStatus`)
+   and parse whether auto-merge is enabled.
+   If `true`, note to the user that auto-merge is enabled and the PR will merge automatically.
 
-   Parse the key:value stdout output (`status`, `url`,
-   `duration`, `failed_jobs`). Then:
-   - **`pass`** — continue to step 8b
-   - **`fail`** — show the failed jobs and log excerpt
-     (printed to stderr by `run watch`). Ask via
-     AskUserQuestion:
-     - **Fix it** — pause the `end` flow; user will
-       address failures and re-invoke
-     - **Ignore** — continue to step 8b
-   - **`no-workflow`** — note that no CI workflow was
-     found; continue to step 8b
-   - **`timeout`** — ask via AskUserQuestion:
-     - **Wait longer** — re-run `run watch` with
-       `--initial-delay 0` and a longer `--timeout`
-     - **Continue** — proceed to step 8b
+8b. **Wait for merge** — skip this step if `ON_BASE` is true (direct-to-default pushes have no PR to wait on). Otherwise, poll until the PR merges:
+   inspect the PR directly (for example with `gh pr view --json state,mergedAt,url,number`)
+   until it merges, closes, blocks, times out, or the user chooses to stop waiting.
+   Normalize the result into `merged`, `closed`, `blocked`, `timeout`, or `no-pr`, then:
 
-8a. **Check auto-merge** — only when step 8 returned
-   `pass` and `ON_BASE` is false:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli \
-     pr auto-merge-status --branch "$CURRENT"
-   ```
-
-   Parse the `auto_merge` value from the output.
-   If `true`, note to the user that auto-merge is enabled
-   and the PR will merge automatically.
-
-8b. **Wait for merge** — skip this step if `ON_BASE` is
-   true (direct-to-default pushes have no PR to wait on).
-   Otherwise, poll until the PR merges:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli \
-     pr wait --branch "$CURRENT"
-   ```
-
-   Parse the key:value stdout output (`status`,
-   `pr_number`, `url`, `duration`). Then:
-   - **`merged`** — continue to step 9
-   - **`closed`** — ask via AskUserQuestion:
-     - **Return to default branch** — continue to step 9
-     - **Investigate** — pause the `end` flow for the
-       user to investigate
-   - **`blocked`** — ask via AskUserQuestion:
-     - **Fix conflicts** — pause the `end` flow for the
-       user to resolve conflicts and re-invoke
-     - **Skip wait** — continue to step 9
-   - **`timeout`** — if auto-merge was detected in
-     step 8a, automatically re-run `pr wait` with
-     `--timeout 600` (up to 2 retries, no prompt).
-     If auto-merge was NOT detected, ask via
-     AskUserQuestion:
-     - **Wait longer** — re-run `pr wait` with a
-       longer `--timeout`
-     - **Return now** — continue to step 9
-   - **`no-pr`** — note that no PR was found;
-     continue to step 9
+- **`merged`** — continue to step 9
+- **`closed`** — ask via AskUserQuestion:
+  - **Return to default branch** — continue to step 9
+  - **Investigate** — pause the `end` flow for the user to investigate
+- **`blocked`** — ask via AskUserQuestion:
+  - **Fix conflicts** — pause the `end` flow for the user to resolve conflicts and re-invoke
+  - **Skip wait** — continue to step 9
+- **`timeout`** — ask via AskUserQuestion whether to keep waiting or return now
+- **`no-pr`** — note that no PR was found; continue to step 9
 
 9. **Return to default branch:**
 
    ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/branch default \
-     && git pull
+   git switch "$DEFAULT" && git pull --ff-only
    ```
 
    Skip if already on the default branch.
 
 10. **Final summary** — present to the user:
-    - PR URL (if created)
-    - CI status (pass/fail/no-workflow/timeout)
-    - Current branch (should be the default branch now)
-    - Linked issue (if any)
+
+- PR URL (if created)
+- CI status (pass/fail/no-workflow/timeout)
+- Current branch (should be the default branch now)
+- Linked issue (if any)
 
 ### Notes
 
-- Do NOT open the PR earlier — PR creation triggers
-  CI and merge pipelines
-- WIP commits in the branch are fine; squashing is
-  optional (not forced)
+- Do NOT open the PR earlier — PR creation triggers CI and merge pipelines
+- WIP commits in the branch are fine; squashing is optional (not forced)
+- Use direct `git`/`gh` commands rather than plugin helper-script paths; Copilot
+  CLI does not guarantee plugin-root environment variables inside Bash tool invocations.

--- a/plugins-copilot/session/commands/handoff.md
+++ b/plugins-copilot/session/commands/handoff.md
@@ -8,12 +8,10 @@ Commit all work, push, and record handoff context on the linked issue for cross-
 ### Steps
 
 1. Gather current state:
+   inspect the current branch, default branch, recent commits, changed files,
+   and any linked issue directly with `git` and native host tooling.
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup
-   ```
-
-2. Based on catchup output and conversation context, construct the handoff content:
+2. Based on the repo state and conversation context, construct the handoff content:
 
    **WIP commit body** (what changed — lives in git history):
 
@@ -38,43 +36,25 @@ Commit all work, push, and record handoff context on the linked issue for cross-
    ```
 
 3. Create the WIP commit:
+   build a normal git commit that captures the in-progress summary in both the
+   subject and body. Include:
+   - branch name
+   - UTC timestamp
+   - host name
+   - the `=== IN PROGRESS ===` section
+   - the staged file list
 
-   ```bash
-   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-   TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-   HOSTNAME=$(hostname -s 2>/dev/null || echo "unknown")
-   git add -A
-   git commit --no-verify -m "WIP: <first line of IN PROGRESS>
-
-=== HANDOFF ===
-Branch: $BRANCH
-Timestamp: $TIMESTAMP
-From: $HOSTNAME
-
-=== IN PROGRESS ===
-<in-progress content>
-
-=== FILES IN THIS COMMIT ===
-$(git diff --cached --name-only)"
-   git push
-
-   ```text
-
-   Substitute all template values with actual content before executing. If `git push` fails, the commit still exists locally — inform the user to push manually.
+   Substitute all template values with actual content before executing.
 
 4. If the current branch matches `type/NNN-*`, post the handoff comment to the linked issue:
+   - on GitHub repos, prefer `gh issue comment <N>` with the handoff body from step 2
+   - otherwise use the equivalent host-native issue-comment command if available
+   - use stdin or a heredoc rather than relying on plugin helper-script paths
 
-```
+5. Before running `git push`, confirm the user wants the branch published if they
+   have not already approved pushing in this session.
 
-   ```bash
-   cat > /tmp/handoff-comment.md << 'EOF'
-   <issue comment content from step 2>
-   EOF
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <N> --body-file /tmp/handoff-comment.md
-   rm -f /tmp/handoff-comment.md
-   ```
-
-5. Confirm to the user:
+6. Confirm to the user:
    - Branch pushed
    - Issue #N updated with handoff context (if applicable)
    - How to resume: `git pull && /session:resume` on the other machine

--- a/plugins-copilot/session/commands/issue.md
+++ b/plugins-copilot/session/commands/issue.md
@@ -7,39 +7,29 @@ Select an open issue and begin work on it.
 
 ### Steps
 
-1. Fetch open issues:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue list --limit 20 --state open
-   ```
+1. Fetch open issues with native host tooling:
+   - on GitHub repos, prefer `gh issue list --limit 20 --state open --json number,title,labels,milestone,comments,createdAt`
+   - on other hosts, use the equivalent host-native issue command if available
 
 2. **Rank and select.** From the returned JSON array, pick the top 3 by priority:
    - Labels indicating urgency: `critical`, `blocker`, `high-priority`, `bug` rank higher
    - Issues with a milestone set rank higher than those without
-   - More comments → higher priority (community signal)
+   - More comments -> higher priority (community signal)
    - Older issues rank higher than newer (age as proxy for neglect)
 
    Display the top 3 as choices and use AskUserQuestion. Include issue number, title, and labels for each choice.
 
-3. Fetch the full issue:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue show <N>
-   ```
+3. Fetch the full issue details and recent discussion for the selected issue.
 
 4. **Determine branch type** from issue labels:
-   - `bug`, `fix` → `bug/`
-   - `enhancement`, `feature`, `improvement` → `enhancement/`
-   - `docs`, `chore`, `refactor`, `maintenance` → `chore/`
-   - No matching label → `feature/`
+   - `bug`, `fix` -> `bug/`
+   - `enhancement`, `feature`, `improvement` -> `enhancement/`
+   - `docs`, `chore`, `refactor`, `maintenance` -> `chore/`
+   - No matching label -> `feature/`
 
-5. **Create the branch.** Generate a kebab-case slug (3-5 words) from the issue title:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/branch create <type>/<N>-<slug>
-   ```
-
-   Example: issue #42 "Fix login crash on empty password" → `bug/42-fix-login-crash`
+5. **Create the branch.** Generate a kebab-case slug (3-5 words) from the issue title,
+   then create and switch to `<type>/<N>-<slug>` with `git switch -c` (or the
+   equivalent `git checkout -b` fallback on older Git versions).
 
 6. Confirm to the user:
    - Branch created

--- a/plugins-copilot/session/commands/orchestrate.md
+++ b/plugins-copilot/session/commands/orchestrate.md
@@ -20,7 +20,7 @@ The workflow has seven phases. Two have hard user gates (Refine and Execute). Th
 
 Before starting Phase 1, check whether prior phases of this workflow have already run on this branch:
 
-1. Run `bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup` to gather branch state.
+1. Inspect the current repo directly with `git` — extract the current branch, the default branch (`origin/HEAD`, falling back to `main`/`master`), commits ahead of default, uncommitted changes, and whether the branch matches the default with no diverging commits.
 2. Inspect the most recent commit messages and any `wip/`, `feat/`, `enhancement/`, `chore/`, `bug/` branch names for evidence of prior work — recent commits referencing the spec/plan, multiple commits since the default branch, or a checkpoint comment on the linked issue.
 3. If any signal of prior orchestrate work is present, ask via `AskUserQuestion`:
    - **Resume from Plan** — re-use existing exploration, regenerate the plan

--- a/plugins-copilot/session/commands/reset.md
+++ b/plugins-copilot/session/commands/reset.md
@@ -9,16 +9,18 @@ Reset the workspace to a clean state on the default branch. Use this between tas
 
 1. **Check for uncommitted work.** Run `git status --porcelain`. If there are uncommitted changes, warn the user and list the dirty files. Ask for confirmation before continuing — uncommitted work will be lost.
 
-2. **Determine the default branch:**
+2. **Determine the default branch.** Prefer `origin/HEAD` if available:
 
    ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo default-branch
+   git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||'
    ```
+
+   If that fails, fall back to `main` or `master` (whichever exists locally).
 
 3. **Switch to the default branch and update:**
 
    ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/branch default
+   git checkout <default-branch>
    git fetch --prune
    git pull
    ```

--- a/plugins-copilot/session/commands/resume.md
+++ b/plugins-copilot/session/commands/resume.md
@@ -8,32 +8,21 @@ Resume work on an existing in-progress branch.
 ### Steps
 
 1. List active branches (not merged to default):
-
-   ```bash
-   DEFAULT=$(bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo default-branch)
-   git --no-pager branch --no-merged "$DEFAULT" --format '%(refname:short)' 2>/dev/null
-   ```
+   determine the default branch directly from git, then list local branches not
+   yet merged into it.
 
 2. If more than one branch exists, use AskUserQuestion to let the user pick. If only one, proceed with it automatically.
 
 3. Check out the selected branch if not already on it:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/branch switch <branch>
-   ```
+   use `git switch <branch>` (or `git checkout <branch>` on older Git versions).
 
 4. Gather context from multiple sources in parallel:
-
-   ```bash
-   # Full state dump
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup
-   ```
+   - current branch state, commits ahead of default, uncommitted changes, and recent commits
+   - changed files from committed and uncommitted work
 
    **If the branch name matches `type/NNN-*`**, extract the issue number and fetch it:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue show <N>
-   ```
+   - on GitHub repos, prefer `gh issue view <N> --json title,body,state,comments,labels,url`
+   - otherwise use the equivalent host-native issue command if available
 
    **Check for a WIP/handoff commit** — search recent commits for one with `=== IN PROGRESS ===` in the body:
 

--- a/plugins-copilot/session/commands/start.md
+++ b/plugins-copilot/session/commands/start.md
@@ -8,32 +8,22 @@ Generic entry point. Shows available work and lets the user pick what to focus o
 ### Steps
 
 1. Gather current state:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup
-   ```
+   - current branch
+   - default branch
+   - uncommitted changes
+   - recent commits
+   - whether the current branch already maps to a linked issue
 
 2. Collect the two sources of available work:
 
-   **Open issues** (unstarted work):
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue list --limit 20 --state open
-   ```
+   **Open issues** (unstarted work) — on GitHub repos, prefer
+   `gh issue list --limit 20 --state open --json number,title,labels,milestone,comments,createdAt`.
+   Use the equivalent host-native issue command on other platforms when available.
 
    **Active branches** (in-progress work) — branches not yet merged to the default branch, sorted by most recent commit:
-
-   ```bash
-   DEFAULT=$(bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli repo default-branch)
-   # Unmerged branches sorted by most recent commit (top 10)
-   git --no-pager branch --no-merged "$DEFAULT" \
-     --sort=-committerdate \
-     --format '%(refname:short)' 2>/dev/null | head -10
-   # Branch summary counts
-   TOTAL=$(git --no-pager branch --format '%(refname:short)' 2>/dev/null | wc -l | tr -d ' ')
-   MERGED=$(git --no-pager branch --merged "$DEFAULT" --format '%(refname:short)' 2>/dev/null | wc -l | tr -d ' ')
-   UNMERGED=$(git --no-pager branch --no-merged "$DEFAULT" --format '%(refname:short)' 2>/dev/null | wc -l | tr -d ' ')
-   ```
+   - determine the default branch directly from git
+   - list unmerged branches sorted by most recent commit
+   - compute total, merged, and unmerged branch counts
 
 3. **Present the options.** Build a numbered list combining both sources:
    - Issues displayed as: `[issue] #N — <title>` (show at most 10)
@@ -45,11 +35,11 @@ Generic entry point. Shows available work and lets the user pick what to focus o
 
 4. **Act on the selection:**
 
-   - **Issue selected** — follow the `issue` action from step 3 onward (branch creation), skipping the list/pick steps
-   - **Branch selected** — follow the `resume` action from step 2 onward (context extraction), skipping the list/pick step
+   - **Issue selected** — fetch the full issue, choose the branch prefix from labels, create a local branch with `git switch -c`, and continue with the issue context
+   - **Branch selected** — switch to that branch if needed, then follow the `resume` flow from the context-building step onward
    - **Freeform selected** — ask the user to describe the task, then:
-     - Create a `wip/<kebab-slug>` branch: `bash ${COPILOT_PLUGIN_ROOT}/scripts/branch create wip/<slug>`
-     - No issue is linked; proceed with free-form task description as context
+     - Create and switch to a `wip/<kebab-slug>` branch with `git switch -c`
+     - No issue is linked; proceed with the free-form task description as context
 
 5. Confirm the starting context to the user:
    - Branch name (new or existing)

--- a/plugins-copilot/session/hooks/hooks.json
+++ b/plugins-copilot/session/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/plugins-copilot/session/skills/checkpoint/SKILL.md
+++ b/plugins-copilot/session/skills/checkpoint/SKILL.md
@@ -15,10 +15,8 @@ Commits staged/unstaged changes and posts structured context to the linked issue
 ### Steps
 
 1. Gather current state:
-
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/catchup
-   ```
+   inspect the current branch, default branch, recent commits, changed files,
+   and any linked issue directly with `git` and native host tooling.
 
 2. Infer what's in progress and what should come next from conversation context. When auto-triggering, do NOT ask — infer from the conversation. Only use AskUserQuestion if explicitly invoked and progress is genuinely unclear.
 
@@ -41,19 +39,15 @@ Commits staged/unstaged changes and posts structured context to the linked issue
    ```bash
    git add -A
    git commit --no-verify -m "checkpoint: <brief description of progress>"
-   git push
    ```
 
    If there are no changes to commit, skip the commit step but still post the issue comment.
+   Only push if the user explicitly asked to publish the checkpoint or has already
+   approved pushing in this session.
 
 5. If the current branch matches `type/NNN-*`, post the checkpoint as an issue comment:
-
-   ```bash
-   cat > /tmp/checkpoint-comment.md << 'EOF'
-   <checkpoint content from step 3>
-   EOF
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/git-cli issue comment <N> --body-file /tmp/checkpoint-comment.md
-   rm -f /tmp/checkpoint-comment.md
-   ```
+   - on GitHub repos, prefer `gh issue comment <N>` with the body from step 3
+   - otherwise use the equivalent host-native issue-comment command if available
+   - use stdin or a heredoc rather than relying on plugin helper-script paths
 
 6. Briefly confirm: checkpoint committed and (if applicable) posted to issue #N. When auto-triggering, keep to one line. When user-invoked, mention `/session:resume` to continue from this point.

--- a/plugins-copilot/session/skills/summarize/SKILL.md
+++ b/plugins-copilot/session/skills/summarize/SKILL.md
@@ -2,27 +2,28 @@
 user-invocable: false
 name: summarize
 description: >-
-  Summarize the current repo state. Triggers on "what was I working on?",
-  "session status", "catch me up", or when returning to active work.
-  Returns a paragraph plus categorized file/detail bullets.
+  Summarize the current repo situation using a tiered context-aware snapshot
+  and return a paragraph + categorized file/detail bullets.
 allowed-tools: Task, Bash, Read
 ---
 
 # Summarize
 
-Use one script call as the source of truth, then summarize with an agent.
+Use one direct git snapshot as the source of truth, then summarize with an agent.
 
 ## Steps
 
-1. Run:
+1. Gather one direct repo snapshot with `git`:
+   - whether this is a git repository
+   - current branch and default branch
+   - clean/dirty state
+   - recent commits
+   - committed, staged, unstaged, and untracked file lists
+   - diff stats or short summaries for each change bucket
 
-   ```bash
-   bash ${COPILOT_PLUGIN_ROOT}/scripts/sitrep
-   ```
+2. If the snapshot shows this is not a git repository, report that a summary cannot be generated outside a git repository.
 
-2. If output says `is_git_repo: false`, report that a summary cannot be generated outside a git repository.
-
-3. Otherwise, invoke the Task tool (`agent_type: general-purpose`) and provide only this script output as input context.
+3. Otherwise, invoke the Task tool (`agent_type: general-purpose`) and provide only this snapshot as input context.
 
 4. Return exactly this structure:
 
@@ -43,7 +44,7 @@ Use one script call as the source of truth, then summarize with an agent.
 
 ## Rules
 
-- Trust script sections as authoritative (do not run extra git commands unless script fails).
+- Trust the initial snapshot as authoritative (do not keep running extra git commands once it is collected).
 - Include committed + staged + unstaged + untracked file changes when present.
 - Group files under 2-5 major categories (examples: "New functionality", "Refactors", "Fixes", "Docs/metadata").
-- If output shows `clean: true` with no active branches, return only a short paragraph and no bullet list.
+- If the snapshot shows a clean repo with no relevant in-flight work, return only a short paragraph and no bullet list.

--- a/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/stl-game-config/hooks/hooks.json
+++ b/plugins-copilot/stl-game-config/hooks/hooks.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
-  "hooks": {
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-      }
-    ]
-  }
+  "hooks": [
+    {
+      "type": "command",
+      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
+      "event": "preToolUse"
+    }
+  ]
 }

--- a/tests/git-worktree/test-command-docs.sh
+++ b/tests/git-worktree/test-command-docs.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# test-command-docs.sh — Checks that Copilot-facing git-worktree docs avoid
+# relying on COPILOT_PLUGIN_ROOT inside Bash examples and describe the direct
+# git worktree flows the agent should use.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$SCRIPT_DIR/../../plugins-copilot/git-worktree"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle" 2>/dev/null; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s (missing: %s)\n" "$label" "$needle"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! echo "$haystack" | grep -qF "$needle" 2>/dev/null; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s (unexpected: %s)\n" "$label" "$needle"
+    ((FAIL++)) || true
+  fi
+}
+
+echo "── skill docs avoid plugin-root bash paths ──"
+
+LIST_DOC=$(cat "$PLUGIN_DIR/skills/worktree-list/SKILL.md")
+CREATE_DOC=$(cat "$PLUGIN_DIR/skills/worktree-create/SKILL.md")
+REMOVE_DOC=$(cat "$PLUGIN_DIR/skills/worktree-remove/SKILL.md")
+PARALLEL_DOC=$(cat "$PLUGIN_DIR/skills/worktree-parallel-work/SKILL.md")
+
+assert_not_contains "worktree-list skill avoids COPILOT_PLUGIN_ROOT" '${COPILOT_PLUGIN_ROOT}' "$LIST_DOC"
+assert_not_contains "worktree-create skill avoids COPILOT_PLUGIN_ROOT" '${COPILOT_PLUGIN_ROOT}' "$CREATE_DOC"
+assert_not_contains "worktree-remove skill avoids COPILOT_PLUGIN_ROOT" '${COPILOT_PLUGIN_ROOT}' "$REMOVE_DOC"
+assert_not_contains "worktree-parallel-work skill avoids COPILOT_PLUGIN_ROOT" '${COPILOT_PLUGIN_ROOT}' "$PARALLEL_DOC"
+
+echo "── skill docs describe direct git worktree flows ──"
+
+assert_contains "worktree-list skill uses git worktree list" 'git worktree list --porcelain' "$LIST_DOC"
+assert_contains "worktree-create skill uses git worktree add" 'git worktree add <path>' "$CREATE_DOC"
+assert_contains "worktree-create skill derives repo root" 'git rev-parse --show-toplevel' "$CREATE_DOC"
+assert_contains "worktree-remove skill uses git worktree remove" 'git worktree remove <path>' "$REMOVE_DOC"
+assert_contains "worktree-remove skill uses git worktree list" 'git worktree list --porcelain' "$REMOVE_DOC"
+assert_contains "worktree-parallel-work skill points at create flow" 'git worktree add' "$PARALLEL_DOC"
+assert_contains "worktree-parallel-work skill points at remove flow" 'git worktree remove' "$PARALLEL_DOC"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+printf "  \033[32m%d passed\033[0m" "$PASS"
+if [[ $FAIL -gt 0 ]]; then
+  printf "  \033[31m%d failed\033[0m" "$FAIL"
+fi
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Re-applies the empirically-validated Copilot CLI compatibility fixes from `chore/copilot-plugin-compatibility-pass` (originally authored in a Copilot CLI session), adapted to current master and extended to cover plugins that didn't exist on the original branch.

The motivating constraint: `${COPILOT_PLUGIN_ROOT}` is **not** reliably substituted inside Bash tool invocations from Copilot command/skill markdown. The original branch verified this in a live Copilot session.

## Changes by category

### Copilot docs policy (26 files)
- Strip `${COPILOT_PLUGIN_ROOT}` from every Copilot command/skill markdown
- Replace plugin-script invocations with direct git/`gh` flows (or honest "use the plugin's normal flow" prose where no native equivalent exists)
- Covers: convert-doc, elevated-edit, format-on-save, git-tools (ship/git-cli), git-worktree (worktree-create/list/remove/parallel-work), image, java-toolkit (java-toolkit, jar-explore, setup), kb-capture, markdown, notify-on-stop, permission-manager, session (8 commands + 2 skills), session-history-analyzer, stl-game-config

### Copilot hooks normalization (13 files)
- Convert `{event: [...]}` object form to `[{event, ...}]` flat array form
- Matches java-toolkit's existing shape and the documented Copilot format

### Real bug fixes
- `plugins-claude/java-toolkit/hooks/hooks.json` — wrap entry in `{matcher, hooks:[{type, command}]}`; master had the broken top-level `{command, when}` form
- `plugins-copilot/java-toolkit/docker-compose.yml` — add missing symlink (plugin was non-functional on Copilot side without it)
- `plugins-copilot/git-worktree/` — add `approve-own-scripts.sh` hook + script symlink

### Validator tightening
- New checks: marketplace coverage, wrapped Claude hook shape, flat-array Copilot hook shape, Copilot docs banned from referencing `${COPILOT_PLUGIN_ROOT}`, script auto-approval registered, docker-compose assets co-located
- New test: `tests/git-worktree/test-command-docs.sh` (11 assertions)

### Marketplace polish
- `format-on-save` description: `rustfmt` → `cargo fmt, taplo, ruff` (both catalogs)
- `notify-on-stop` description: expand env var + platform list (both catalogs)
- `session-history-analyzer` Copilot description: "Claude Code" → "Copilot CLI"

### Version bumps
- 13 plugins bumped by patch on both Claude and Copilot sides (lockstep maintained)

## Test plan

- [x] `bash test.sh` — 1545 passed, 0 failed
- [x] `bash .github/scripts/validate-plugins.sh` — 276 checks, 0 failures (with tightened rules in effect)
- [x] `bash .github/scripts/validate-frontmatter.sh` — 105 checks, 0 failures
- [x] `rumdl check .` — 0 issues in 84 files
- [x] `bash tests/git-worktree/test-command-docs.sh` — 11 passed

## Notes

- The original branch `chore/copilot-plugin-compatibility-pass` is now obsolete and can be deleted after this lands.
- Some retired plugins on the original branch (frontmatter-query, jar-explore, maven-indexer, maven-toolkit, maven-tools, git-cli) were skipped — they no longer exist on master.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>