### PR TITLE
fix(git-tools): use plural --labels/--assignees for tea

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -332,7 +332,7 @@ case "$cmd:$sub" in
         args=(--output json --limit "$limit" --state "$state"
               --fields "index,title,body,state,labels,milestone,comments,created,updated,assignees,url")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        [[ -n "$label"    ]] && args+=(--label "$label")
+        [[ -n "$label"    ]] && args+=(--labels "$label")
         cli_json '[.[] | {number: (.index | tonumber? // .index), title, body: (.body // ""), state, author: (.author // ""), labels: (if .labels and (.labels | type) == "array" then [.labels[].name] elif .labels and (.labels | type) == "string" and .labels != "" then [.labels] else [] end), milestone: (.milestone // null), assignees: (if .assignees and (.assignees | type) == "array" then [.assignees[].login] elif .assignees and (.assignees | type) == "string" and .assignees != "" then [.assignees] else [] end), created_at: (.created // ""), updated_at: (.updated // null), url: (.url // "")}]' \
           env NO_COLOR=1 tea issues list "${args[@]}"
         ;;
@@ -381,8 +381,8 @@ case "$cmd:$sub" in
       gitea)
         args=(--title "$title")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
-        [[ -n "$label"    ]] && args+=(--label "$label")
-        [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
+        [[ -n "$label"    ]] && args+=(--labels "$label")
+        [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
         NO_COLOR=1 tea issues create "${args[@]}"
         ;;
     esac

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Work session management — start, end, checkpoint, handoff, resume, issue, reset, orchestrate, plus a model-triggered summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -332,7 +332,7 @@ case "$cmd:$sub" in
         args=(--output json --limit "$limit" --state "$state"
               --fields "index,title,body,state,labels,milestone,comments,created,updated,assignees,url")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        [[ -n "$label"    ]] && args+=(--label "$label")
+        [[ -n "$label"    ]] && args+=(--labels "$label")
         cli_json '[.[] | {number: (.index | tonumber? // .index), title, body: (.body // ""), state, author: (.author // ""), labels: (if .labels and (.labels | type) == "array" then [.labels[].name] elif .labels and (.labels | type) == "string" and .labels != "" then [.labels] else [] end), milestone: (.milestone // null), assignees: (if .assignees and (.assignees | type) == "array" then [.assignees[].login] elif .assignees and (.assignees | type) == "string" and .assignees != "" then [.assignees] else [] end), created_at: (.created // ""), updated_at: (.updated // null), url: (.url // "")}]' \
           env NO_COLOR=1 tea issues list "${args[@]}"
         ;;
@@ -381,8 +381,8 @@ case "$cmd:$sub" in
       gitea)
         args=(--title "$title")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
-        [[ -n "$label"    ]] && args+=(--label "$label")
-        [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
+        [[ -n "$label"    ]] && args+=(--labels "$label")
+        [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
         NO_COLOR=1 tea issues create "${args[@]}"
         ;;
     esac

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Work session management — start, end, checkpoint, handoff, resume, issue, reset, orchestrate, plus a model-triggered summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -332,7 +332,7 @@ case "$cmd:$sub" in
         args=(--output json --limit "$limit" --state "$state"
               --fields "index,title,body,state,labels,milestone,comments,created,updated,assignees,url")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        [[ -n "$label"    ]] && args+=(--label "$label")
+        [[ -n "$label"    ]] && args+=(--labels "$label")
         cli_json '[.[] | {number: (.index | tonumber? // .index), title, body: (.body // ""), state, author: (.author // ""), labels: (if .labels and (.labels | type) == "array" then [.labels[].name] elif .labels and (.labels | type) == "string" and .labels != "" then [.labels] else [] end), milestone: (.milestone // null), assignees: (if .assignees and (.assignees | type) == "array" then [.assignees[].login] elif .assignees and (.assignees | type) == "string" and .assignees != "" then [.assignees] else [] end), created_at: (.created // ""), updated_at: (.updated // null), url: (.url // "")}]' \
           env NO_COLOR=1 tea issues list "${args[@]}"
         ;;
@@ -381,8 +381,8 @@ case "$cmd:$sub" in
       gitea)
         args=(--title "$title")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
-        [[ -n "$label"    ]] && args+=(--label "$label")
-        [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
+        [[ -n "$label"    ]] && args+=(--labels "$label")
+        [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
         NO_COLOR=1 tea issues create "${args[@]}"
         ;;
     esac


### PR DESCRIPTION
## Summary

`tea` uses `--labels` (plural) and, for create commands, `--assignees` (plural). The git-cli wrapper was passing the singular `--label`/`--assignee` in the gitea branches, so `tea` rejected the flag and aborted. `gh` keeps the singular form, so those branches are unchanged.

- `issue list` (gitea): `--label` → `--labels`
- `issue create` (gitea): `--label` → `--labels`, `--assignee` → `--assignees`
- Bump `git-tools` to 2.0.7 and `session` to 3.10.2 (both vendor `git-cli`)

## Test plan

- [x] `bash utils/sync.sh --check` — no drift
- [x] `bash .github/scripts/validate-plugins.sh` — 276 checks, 0 failures
- [ ] Manually invoke `git-cli issue list --label foo` against a Gitea remote and confirm it no longer errors on the flag