### PR TITLE
feat(stl-game-config): delegate game research to a subagent

### DIFF
--- a/plugins-claude/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-claude/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/stl-game-config/README.md
+++ b/plugins-claude/stl-game-config/README.md
@@ -21,7 +21,7 @@ Invoke via: `/stl-game-config` or let the skill trigger automatically when you a
 
 1. **Gets game info** - Game name, any specific issues
 2. **Detects system** - Runs `system-info.sh` to gather GPU, compositor, HDR, API data
-3. **Researches game** - ProtonDB, PCGamingWiki for AppID, API, RT/DLSS/HDR support
+3. **Researches game** - dispatches a read-only research subagent against ProtonDB and PCGamingWiki for AppID, API, RT/DLSS/HDR support; the agent reports only the key findings back, keeping raw page content out of the main session
 4. **Selects templates** - Chooses base + GPU + compositor + API templates based on detection
 5. **Creates config** - Writes per-game STL configuration files (gamecfgs/id/{APPID}.conf)
 6. **Verifies** - Confirms config exists and provides testing/MangoHud verification guidance

--- a/plugins-claude/stl-game-config/skills/stl-game-config/SKILL.md
+++ b/plugins-claude/stl-game-config/skills/stl-game-config/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: stl-game-config
 description: Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration. Detects GPU vendor (NVIDIA/AMD/Intel), compositor (KDE/Wayland), HDR capability, and graphics API to generate optimal Proton/DXVK/VKD3D settings. Handles modern DX12/RT games and retro DX9 titles.
-allowed-tools: Read, Grep, Glob, Bash, Edit, Write, WebFetch, WebSearch
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Agent
 ---
 
 # STL Game Config Skill
@@ -29,7 +29,7 @@ Configure Steam games for optimal performance on Linux using SteamTinkerLaunch w
 **Tools by step:**
 
 - **System Detection**: Bash (system-info.sh script)
-- **Game Research**: WebFetch (ProtonDB, PCGamingWiki), Grep/Glob (knowledge base)
+- **Game Research**: Agent (dispatch a research subagent — see Step 3; the parent does **not** fetch web pages directly)
 - **Template Generation**: Bash (generate-stl-config.sh script)
 - **Verification**: Bash (file checks), Read (logs)
 
@@ -51,11 +51,15 @@ Parse the JSON output to determine:
 - Compositor (kde/gnome/other)
 - KDE HDR enabled status
 
-### Step 3: Research Game
+### Step 3: Research Game (agentic — delegate, don't fetch inline)
 
-Gather all required data before configuration:
+**Do this research in a subagent, not the parent session.** ProtonDB and PCGamingWiki pages are long and noisy; fetching them inline floods the main context with content you don't need. Dispatch a research subagent via the `Agent` tool, have it do all the web work, and have it return **only the structured findings** below — never the raw page text.
 
-**Data points to collect:**
+**Dispatch:** `Agent` tool with `subagent_type: research` (read-only; falls back to `general-purpose` if `research` is unavailable). For a single game one agent is enough; if researching several games at once, dispatch one agent per game in a single message so they run in parallel.
+
+**The agent's prompt MUST include** the game name, the data points to collect, the source URLs, and an explicit instruction: *"Report only the structured summary below. Do not paste raw page content, comment threads, or full review text into your reply — distill to the key details only."*
+
+**Data points the agent collects:**
 
 | Data | Primary Source | Fallback |
 |------|----------------|----------|
@@ -65,7 +69,7 @@ Gather all required data before configuration:
 | Linux issues | ProtonDB reports | - |
 | Existing config | personal game-notes KB (if any) | Create new |
 
-**Web research workflow:**
+**Research workflow the agent follows:**
 
 1. **Find App ID**: Extract from Steam store URL or search SteamDB
 2. **ProtonDB** (`https://www.protondb.com/app/{APPID}`):
@@ -77,8 +81,9 @@ Gather all required data before configuration:
    - Ray tracing support and type
    - Known Linux/Proton issues
 4. **Knowledge base** (optional): if you keep game notes, glob your KB for `*{game-name}*.md`
+5. **Anti-cheat**: if ProtonDB mentions EAC/BattlEye issues, check [areweanticheatyet.com](https://areweanticheatyet.com/) — some games require developer opt-in for Linux support.
 
-**Anti-cheat note:** If ProtonDB mentions EAC/BattlEye issues, check [areweanticheatyet.com](https://areweanticheatyet.com/) - some games require developer opt-in for Linux support.
+**What the agent returns to the parent** — just the filled-in findings block (App ID, graphics API, RT/DLSS/HDR support, ProtonDB rating, top issues, recommended Proton version, anti-cheat status). The parent uses that summary for Steps 4–5; it should never need to read a fetched page itself.
 
 ### Step 4: Present Findings
 

--- a/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

Makes the `stl-game-config` research stage **agentic**. Previously ProtonDB / PCGamingWiki pages were fetched directly into the parent session via `WebFetch`, flooding the main context with long, noisy page content. Now the research is delegated to a read-only subagent that returns only the structured findings the parent needs for template selection.

- **Step 3 rewritten** to dispatch `subagent_type: research` (fallback `general-purpose`) with an explicit instruction to report only the key details — App ID, graphics API, RT/DLSS/HDR support, ProtonDB rating, top issues, recommended Proton version, anti-cheat status — never raw page text.
- **`allowed-tools`**: dropped `WebFetch, WebSearch`, added `Agent`. The parent can no longer fetch pages itself, structurally forcing delegation.
- Note parallel dispatch when researching multiple games at once.
- **README** step 3 updated to describe the agentic flow.
- Version bump `1.0.3` → `1.1.0` on both the Claude and Copilot variants.

## Test plan

- [x] `bash .github/scripts/validate-plugins.sh` — 276 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 105 checks, 0 failures
- [x] `rumdl check` on edited SKILL.md + README.md — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)