### PR TITLE
fix(permission-manager): ask instead of deny on push to protected branch

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/classifiers/git.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/git.sh
@@ -146,7 +146,7 @@ extract_checkout_target() {
   done
 }
 
-# Classify git push: deny if targeting a protected branch.
+# Classify git push: ask before pushing to a protected branch.
 check_git_push() {
   local -a args=("$@")
   local has_force=false
@@ -185,7 +185,7 @@ check_git_push() {
       target="$refspec"
     fi
     if is_protected_branch "$target"; then
-      deny "git push to protected branch ($target) is not allowed"
+      ask "git push to protected branch ($target) — confirm this is intentional"
       return 0
     fi
   done

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -161,12 +161,15 @@ run_test_both allow "git add ." "git add stages files"
 run_test_both allow "git branch -d old-branch" "git branch -d non-protected"
 run_test_both allow "git branch -D old-branch" "git branch -D non-protected"
 
-# ===== DENY: git push to protected branches =====
-echo "── Git push to protected branches (denied) ──"
-run_test_both deny "git push origin main" "git push to main"
-run_test_both deny "git push origin master" "git push to master"
-run_test_both deny "git push origin HEAD:main" "git push refspec to main"
-run_test_both deny "git push origin feature:master" "git push refspec to master"
+# ===== ASK: git push to protected branches =====
+echo "── Git push to protected branches (ask) ──"
+run_test_both ask "git push origin main" "git push to main"
+run_test_both ask "git push origin master" "git push to master"
+run_test_both ask "git push origin HEAD:main" "git push refspec to main"
+run_test_both ask "git push origin feature:master" "git push refspec to master"
+
+# ===== DENY: git branch write operations on protected branches =====
+echo "── Git branch ops on protected branches (denied) ──"
 run_test_both deny "git branch -d main" "git branch -d main"
 run_test_both deny "git branch -D master" "git branch -D master"
 run_test_both deny "git branch -m old-name main" "git branch -m to main"
@@ -1334,9 +1337,11 @@ echo "── Compound with branch workflow ──"
 run_test_both allow "git status && git push" "compound: read + push (current branch)"
 run_test_both allow "git add . && git commit -m 'fix'" "compound: add + commit"
 
-# ===== DENY: compound with protected branch =====
-echo "── Compound with protected branch ──"
-run_test_both deny "git status && git push origin main" "compound: read + push main"
+# ===== ASK: compound with protected-branch push =====
+echo "── Compound with protected-branch push ──"
+run_test_both ask "git status && git push origin main" "compound: read + push main"
+# A compound containing a still-denied segment stays denied (most-restrictive wins)
+run_test_both deny "git status && git branch -D main" "compound: read + delete protected branch"
 
 # ===== ALLOW: compound with local build segment =====
 echo "── Compound with local build segment ──"


### PR DESCRIPTION
## Summary

The Bash classifier issued a hard `deny` on any `git push` to `main`/`master`, an absolute block with no override. On repos without branch protection — where pushing to master is perfectly fine — this is obnoxious and unworkable.

This downgrades the protected-branch push from `deny` to `ask`, so the hook passes through to the client's own permission prompt. The user stays in the loop on every protected-branch push but can approve on the spot rather than being walled off.

No detection logic, no per-repo config — just the behavior swap.

### Changes
- `scripts/classifiers/git.sh` — `check_git_push`: `deny` → `ask` for protected-branch push targets
- `tests/permission-manager/test-classify.sh` — push + compound cases flipped `deny` → `ask`; added a `git branch -D main` compound case to preserve most-restrictive-wins coverage
- Left the hard `deny` on `git branch -d/-D/-m` of protected branches intact (destructive, out of scope)
- Bumped `permission-manager` `2.15.1` → `2.15.2` (claude + copilot manifests)

## Test plan
- `bash tests/permission-manager/test-classify.sh` → **1162 passed**
- `bash .github/scripts/validate-plugins.sh` → **276 checks, 0 failures**, no util drift