### PR TITLE
docs(git-tools): trim git-cli skill description

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-tools/skills/git-cli/SKILL.md
@@ -11,117 +11,35 @@ allowed-tools: Bash
 
 # git-cli
 
-**CRITICAL: Never run `gh` or `tea` directly.** Always use the wrapper script below.
-The current repository may use GitHub or Gitea — the wrapper auto-detects the platform
-from the git remote so the correct CLI is used every time. Running `gh` directly will
-fail on Gitea repositories and vice versa.
+**Always invoke `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli`. Never run `gh` or `tea` directly** — the current repo may use either and the wrapper auto-detects from the git remote. Raw `gh` against a Gitea repo (and vice versa) will hit the wrong API.
 
-## When to use this skill
+## Command reference
 
-- File a bug or enhancement issue discovered mid-session
-- Check open issues to understand what work is planned or in progress
-- Post a progress comment on a linked issue
-- Check CI run status or fetch logs for a failing build
-- Inspect the current state of a pull request
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli --help` for the full subcommand list (`issue`, `pr`, `run`, `repo`, `user`) and per-command flags. A few non-obvious ones worth knowing:
 
-## Available commands
+- `pr show --branch NAME` — resolve the most-recent PR for a branch.
+- `pr wait --branch NAME` — poll until merged/closed/blocked (default 300s). **Use this instead of writing your own poll loop.**
+- `run watch --branch NAME` — poll CI to pass/fail/timeout with proper terminal-state detection. **Use this instead of writing your own poll loop.**
+- `run show <id>` — aggregates per-job status on Gitea so failed jobs don't get masked by a run-level success (#87).
 
-### Issues
+## Body input
+
+`--body` reads from stdin (heredoc or pipe). No temp files, no `--body TEXT` form:
 
 ```bash
-# List open issues (returns normalized JSON array)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue list [--limit N] [--state open|closed|all] [--label LABEL] [--assignee USER]
-
-# Show a single issue with full body and comments
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue show <number>
-
-# Create an issue (pipe body to --body via heredoc)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Title" --body [--label bug] <<'EOF'
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body <<'EOF'
 ## Problem
 ...
 EOF
 
-# Add a comment (heredoc for multi-line, printf for short)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body <<'EOF'
-Progress update...
-EOF
-printf 'LGTM' | ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue comment <number> --body
-
-# Close or reopen
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue close <number>
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue reopen <number>
+printf 'LGTM' | ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment 42 --body
 ```
 
-### Pull Requests
+`--body-file FILE` is also available (`--body-file -` is equivalent to `--body`).
 
-```bash
-# List PRs
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr list [--state open|closed|merged|all] [--limit N]
+## Normalized JSON output
 
-# Show a single PR with details — by number, or by branch name
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show <number>
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show --branch <branch>      # resolves to most-recent PR for that branch
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr show --branch "$(git rev-parse --abbrev-ref HEAD)"
-
-# Create a PR (auto-assigns to current user; --base defaults to repo's primary branch)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "Title" --head branch [--base main] --body <<'EOF'
-## Summary
-...
-
-## Test plan
-...
-EOF
-
-# Comment on a PR
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment <number> --body <<'EOF'
-Review follow-up...
-EOF
-
-# Merge or close
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr merge <number> [--squash | --rebase]
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr close <number>
-
-# Wait for a PR to merge (polls until merged, closed, or timeout)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr wait --branch NAME [--timeout 300] [--interval 15]
-```
-
-### CI Runs
-
-```bash
-# List recent runs (JSON with id, status, workflow, branch, event, started_at)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run list [--limit N] [--status failure|success|pending] [--branch BRANCH]
-
-# Show details of a specific run
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run show <run-id>
-
-# Fetch logs (--failed-only shows only failing steps on GitHub)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run logs <run-id>
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run logs <run-id> --failed-only
-
-# Watch for CI completion (polls until pass/fail/timeout)
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run watch --branch NAME [--initial-delay S] [--timeout S] [--interval S]
-# Outputs: status (pass|fail|closed|timeout|no-workflow), url, duration
-# On fail: also emits failed_jobs: <comma-separated names> and dumps failed job logs to stderr
-# Cancelled/skipped runs report status: fail with a reason: line so callers
-# gating on status: pass stop instead of advancing.
-# Per-job status is aggregated on both gh and tea — a run-level "success" with
-# any failed job still yields status: fail (Gitea masks job failures behind a
-# run-level success, see issue #87).
-# On GitHub with a PR: uses statusCheckRollup for reliable CI + merge state detection
-# Without a PR: falls back to run list polling
-```
-
-### Repo / User
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo default-branch   # e.g. "main" or "master"
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo info             # name, description, stars, etc.
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli user whoami           # {"login": "username"}
-```
-
-## Output format
-
-All commands return JSON. Issue and PR objects use a normalized schema:
+All commands return JSON with a consistent schema across platforms. Issue/PR objects use:
 
 ```json
 {
@@ -130,30 +48,13 @@ All commands return JSON. Issue and PR objects use a normalized schema:
   "body": "...",
   "state": "open",
   "author": "username",
-  "labels": ["bug", "high-priority"],
-  "milestone": null,
+  "labels": ["bug"],
   "assignees": ["username"],
+  "milestone": null,
   "created_at": "2026-01-01T00:00:00Z",
   "updated_at": "2026-01-01T00:00:00Z",
   "url": "https://..."
 }
 ```
 
-## Writing issue/PR bodies
-
-Pipe the body to `--body` via a heredoc. No temp file, no cleanup:
-
-```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body <<'EOF'
-## Problem
-...
-
-## Steps to reproduce
-...
-EOF
-```
-
-`--body-file FILE` remains available when the body is already on disk, and
-`--body-file -` is equivalent to `--body` (reads stdin). There is no
-`--body TEXT` form — stdin handles every size from one-liners to full PR
-descriptions.
+Downstream skills (e.g. `session/*`) depend on this shape — don't bypass the wrapper just to get raw `gh`/`tea` output.

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

- Shrinks `plugins-claude/git-tools/skills/git-cli/SKILL.md` from 5.4 KB / 160 lines to 2.2 KB / 60 lines (~60% reduction in always-loaded skill description budget).
- Per-subcommand bash examples now live in `git-cli --help`; the SKILL.md keeps only what's not discoverable from `--help`:
  - the never-call-raw-`gh`/`tea` directive (the skill's reason to exist)
  - four non-obvious commands worth naming (`pr show --branch`, `pr wait`, `run watch`, `run show`) with explicit "use this instead of writing your own poll loop" nudges
  - the stdin-only `--body` idiom (no `--body TEXT` form — wrapper-specific)
  - the normalized JSON schema that downstream `session/*` skills depend on
- The script (1271 lines), `ship` orchestrator, and Copilot-side SKILL (already a raw-`gh` recipe) are untouched.
- Plugin version bumped 2.0.7 → 2.0.8 on both Claude and Copilot sides per project convention.

## Test plan

- [x] `bash .github/scripts/validate-plugins.sh` — 276/276 ✓
- [x] `bash .github/scripts/validate-frontmatter.sh` — 105/105 ✓
- [x] `rumdl check plugins-claude/git-tools/skills/git-cli/SKILL.md` — clean
- [x] Vendored utils drift check — passes (no script changes)