### PR TITLE
fix(auto-session-title): use main repo name in worktree titles

### DIFF
--- a/plugins-claude/auto-session-title/.claude-plugin/plugin.json
+++ b/plugins-claude/auto-session-title/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-session-title",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Auto-rename Claude Code sessions (and terminal tab titles) from git context. Always prefixes with the repo name; skips emit when there's no useful name to attach.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/auto-session-title/README.md
+++ b/plugins-claude/auto-session-title/README.md
@@ -12,8 +12,19 @@ A `UserPromptSubmit` hook fires on every user message and resolves a title like 
 | Detached HEAD, no override | nothing |
 | Named branch, no override | `<repo>:<branch>` |
 | Override file present | `<repo>:<override-line-1>` |
+| Inside a worktree under `<repo>/.claude/worktrees/` or `<repo>/.github/worktrees/` | `<main-repo>↪<short-branch>` (or `<main-repo>↪<override>`) |
 
 The project prefix is **always** preserved — the override file contains only the suffix.
+
+## Worktrees
+
+Agent-spawned worktrees (Claude Code's `EnterWorktree`, the `git-worktree` Copilot plugin, etc.) often have long auto-generated paths and branch names like `agent-<bighash>` / `worktree-agent-<bighash>`. Naively combining the worktree directory with the branch produced unreadable titles like `agent-<bighash>:worktree-agent-<bighash>`.
+
+When the checkout lives under either of the known worktree base directories, the hook now:
+
+- Uses the **main repo** name (not the worktree directory) as the prefix.
+- Uses `↪` instead of `:` as the separator so worktree sessions are visually distinct.
+- Strips noisy `worktree-` / `agent-` prefixes from the branch and caps it at 12 characters.
 
 ## Override file
 

--- a/plugins-claude/auto-session-title/scripts/session-title
+++ b/plugins-claude/auto-session-title/scripts/session-title
@@ -5,8 +5,14 @@
 # Resolution:
 #   - Not in a git repo:                  skip emit (Claude Code leaves current title alone)
 #   - Detached HEAD with no override:     skip emit (bare SHA conveys nothing)
-#   - Override file present and non-empty: emit "<repo>:<override-line-1>"
-#   - Otherwise:                          emit "<repo>:<branch>"
+#   - Override file present and non-empty: emit "<repo><sep><override-line-1>"
+#   - Otherwise:                          emit "<repo><sep><branch-or-short>"
+#
+# Worktree handling: when the checkout lives under <main-repo>/.claude/worktrees/ or
+# <main-repo>/.github/worktrees/ (the conventions used by Claude Code's EnterWorktree
+# and the git-worktree Copilot plugin), the prefix is the *main* repo name and the
+# separator becomes "↪" with a shortened branch label, so titles stay readable when
+# many agent-spawned worktrees are open at once.
 #
 # Override file lives at $(git rev-parse --git-dir)/claude-session-title — per-worktree
 # and inside the gitdir, so it's never tracked. Project prefix is ALWAYS preserved.
@@ -25,8 +31,22 @@ emit_noop() {
 
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || emit_noop
 toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || emit_noop
-repo=$(basename "$toplevel")
+common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || emit_noop
+
+# Main-repo root = parent of the shared .git directory. Holds across linked worktrees.
+main_root=$(dirname "$common_dir")
+repo=$(basename "$main_root")
 [[ -n "$repo" ]] || emit_noop
+
+# Detect "agent-style" worktrees by their known parent directories.
+sep=":"
+is_worktree=0
+case "$toplevel" in
+  "$main_root/.claude/worktrees/"* | "$main_root/.github/worktrees/"*)
+    is_worktree=1
+    sep="↪"
+    ;;
+esac
 
 suffix=""
 override="$git_dir/claude-session-title"
@@ -38,9 +58,17 @@ if [[ -z "$suffix" ]]; then
   branch=$(git branch --show-current 2>/dev/null)
   [[ -n "$branch" ]] || emit_noop
   suffix="$branch"
+  if (( is_worktree )); then
+    # Strip noisy prefixes the worktree tooling tends to add, then cap length.
+    suffix="${suffix#worktree-}"
+    suffix="${suffix#agent-}"
+    if (( ${#suffix} > 12 )); then
+      suffix="${suffix:0:12}"
+    fi
+  fi
 fi
 
-jq -nc --arg t "${repo}:${suffix}" '{
+jq -nc --arg t "${repo}${sep}${suffix}" '{
   hookSpecificOutput: {
     hookEventName: "UserPromptSubmit",
     sessionTitle: $t


### PR DESCRIPTION
## Summary

Agent-spawned worktrees produced unreadable titles like `agent-<bighash>:worktree-agent-<bighash>` because the prefix was derived from the worktree's directory basename and the suffix from its equally noisy branch name.

- Resolve the prefix from the parent of `git rev-parse --git-common-dir` so the main repo name is used across all linked worktrees.
- Detect worktrees by location under `<main>/.claude/worktrees/` (Claude Code) or `<main>/.github/worktrees/` (the `git-worktree` Copilot plugin).
- For detected worktrees, switch the separator to a right-arrow-hook glyph, strip `worktree-` / `agent-` prefixes from the branch, and cap the suffix at 12 characters.
- Bump plugin version to `1.2.0` and document the new behavior in the README.

## Test plan

Smoke-tested locally against a scratch git repo with a linked worktree under `.claude/worktrees/`:

- [x] Main repo, plain branch → `fake-main:main`
- [x] Main repo, override file → `fake-main:shipping-stuff`
- [x] Worktree, no override → `fake-main↪abcdef123456`
- [x] Worktree, override file → `fake-main↪fixing-bug`
- [x] Outside any git repo → no-op
- [x] `bash .github/scripts/validate-plugins.sh` passes (282 checks, 0 failures)
- [x] `rumdl check plugins-claude/auto-session-title/` passes