### PR TITLE
feat(auto-session-title): add hook-driven session/tab title plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,6 +36,15 @@
       "author": {
         "name": "Logan Gagne"
       },
+      "category": "productivity",
+      "description": "Auto-rename Claude Code sessions and terminal tab titles from git context (<repo>:<branch>), with a per-worktree override and /set + /clear slash commands. Skips emit when there's no useful name to attach.",
+      "name": "auto-session-title",
+      "source": "./plugins-claude/auto-session-title"
+    },
+    {
+      "author": {
+        "name": "Logan Gagne"
+      },
       "category": "development",
       "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
       "name": "git-tools",

--- a/plugins-claude/auto-session-title/.claude-plugin/plugin.json
+++ b/plugins-claude/auto-session-title/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "auto-session-title",
+  "version": "1.0.0",
+  "description": "Auto-rename Claude Code sessions (and terminal tab titles) from git context. Always prefixes with the repo name; skips emit when there's no useful name to attach.",
+  "author": {
+    "name": "Logan Gagne"
+  }
+}

--- a/plugins-claude/auto-session-title/README.md
+++ b/plugins-claude/auto-session-title/README.md
@@ -1,0 +1,30 @@
+# auto-session-title
+
+Auto-rename Claude Code sessions (and terminal tab titles) from git context. Claude Code mirrors the session title out to the terminal window/tab title, so one hook covers both surfaces.
+
+## Behavior
+
+A `UserPromptSubmit` hook fires on every user message and resolves a title like this:
+
+| State | Emitted title |
+|-------|---------------|
+| Not in a git repo | nothing (Claude Code leaves the current title alone) |
+| Detached HEAD, no override | nothing |
+| Named branch, no override | `<repo>:<branch>` |
+| Override file present | `<repo>:<override-line-1>` |
+
+The project prefix is **always** preserved — the override file contains only the suffix.
+
+## Override file
+
+Per-worktree, lives at `$(git rev-parse --git-dir)/claude-session-title`. Because it's inside the gitdir, it's never tracked. Each worktree gets its own override.
+
+## Slash commands
+
+- `/auto-session-title:set <name>` — write the override. Title becomes `<repo>:<name>` on the next user prompt.
+- `/auto-session-title:clear` — remove the override. Title reverts to `<repo>:<branch>`.
+
+## Notes
+
+- Claude Code's built-in `/rename` will be overwritten by the hook on the next prompt. Use `/auto-session-title:set` instead — it preserves the project prefix.
+- The hook is intentionally **Claude Code only**: it uses the `sessionTitle` field on `UserPromptSubmit` hook output, which isn't part of the Copilot CLI hook surface.

--- a/plugins-claude/auto-session-title/hooks/hooks.json
+++ b/plugins-claude/auto-session-title/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Set the Claude Code session title (and, via mirroring, the terminal tab title) from git context",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/session-title"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins-claude/auto-session-title/scripts/session-title
+++ b/plugins-claude/auto-session-title/scripts/session-title
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: emit a contextual session title when one would add value.
+# Claude Code mirrors `sessionTitle` to the terminal tab/window title.
+#
+# Resolution:
+#   - Not in a git repo:                  skip emit (Claude Code leaves current title alone)
+#   - Detached HEAD with no override:     skip emit (bare SHA conveys nothing)
+#   - Override file present and non-empty: emit "<repo>:<override-line-1>"
+#   - Otherwise:                          emit "<repo>:<branch>"
+#
+# Override file lives at $(git rev-parse --git-dir)/claude-session-title — per-worktree
+# and inside the gitdir, so it's never tracked. Project prefix is ALWAYS preserved.
+
+set -u
+
+# Drain hook payload when piped in; allow manual invocation from a TTY without hanging.
+if [[ ! -t 0 ]]; then
+  cat >/dev/null 2>&1 || true
+fi
+
+emit_noop() {
+  printf '{}\n'
+  exit 0
+}
+
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || emit_noop
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || emit_noop
+repo=$(basename "$toplevel")
+[[ -n "$repo" ]] || emit_noop
+
+suffix=""
+override="$git_dir/claude-session-title"
+if [[ -f "$override" ]]; then
+  suffix=$(head -n1 "$override" 2>/dev/null | sed 's/[[:space:]]*$//;s/^[[:space:]]*//')
+fi
+
+if [[ -z "$suffix" ]]; then
+  branch=$(git branch --show-current 2>/dev/null)
+  [[ -n "$branch" ]] || emit_noop
+  suffix="$branch"
+fi
+
+jq -nc --arg t "${repo}:${suffix}" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    sessionTitle: $t
+  }
+}'

--- a/plugins-claude/auto-session-title/skills/clear/SKILL.md
+++ b/plugins-claude/auto-session-title/skills/clear/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: clear
+description: "Clear the session-title override — title reverts to <repo>:<branch>"
+disable-model-invocation: true
+allowed-tools: Bash
+---
+
+Remove the per-worktree session-title override file so the hook falls back to branch-derived naming.
+
+### Steps
+
+1. Delete the override file if it exists:
+
+   ```bash
+   GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+   rm -f "$GIT_DIR/claude-session-title"
+   ```
+
+2. Confirm in one line: override cleared, title will revert to `<repo>:<branch>` on the next user prompt.

--- a/plugins-claude/auto-session-title/skills/set/SKILL.md
+++ b/plugins-claude/auto-session-title/skills/set/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: set
+description: "Set a custom session-title suffix (auto-prefixed with the project name on the next user prompt)"
+disable-model-invocation: true
+allowed-tools: Bash
+---
+
+Write a per-worktree override so the next user prompt produces a session title of `<repo>:<custom-name>` instead of `<repo>:<branch>`.
+
+### Steps
+
+1. Extract the custom name from the user's invocation arguments. If no arguments were provided, print this and stop:
+
+   ```text
+   Usage: /auto-session-title:set <name>
+   ```
+
+2. Write the name to the per-worktree override file:
+
+   ```bash
+   GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || { echo "Not in a git repo"; exit 1; }
+   printf '%s\n' "<name>" > "$GIT_DIR/claude-session-title"
+   ```
+
+3. Confirm in one line: the override is set and the title will become `<repo>:<name>` on the next user prompt.


### PR DESCRIPTION
## Summary

- New Claude-only plugin `auto-session-title` that auto-renames Claude Code sessions and terminal tab titles from git context (`<repo>:<branch>`)
- Always preserves the repo-name prefix; skips emit when nothing useful can be said (detached HEAD, outside a git repo) so the current title is left alone
- Per-worktree override file at `$(git rev-parse --git-dir)/claude-session-title` lets users (or future skills in `session/`) pin a custom suffix; `/auto-session-title:set <name>` and `/auto-session-title:clear` are thin slash commands over the file

## How it works

Implementation hinges on two Claude Code hook fields: `sessionTitle` on `UserPromptSubmit` `hookSpecificOutput` (sets Claude's internal session label), which Claude Code then mirrors to the terminal tab title automatically. One hook covers both surfaces.

The hook fires on every user prompt and resolves to one of:

| State | Emitted |
|---|---|
| Outside a git repo | `{}` — no-op, current title preserved |
| Detached HEAD, no override | `{}` |
| Named branch, no override | `<repo>:<branch>` |
| Override file present | `<repo>:<override-line-1>` (prefix always preserved) |

## Test plan

- [x] Hook script smoke-tested locally for all four cases above
- [x] End-to-end verified in a live Claude Code session: title `agent-toolkit:bug/103-gitea-run-watch-branch` appeared in both the session label (visible in `claude -r`) and the terminal tab title
- [x] `bash .github/scripts/validate-plugins.sh` — 282 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 0 failures
- [x] `rumdl check plugins-claude/auto-session-title/` — no issues
- [x] `bash test.sh` — 1560 passed, 0 failed across 20 suites
- [ ] CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)