### PR TITLE
fix(elevated-edit): detect bare host:path as remote in file-bridge

### DIFF
--- a/plugins-claude/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-claude/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/elevated-edit/scripts/file-bridge
+++ b/plugins-claude/elevated-edit/scripts/file-bridge
@@ -31,15 +31,17 @@ check_deps() {
   fi
 }
 
-# Parse user@host:path into REMOTE_HOST and REMOTE_PATH
-# Sets IS_REMOTE=true if remote, false otherwise
+# Parse [user@]host:path into REMOTE_HOST and REMOTE_PATH
+# Sets IS_REMOTE=true if remote, false otherwise.
+# Matches scp/rsync semantics: a colon makes it remote unless the segment
+# before the first colon contains a slash (i.e. it's a local path).
 parse_source() {
   local src="$1"
   IS_REMOTE=false
   REMOTE_HOST=""
   REMOTE_PATH=""
 
-  if [[ "$src" == *@*:* ]]; then
+  if [[ "$src" == *:* && "${src%%:*}" != */* ]]; then
     IS_REMOTE=true
     REMOTE_HOST="${src%%:*}"
     REMOTE_PATH="${src#*:}"
@@ -501,4 +503,7 @@ main() {
   esac
 }
 
-main "$@"
+# Only run main when executed directly, so the script can be sourced for tests.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/tests/elevated-edit/test-file-bridge-parse.sh
+++ b/tests/elevated-edit/test-file-bridge-parse.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# test-file-bridge-parse.sh — assertions for parse_source() in file-bridge.
+# Covers ssh-alias detection (bare host:path), explicit user@host:path,
+# absolute/relative/tilde local paths, and the colon-without-slash ambiguity.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../../plugins-claude/elevated-edit/scripts/file-bridge"
+
+# Source the script — its main guard prevents auto-execution.
+# shellcheck source=/dev/null
+source "$SCRIPT"
+
+PASS=0
+FAIL=0
+
+assert_parse() {
+  local label="$1" input="$2" want_remote="$3" want_host="$4" want_path="$5"
+
+  parse_source "$input"
+
+  if [[ "$IS_REMOTE" == "$want_remote" && "$REMOTE_HOST" == "$want_host" && "$REMOTE_PATH" == "$want_path" ]]; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s\n" "$label"
+    printf "      input:  %s\n" "$input"
+    printf "      want:   IS_REMOTE=%s REMOTE_HOST=%q REMOTE_PATH=%q\n" "$want_remote" "$want_host" "$want_path"
+    printf "      got:    IS_REMOTE=%s REMOTE_HOST=%q REMOTE_PATH=%q\n" "$IS_REMOTE" "$REMOTE_HOST" "$REMOTE_PATH"
+    ((FAIL++)) || true
+  fi
+}
+
+echo "── parse_source: remote forms ──"
+assert_parse "bare host:path (ssh alias, the bug fix)" \
+  "apollo:/etc/hosts" true "apollo" "/etc/hosts"
+assert_parse "user@host:path (explicit user)" \
+  "root@apollo:/etc/hosts" true "root@apollo" "/etc/hosts"
+assert_parse "host:path with relative remote path" \
+  "apollo:relative/file" true "apollo" "relative/file"
+assert_parse "user@host:path with tilde-relative remote" \
+  "logan@apollo:~/.bashrc" true "logan@apollo" "~/.bashrc"
+
+echo "── parse_source: local forms ──"
+assert_parse "absolute local path" \
+  "/etc/hosts" false "" "/etc/hosts"
+assert_parse "relative local path with ./" \
+  "./relative/file" false "" "./relative/file"
+assert_parse "plain relative local path" \
+  "file.txt" false "" "file.txt"
+assert_parse "tilde local path expands" \
+  "~/file" false "" "$HOME/file"
+assert_parse "absolute path containing a colon" \
+  "/tmp/weird:name" false "" "/tmp/weird:name"
+
+echo "── parse_source: documented limitation ──"
+# scp/rsync convention: a relative path with a colon before the first '/'
+# is treated as remote. Users with such filenames must prefix './'.
+assert_parse "ambiguous 'weird:name' parses as remote (scp semantics)" \
+  "weird:name/file" true "weird" "name/file"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+exit $((FAIL > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary

- `file-bridge` `parse_source()` now matches ssh-config host aliases without an explicit `user@` (e.g. `apollo:/etc/hosts`). Detection follows scp/rsync semantics: remote when the source contains `:` and the segment before the first `:` has no `/`.
- Adds a `main` guard so the script can be sourced for tests without auto-running.
- New `tests/elevated-edit/test-file-bridge-parse.sh` (10 cases) covers bare host, `user@host`, absolute/relative/tilde local paths, and the documented colon ambiguity.
- Patch bumps both `elevated-edit` plugin manifests to `0.1.6`.

Fixes #101

## Test plan

- [x] `bash tests/elevated-edit/test-file-bridge-parse.sh` — 10/10 pass
- [x] `bash test.sh` — 1557 tests, 20 suites, 0 failures
- [x] `bash .github/scripts/validate-plugins.sh` — 276 checks, 0 failures (version sync ✓)
- [x] `bash .github/scripts/validate-frontmatter.sh` — 105 checks, 0 failures
- [x] `rumdl check .` — clean