### PR TITLE
fix(git-tools): correlate Gitea run-watch by head_branch

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -728,11 +728,37 @@ case "$cmd:$sub" in
           env GH_NO_COLOR=1 gh run list "${args[@]}"
         ;;
       gitea)
-        args=(--output json --limit "$limit")
-        [[ -n "$status" ]] && args+=(--status "$status")
-        [[ -n "$branch" ]] && args+=(--branch "$branch")
-        cli_json '[.[] | {id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}]' \
-          env NO_COLOR=1 tea actions runs list "${args[@]}"
+        # Source from Gitea REST API directly. `tea actions runs list`
+        # filters server-side by a `branch` column that Gitea leaves empty
+        # on `pull_request` runs, so the watcher's --branch lookup misses
+        # correlated runs (#103). Fetch unfiltered via `tea api`, normalize
+        # `branch` from `head_branch`, and apply --branch client-side.
+        query="limit=$limit"
+        [[ -n "$status" ]] && query+="&status=$status"
+        raw_stderr=$(mktemp); raw_rc=0
+        raw=$(NO_COLOR=1 tea api "repos/{owner}/{repo}/actions/runs?$query" 2>"$raw_stderr") \
+          || raw_rc=$?
+        if [[ $raw_rc -ne 0 ]]; then
+          err=$(cat "$raw_stderr"); rm -f "$raw_stderr"
+          die "tea api repos/{owner}/{repo}/actions/runs failed: $err"
+        fi
+        rm -f "$raw_stderr"
+        echo "$raw" | jq --arg b "$branch" '
+          [(.workflow_runs // []) | .[] | {
+            id:         (.id | tostring),
+            status:     (if (.conclusion // "") != "" then (.conclusion | ascii_downcase)
+                         elif .status == "completed" then "success"
+                         else (.status // "unknown" | ascii_downcase) end),
+            workflow:   (.name // .workflow_id // ""),
+            branch:     (((.head_branch // "") | select(. != "")) // (.branch // "")),
+            head_sha:   (.head_sha // ""),
+            event:      (.event // ""),
+            started_at: (.run_started_at // .created // ""),
+            duration:   (.duration // null),
+            url:        (.url // "")
+          }]
+          | if $b == "" then . else [.[] | select(.branch == $b)] end
+        '
         ;;
     esac
     ;;
@@ -1097,7 +1123,15 @@ case "$cmd:$sub" in
         if [[ "$elapsed" -ge "$no_run_deadline" ]]; then
           echo "status: no-workflow"
           echo "duration: ${elapsed}s"
-          echo "No CI workflow found for branch '$branch' after ${elapsed}s" >&2
+          # Distinguish "no workflow registered at all" from "runs exist
+          # but none correlate to this branch" so callers (#103) can tell
+          # a real CI absence from a branch-correlation gap.
+          any_runs=$("$0" run list --limit 1 2>/dev/null | jq -r '.[0] // empty')
+          if [[ -n "$any_runs" && "$any_runs" != "null" ]]; then
+            echo "CI workflow runs exist but none correlate to branch '$branch' after ${elapsed}s" >&2
+          else
+            echo "No CI workflow found for branch '$branch' after ${elapsed}s" >&2
+          fi
           exit 3
         fi
         echo "No runs found yet for '$branch', retrying in ${interval}s..." >&2

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Work session management — start, end, checkpoint, handoff, resume, issue, reset, orchestrate, plus a model-triggered summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -728,11 +728,37 @@ case "$cmd:$sub" in
           env GH_NO_COLOR=1 gh run list "${args[@]}"
         ;;
       gitea)
-        args=(--output json --limit "$limit")
-        [[ -n "$status" ]] && args+=(--status "$status")
-        [[ -n "$branch" ]] && args+=(--branch "$branch")
-        cli_json '[.[] | {id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}]' \
-          env NO_COLOR=1 tea actions runs list "${args[@]}"
+        # Source from Gitea REST API directly. `tea actions runs list`
+        # filters server-side by a `branch` column that Gitea leaves empty
+        # on `pull_request` runs, so the watcher's --branch lookup misses
+        # correlated runs (#103). Fetch unfiltered via `tea api`, normalize
+        # `branch` from `head_branch`, and apply --branch client-side.
+        query="limit=$limit"
+        [[ -n "$status" ]] && query+="&status=$status"
+        raw_stderr=$(mktemp); raw_rc=0
+        raw=$(NO_COLOR=1 tea api "repos/{owner}/{repo}/actions/runs?$query" 2>"$raw_stderr") \
+          || raw_rc=$?
+        if [[ $raw_rc -ne 0 ]]; then
+          err=$(cat "$raw_stderr"); rm -f "$raw_stderr"
+          die "tea api repos/{owner}/{repo}/actions/runs failed: $err"
+        fi
+        rm -f "$raw_stderr"
+        echo "$raw" | jq --arg b "$branch" '
+          [(.workflow_runs // []) | .[] | {
+            id:         (.id | tostring),
+            status:     (if (.conclusion // "") != "" then (.conclusion | ascii_downcase)
+                         elif .status == "completed" then "success"
+                         else (.status // "unknown" | ascii_downcase) end),
+            workflow:   (.name // .workflow_id // ""),
+            branch:     (((.head_branch // "") | select(. != "")) // (.branch // "")),
+            head_sha:   (.head_sha // ""),
+            event:      (.event // ""),
+            started_at: (.run_started_at // .created // ""),
+            duration:   (.duration // null),
+            url:        (.url // "")
+          }]
+          | if $b == "" then . else [.[] | select(.branch == $b)] end
+        '
         ;;
     esac
     ;;
@@ -1097,7 +1123,15 @@ case "$cmd:$sub" in
         if [[ "$elapsed" -ge "$no_run_deadline" ]]; then
           echo "status: no-workflow"
           echo "duration: ${elapsed}s"
-          echo "No CI workflow found for branch '$branch' after ${elapsed}s" >&2
+          # Distinguish "no workflow registered at all" from "runs exist
+          # but none correlate to this branch" so callers (#103) can tell
+          # a real CI absence from a branch-correlation gap.
+          any_runs=$("$0" run list --limit 1 2>/dev/null | jq -r '.[0] // empty')
+          if [[ -n "$any_runs" && "$any_runs" != "null" ]]; then
+            echo "CI workflow runs exist but none correlate to branch '$branch' after ${elapsed}s" >&2
+          else
+            echo "No CI workflow found for branch '$branch' after ${elapsed}s" >&2
+          fi
           exit 3
         fi
         echo "No runs found yet for '$branch', retrying in ${interval}s..." >&2

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Work session management — start, end, checkpoint, handoff, resume, issue, reset, orchestrate, plus a model-triggered summarize skill",
   "author": {
     "name": "Logan Gagne"

--- a/tests/session/test-ci-poll.sh
+++ b/tests/session/test-ci-poll.sh
@@ -677,27 +677,43 @@ gitea_run_test() {
 }
 
 # ---------------------------------------------------------------------------
+# Mock dispatch shape
+#
+# After the #103 fix, `git-cli run list` on Gitea calls
+# `tea api repos/{owner}/{repo}/actions/runs?limit=N[&status=...]`
+# instead of `tea actions runs list`. The mock dispatches:
+#   - tea api repos/.../actions/runs?<query>          → workflow_runs list
+#   - tea api repos/.../actions/runs/<id>/jobs         → per-job statuses
+#   - tea actions runs view <id>                       → single run (run show)
+#   - tea actions runs logs <id>                       → log text (run logs)
+#
+# `head_branch` is populated on Gitea runs even when `branch` is "" (the
+# #103 bug); the wrapper normalizes `branch` from `head_branch`.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Test: top-level success, all jobs success → status: pass (sanity baseline)
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        echo '[{"id":900,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/900"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":900,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha900","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/900"}'
         ;;
-      view)
-        echo '{"id":900,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/900"}'
-        ;;
-      logs)
-        echo "all green"
-        ;;
+      "runs logs") echo "all green" ;;
     esac
     ;;
-  "api ")
-    # tea api repos/{owner}/{repo}/actions/runs/<id>/jobs
-    echo '{"jobs":[{"id":1,"name":"build","status":"completed","conclusion":"success"}],"total_count":1}'
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        echo '{"jobs":[{"id":1,"name":"build","status":"completed","conclusion":"success"}],"total_count":1}'
+        ;;
+      *actions/runs*)
+        echo '{"total_count":1,"workflow_runs":[{"id":900,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha900","branch":"","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/900"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF
@@ -709,23 +725,25 @@ gitea_run_test "pass" "0" "[gitea] all jobs success → status: pass"
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        # Gitea bug: top-level status reads "success" even with a failed job
-        echo '[{"id":879,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/879"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":879,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha879","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/879"}'
         ;;
-      view)
-        echo '{"id":879,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/879"}'
-        ;;
-      logs)
-        echo "Job 'lint' failed"
-        ;;
+      "runs logs") echo "Job 'lint' failed" ;;
     esac
     ;;
-  "api ")
-    echo '{"jobs":[{"id":2,"name":"lint","status":"completed","conclusion":"failure"},{"id":3,"name":"merge","status":"completed","conclusion":"skipped"}],"total_count":2}'
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        echo '{"jobs":[{"id":2,"name":"lint","status":"completed","conclusion":"failure"},{"id":3,"name":"merge","status":"completed","conclusion":"skipped"}],"total_count":2}'
+        ;;
+      *actions/runs*)
+        # Gitea bug: top-level run reads success even though a job failed.
+        echo '{"total_count":1,"workflow_runs":[{"id":879,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha879","branch":"","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/879"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF
@@ -749,22 +767,24 @@ fi
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        echo '[{"id":880,"status":"failure","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":20,"url":"https://gitea.example.com/owner/repo/actions/runs/880"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":880,"status":"completed","conclusion":"failure","name":"ci.yml","head_branch":"test-branch","head_sha":"sha880","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":20,"url":"https://gitea.example.com/owner/repo/actions/runs/880"}'
         ;;
-      view)
-        echo '{"id":880,"status":"failure","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":20,"url":"https://gitea.example.com/owner/repo/actions/runs/880"}'
-        ;;
-      logs)
-        echo "Job 'build' failed"
-        ;;
+      "runs logs") echo "Job 'build' failed" ;;
     esac
     ;;
-  "api ")
-    echo '{"jobs":[{"id":4,"name":"build","status":"completed","conclusion":"failure"}],"total_count":1}'
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        echo '{"jobs":[{"id":4,"name":"build","status":"completed","conclusion":"failure"}],"total_count":1}'
+        ;;
+      *actions/runs*)
+        echo '{"total_count":1,"workflow_runs":[{"id":880,"status":"completed","conclusion":"failure","name":"ci.yml","head_branch":"test-branch","head_sha":"sha880","branch":"","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":20,"url":"https://gitea.example.com/owner/repo/actions/runs/880"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF
@@ -776,20 +796,24 @@ gitea_run_test "fail" "0" "[gitea] top-level failure → status: fail"
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        echo '[{"id":881,"status":"cancelled","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":5,"url":"https://gitea.example.com/owner/repo/actions/runs/881"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":881,"status":"cancelled","conclusion":"cancelled","name":"ci.yml","head_branch":"test-branch","head_sha":"sha881","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":5,"url":"https://gitea.example.com/owner/repo/actions/runs/881"}'
         ;;
-      view)
-        echo '{"id":881,"status":"cancelled","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":5,"url":"https://gitea.example.com/owner/repo/actions/runs/881"}'
-        ;;
-      logs) echo "" ;;
+      "runs logs") echo "" ;;
     esac
     ;;
-  "api ")
-    echo '{"jobs":[],"total_count":0}'
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        echo '{"jobs":[],"total_count":0}'
+        ;;
+      *actions/runs*)
+        echo '{"total_count":1,"workflow_runs":[{"id":881,"status":"cancelled","conclusion":"cancelled","name":"ci.yml","head_branch":"test-branch","head_sha":"sha881","branch":"","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":5,"url":"https://gitea.example.com/owner/repo/actions/runs/881"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF
@@ -812,24 +836,28 @@ fi
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        echo '[{"id":882,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/882"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":882,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha882","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/882"}'
         ;;
-      view)
-        echo '{"id":882,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/882"}'
-        ;;
-      logs)
+      "runs logs")
         # Older Gitea: jobs API absent; the log dump is the only signal.
         printf "step output...\nJob 'lint' failed\nmore output\n"
         ;;
     esac
     ;;
-  "api ")
-    # Older Gitea: endpoint not implemented — return empty/non-JSON.
-    exit 1
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        # Older Gitea: endpoint not implemented — return non-zero/empty.
+        exit 1
+        ;;
+      *actions/runs*)
+        echo '{"total_count":1,"workflow_runs":[{"id":882,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha882","branch":"","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/882"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF
@@ -848,55 +876,151 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test: --branch is forwarded to `tea actions runs list`
+# Test (#103): pull_request run with empty branch + populated head_branch
+# correlates to --branch and run watch reports success. Repro: the run lists
+# `branch: ""` (Gitea omits branch on pull_request events) but `head_branch`
+# carries the actual branch name.
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        # Fail loudly if the wrapper drops --branch (this was the bug).
-        if [[ "$*" != *"--branch test-branch"* ]]; then
-          echo "MOCK ERROR: --branch flag missing from tea actions runs list" >&2
-          echo '[]'
-          exit 1
-        fi
-        echo '[{"id":883,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/883"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":920,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha920","event":"pull_request","run_started_at":"2024-01-01T00:00:00Z","duration":41,"url":"https://gitea.example.com/owner/repo/actions/runs/920"}'
         ;;
-      view)
-        echo '{"id":883,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/883"}'
-        ;;
-      logs) echo "" ;;
+      "runs logs") echo "" ;;
     esac
     ;;
-  "api ")
-    echo '{"jobs":[{"id":7,"name":"build","status":"completed","conclusion":"success"}],"total_count":1}'
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        echo '{"jobs":[{"id":11,"name":"build","status":"completed","conclusion":"success"}],"total_count":1}'
+        ;;
+      *actions/runs*)
+        # Repro of #103: branch is "" (Gitea sets it empty for pull_request
+        # events), but head_branch is populated.
+        echo '{"total_count":1,"workflow_runs":[{"id":920,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha920","branch":"","event":"pull_request","run_started_at":"2024-01-01T00:00:00Z","duration":41,"url":"https://gitea.example.com/owner/repo/actions/runs/920"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF
 
-gitea_run_test "pass" "0" "[gitea] --branch is forwarded to tea actions runs list"
+gitea_run_test "pass" "0" "[gitea] #103 — pull_request run correlates via head_branch → status: pass"
+
+# ---------------------------------------------------------------------------
+# Test (#103): run list --branch X filters client-side by head_branch.
+# Mock returns two runs: one matching, one not. Expect exactly one element
+# with branch=test-branch in the output.
+# ---------------------------------------------------------------------------
+
+write_mock_tea <<'EOF'
+case "$1" in
+  api)
+    case "$2" in
+      *actions/runs*)
+        echo '{"total_count":2,"workflow_runs":[
+          {"id":1001,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha1001","branch":"","event":"pull_request","run_started_at":"2024-01-01T00:00:00Z","duration":10,"url":"u1"},
+          {"id":1002,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"other","head_sha":"sha1002","branch":"","event":"pull_request","run_started_at":"2024-01-01T00:00:00Z","duration":11,"url":"u2"}
+        ]}'
+        ;;
+    esac
+    ;;
+esac
+EOF
+
+list_json=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run list --branch test-branch --limit 5 2>/dev/null) || true
+list_count=$(echo "$list_json" | jq 'length')
+list_branch=$(echo "$list_json" | jq -r '.[0].branch // empty')
+list_sha=$(echo "$list_json" | jq -r '.[0].head_sha // empty')
+if [[ "$list_count" == "1" && "$list_branch" == "test-branch" && "$list_sha" == "sha1001" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] #103 — run list --branch filters client-side, head_sha populated"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (count=%s branch=%s sha=%s)\n" \
+    "[gitea] #103 — run list --branch filters client-side, head_sha populated" "$list_count" "$list_branch" "$list_sha"
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Test (#103): no-workflow stderr distinguishes "no runs" from "runs exist
+# but none correlate to branch". This is defense in depth — the
+# head_branch correlation above should keep this branch from firing in
+# normal operation.
+# ---------------------------------------------------------------------------
+
+# Case A: no runs at all → stderr says "No CI workflow found".
+write_mock_tea <<'EOF'
+case "$1" in
+  api)
+    case "$2" in
+      *actions/runs*) echo '{"total_count":0,"workflow_runs":[]}' ;;
+    esac
+    ;;
+esac
+EOF
+
+exit_code=0
+stderr_out=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch test-branch --initial-delay 0 --timeout 1 --interval 1 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" == "3" ]] && echo "$stderr_out" | grep -q "No CI workflow found"; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] #103 — no runs → stderr says 'No CI workflow found'"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (exit=%s stderr=%s)\n" \
+    "[gitea] #103 — no runs → stderr says 'No CI workflow found'" "$exit_code" "$stderr_out"
+  ((FAIL++)) || true
+fi
+
+# Case B: runs exist but none match branch → stderr says "none correlate".
+write_mock_tea <<'EOF'
+case "$1" in
+  api)
+    case "$2" in
+      *actions/runs*)
+        echo '{"total_count":1,"workflow_runs":[{"id":2001,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"unrelated","head_sha":"sha2001","branch":"","event":"pull_request","run_started_at":"2024-01-01T00:00:00Z","duration":10,"url":"u"}]}'
+        ;;
+    esac
+    ;;
+esac
+EOF
+
+exit_code=0
+stderr_out=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" run watch \
+  --branch test-branch --initial-delay 0 --timeout 1 --interval 1 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" == "3" ]] && echo "$stderr_out" | grep -q "none correlate to branch"; then
+  printf "  \033[32m✓\033[0m %s\n" "[gitea] #103 — runs exist but none match → stderr says 'none correlate'"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (exit=%s stderr=%s)\n" \
+    "[gitea] #103 — runs exist but none match → stderr says 'none correlate'" "$exit_code" "$stderr_out"
+  ((FAIL++)) || true
+fi
 
 # ---------------------------------------------------------------------------
 # Test: pre-check path — completed run with failed job present before loop
 # ---------------------------------------------------------------------------
 
 write_mock_tea <<'EOF'
-case "$1 $2" in
-  "actions runs")
-    case "$3" in
-      list)
-        echo '[{"id":884,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/884"}]'
+case "$1" in
+  actions)
+    case "$2 $3" in
+      "runs view")
+        echo '{"id":884,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha884","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/884"}'
         ;;
-      view)
-        echo '{"id":884,"status":"success","workflow":"ci.yml","branch":"test-branch","event":"push","started":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/884"}'
-        ;;
-      logs) echo "Job 'lint' failed" ;;
+      "runs logs") echo "Job 'lint' failed" ;;
     esac
     ;;
-  "api ")
-    echo '{"jobs":[{"id":8,"name":"lint","status":"completed","conclusion":"failure"}],"total_count":1}'
+  api)
+    case "$2" in
+      *actions/runs/*/jobs)
+        echo '{"jobs":[{"id":8,"name":"lint","status":"completed","conclusion":"failure"}],"total_count":1}'
+        ;;
+      *actions/runs*)
+        echo '{"total_count":1,"workflow_runs":[{"id":884,"status":"completed","conclusion":"success","name":"ci.yml","head_branch":"test-branch","head_sha":"sha884","branch":"","event":"push","run_started_at":"2024-01-01T00:00:00Z","duration":15,"url":"https://gitea.example.com/owner/repo/actions/runs/884"}]}'
+        ;;
+    esac
     ;;
 esac
 EOF

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -728,11 +728,37 @@ case "$cmd:$sub" in
           env GH_NO_COLOR=1 gh run list "${args[@]}"
         ;;
       gitea)
-        args=(--output json --limit "$limit")
-        [[ -n "$status" ]] && args+=(--status "$status")
-        [[ -n "$branch" ]] && args+=(--branch "$branch")
-        cli_json '[.[] | {id: .id, status: (if .status == "completed" then "success" else .status end), workflow, branch: (.branch // ""), event: (.event // ""), started_at: (.started // ""), duration: (.duration // null), url: (.url // "")}]' \
-          env NO_COLOR=1 tea actions runs list "${args[@]}"
+        # Source from Gitea REST API directly. `tea actions runs list`
+        # filters server-side by a `branch` column that Gitea leaves empty
+        # on `pull_request` runs, so the watcher's --branch lookup misses
+        # correlated runs (#103). Fetch unfiltered via `tea api`, normalize
+        # `branch` from `head_branch`, and apply --branch client-side.
+        query="limit=$limit"
+        [[ -n "$status" ]] && query+="&status=$status"
+        raw_stderr=$(mktemp); raw_rc=0
+        raw=$(NO_COLOR=1 tea api "repos/{owner}/{repo}/actions/runs?$query" 2>"$raw_stderr") \
+          || raw_rc=$?
+        if [[ $raw_rc -ne 0 ]]; then
+          err=$(cat "$raw_stderr"); rm -f "$raw_stderr"
+          die "tea api repos/{owner}/{repo}/actions/runs failed: $err"
+        fi
+        rm -f "$raw_stderr"
+        echo "$raw" | jq --arg b "$branch" '
+          [(.workflow_runs // []) | .[] | {
+            id:         (.id | tostring),
+            status:     (if (.conclusion // "") != "" then (.conclusion | ascii_downcase)
+                         elif .status == "completed" then "success"
+                         else (.status // "unknown" | ascii_downcase) end),
+            workflow:   (.name // .workflow_id // ""),
+            branch:     (((.head_branch // "") | select(. != "")) // (.branch // "")),
+            head_sha:   (.head_sha // ""),
+            event:      (.event // ""),
+            started_at: (.run_started_at // .created // ""),
+            duration:   (.duration // null),
+            url:        (.url // "")
+          }]
+          | if $b == "" then . else [.[] | select(.branch == $b)] end
+        '
         ;;
     esac
     ;;
@@ -1097,7 +1123,15 @@ case "$cmd:$sub" in
         if [[ "$elapsed" -ge "$no_run_deadline" ]]; then
           echo "status: no-workflow"
           echo "duration: ${elapsed}s"
-          echo "No CI workflow found for branch '$branch' after ${elapsed}s" >&2
+          # Distinguish "no workflow registered at all" from "runs exist
+          # but none correlate to this branch" so callers (#103) can tell
+          # a real CI absence from a branch-correlation gap.
+          any_runs=$("$0" run list --limit 1 2>/dev/null | jq -r '.[0] // empty')
+          if [[ -n "$any_runs" && "$any_runs" != "null" ]]; then
+            echo "CI workflow runs exist but none correlate to branch '$branch' after ${elapsed}s" >&2
+          else
+            echo "No CI workflow found for branch '$branch' after ${elapsed}s" >&2
+          fi
           exit 3
         fi
         echo "No runs found yet for '$branch', retrying in ${interval}s..." >&2


### PR DESCRIPTION
## Summary

Fix `git-cli run watch --branch` reporting `status: no-workflow` (exit 3) on Gitea PRs that actually built and merged. Gitea emits `branch: ""` on every `pull_request`-triggered run, so `tea actions runs list --branch <name>` matched nothing server-side. The `ship` skill (and any caller gating on `status: pass`) treated healthy auto-merged PRs as CI failures.

- **`run list` (Gitea):** source from `tea api repos/{owner}/{repo}/actions/runs` directly. Normalize `branch` from `head_branch`, add `head_sha`, and apply `--branch` client-side. `tea api` is already the precedent for fetching richer Gitea data (the jobs endpoint at `utils/git-cli:758`).
- **`run watch`:** refine `no-workflow` stderr to distinguish "no runs at all" from "runs exist but none correlate to branch" — defense in depth; should rarely fire now that correlation works.
- **Tests:** restructure Gitea mocks to dispatch on `tea api`. Add four #103 regression cases (pull_request correlation, client-side filter, both no-workflow stderr variants). Existing #87 per-job aggregation tests retained.
- **Versions:** `git-tools` 2.0.8 → 2.0.9, `session` 3.10.2 → 3.10.3 (both Claude + Copilot variants). Vendored `git-cli` copies synced.

Closes #103

## Test plan

- [x] `bash tests/session/test-ci-poll.sh` — 38/38 pass (4 new #103 cases + all existing Gitea + GitHub cases)
- [x] `bash test.sh` — 1560/1560 plugin tests pass across 20 suites
- [x] `bash .github/scripts/validate-plugins.sh` — 276 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 105 checks, 0 failures
- [x] `bash utils/sync.sh --check` — no drift between `utils/` and vendored copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)