### PR TITLE
fix(statusline): detect gitstatusd from Homebrew, $GITSTATUS_DAEMON, and PATH

### DIFF
--- a/plugins-claude/statusline/.claude-plugin/plugin.json
+++ b/plugins-claude/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Configurable status line for Claude Code — git status, model, context, API usage, cost segments with ANSI colors",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/statusline/README.md
+++ b/plugins-claude/statusline/README.md
@@ -63,3 +63,8 @@ Edit via `/statusline:statusline-config` or directly in `~/.config/claude-status
 | `curl` | Yes | API usage polling |
 | `git` | Yes | Branch and status info |
 | `gitstatusd` | No | Faster git queries (falls back to `git status`) |
+
+`gitstatusd` is auto-detected, in order, from `$GITSTATUS_DAEMON`, the
+[gitstatus](https://github.com/romkatv/gitstatus) self-bootstrap cache
+(`~/.cache/gitstatus/`), a Homebrew install (`brew install romkatv/gitstatus/gitstatus`),
+and finally `PATH`. No configuration is needed if any of these is present.

--- a/plugins-claude/statusline/scripts/gitstatusd-discover.sh
+++ b/plugins-claude/statusline/scripts/gitstatusd-discover.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Locate the gitstatusd binary across known install methods.
+# Echoes the first executable match and returns 0; returns 1 if none found.
+# Order: $GITSTATUS_DAEMON, self-bootstrap cache, Homebrew, PATH.
+# Globbing the arch suffix matches whatever romkatv ships (arm64 vs aarch64).
+find_gitstatusd() {
+  local platform candidate brew_prefix
+  platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+  if [[ -n "${GITSTATUS_DAEMON:-}" && -x "${GITSTATUS_DAEMON}" ]]; then
+    echo "$GITSTATUS_DAEMON"
+    return 0
+  fi
+
+  for candidate in "$HOME/.cache/gitstatus/gitstatusd-${platform}-"*; do
+    [[ -x "$candidate" ]] && {
+      echo "$candidate"
+      return 0
+    }
+  done
+
+  if brew_prefix=$(brew --prefix gitstatus 2>/dev/null) && [[ -n "$brew_prefix" ]]; then
+    for candidate in "$brew_prefix/usrbin/gitstatusd-${platform}-"*; do
+      [[ -x "$candidate" ]] && {
+        echo "$candidate"
+        return 0
+      }
+    done
+  fi
+
+  if candidate=$(command -v gitstatusd 2>/dev/null); then
+    echo "$candidate"
+    return 0
+  fi
+
+  return 1
+}

--- a/plugins-claude/statusline/scripts/setup.sh
+++ b/plugins-claude/statusline/scripts/setup.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/gitstatusd-discover.sh"
 STATUSLINE_SH="$SCRIPT_DIR/statusline.sh"
+GITSTATUSD_DISCOVER_SH="$SCRIPT_DIR/gitstatusd-discover.sh"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude-statusline"
 CONFIG_FILE="$CONFIG_DIR/config.json"
 DEFAULT_CONFIG="$SCRIPT_DIR/config.json"
@@ -44,14 +47,7 @@ check_tool awk "should be pre-installed on all systems"
 check_tool git "install with: apt install git / brew install git"
 
 # Optional: gitstatusd for fast git status
-platform=$(uname -s | tr '[:upper:]' '[:lower:]')
-arch=$(uname -m)
-case "$arch" in
-  x86_64) arch="x86_64" ;;
-  aarch64 | arm64) arch="aarch64" ;;
-esac
-gitstatusd_bin="$HOME/.cache/gitstatus/gitstatusd-${platform}-${arch}"
-if [[ -x "$gitstatusd_bin" ]]; then
+if gitstatusd_bin=$(find_gitstatusd); then
   ok "gitstatusd $(dim "(optional, found at $gitstatusd_bin)")"
 else
   warn "gitstatusd not found $(dim "(optional — will use git CLI fallback)")"
@@ -78,6 +74,8 @@ echo "Installing statusline script..."
 cp "$STATUSLINE_SH" "$INSTALL_SCRIPT"
 chmod +x "$INSTALL_SCRIPT"
 ok "Copied to $INSTALL_SCRIPT"
+cp "$GITSTATUSD_DISCOVER_SH" "$INSTALL_DIR/gitstatusd-discover.sh"
+ok "Copied to $INSTALL_DIR/gitstatusd-discover.sh"
 echo ""
 
 # ── Copy default config if none exists ────────────────────────────────────────

--- a/plugins-claude/statusline/scripts/statusline.sh
+++ b/plugins-claude/statusline/scripts/statusline.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/gitstatusd-discover.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/gitstatusd-discover.sh"
+fi
+
 # ── Defaults & Constants ─────────────────────────────────────────────────────
 
 DEFAULT_SEGMENTS=(user dir git model context session weekly extra cost)
@@ -275,17 +281,7 @@ file_age() {
 }
 
 # ── gitstatusd ────────────────────────────────────────────────────────────────
-
-find_gitstatusd() {
-  local arch
-  arch=$(uname -m)
-  local bin="$HOME/.cache/gitstatus/gitstatusd-${PLATFORM}-${arch}"
-  [[ -x "$bin" ]] && {
-    echo "$bin"
-    return 0
-  }
-  return 1
-}
+# find_gitstatusd is provided by gitstatusd-discover.sh (sourced at startup).
 
 query_gitstatusd() {
   local cwd="$1"

--- a/plugins-claude/statusline/scripts/teardown.sh
+++ b/plugins-claude/statusline/scripts/teardown.sh
@@ -52,6 +52,11 @@ else
   ok "No installed script at $INSTALL_SCRIPT"
 fi
 
+if [[ -f "$CONFIG_DIR/gitstatusd-discover.sh" ]]; then
+  rm "$CONFIG_DIR/gitstatusd-discover.sh"
+  ok "Removed $CONFIG_DIR/gitstatusd-discover.sh"
+fi
+
 # ── Optional: clean config and cache ─────────────────────────────────────────
 
 if [[ "$CLEAN_ALL" == "true" ]]; then

--- a/tests/statusline/test-gitstatusd-discover.sh
+++ b/tests/statusline/test-gitstatusd-discover.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# test-gitstatusd-discover.sh — Test harness for gitstatusd-discover.sh.
+# Verifies find_gitstatusd() locates the daemon across $GITSTATUS_DAEMON, the
+# self-bootstrap cache, Homebrew, and PATH, and that globbing the arch suffix
+# works regardless of arm64/aarch64 naming.
+#
+# Usage: bash tests/statusline/test-gitstatusd-discover.sh [filter]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../../plugins-claude/statusline/scripts/gitstatusd-discover.sh"
+
+# shellcheck source=/dev/null
+source "$HELPER"
+
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+PASS=0
+FAIL=0
+SKIP=0
+FILTER="${1:-}"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Run find_gitstatusd in an isolated environment.
+# Args: home_dir  sandbox_bin  [daemon_path]
+# Sets globals DISCOVER_OUT and DISCOVER_RC.
+discover() {
+  local home="$1" sandbox="$2" daemon="${3:-}"
+  local out rc
+  out=$(
+    export HOME="$home"
+    export PATH="$sandbox:/usr/bin:/bin"
+    if [[ -n "$daemon" ]]; then
+      export GITSTATUS_DAEMON="$daemon"
+    else
+      unset GITSTATUS_DAEMON
+    fi
+    find_gitstatusd
+  ) && rc=0 || rc=$?
+  DISCOVER_OUT="$out"
+  DISCOVER_RC="$rc"
+}
+
+check() {
+  local label="$1" expected_out="$2" expected_rc="$3"
+
+  if [[ -n "$FILTER" ]] && ! echo "$label" | grep -qi "$FILTER"; then
+    ((SKIP++)) || true
+    return 0
+  fi
+
+  if [[ "$DISCOVER_OUT" == "$expected_out" && "$DISCOVER_RC" == "$expected_rc" ]]; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s  (expected: out=%q rc=%s, got: out=%q rc=%s)\n" \
+      "$label" "$expected_out" "$expected_rc" "$DISCOVER_OUT" "$DISCOVER_RC"
+    ((FAIL++)) || true
+  fi
+}
+
+mkexec() {
+  mkdir -p "$(dirname "$1")"
+  : >"$1"
+  chmod +x "$1"
+}
+
+# ===== 1. $GITSTATUS_DAEMON override =====
+echo "── \$GITSTATUS_DAEMON override ──"
+home1="$TMP/h1"
+sandbox1="$TMP/bin1"
+daemon1="$TMP/custom/gitstatusd"
+mkdir -p "$home1" "$sandbox1"
+mkexec "$daemon1"
+discover "$home1" "$sandbox1" "$daemon1"
+check "GITSTATUS_DAEMON returned" "$daemon1" "0"
+
+# A non-executable GITSTATUS_DAEMON is ignored (falls through to not-found).
+daemon1b="$TMP/custom/not-exec"
+mkdir -p "$(dirname "$daemon1b")"
+: >"$daemon1b"
+discover "$home1" "$sandbox1" "$daemon1b"
+check "non-executable GITSTATUS_DAEMON ignored" "" "1"
+
+# ===== 2. Self-bootstrap cache (arch glob) =====
+echo "── Self-bootstrap cache ──"
+home2="$TMP/h2"
+sandbox2="$TMP/bin2"
+mkdir -p "$sandbox2"
+cache2="$home2/.cache/gitstatus/gitstatusd-${PLATFORM}-arm64"
+mkexec "$cache2"
+discover "$home2" "$sandbox2"
+check "cache binary found via glob (arm64 suffix)" "$cache2" "0"
+
+# ===== 3. Homebrew prefix =====
+echo "── Homebrew ──"
+home3="$TMP/h3"
+sandbox3="$TMP/bin3"
+brew_prefix="$TMP/brew/opt/gitstatus"
+mkdir -p "$home3" "$sandbox3"
+brew_bin="$brew_prefix/usrbin/gitstatusd-${PLATFORM}-arm64"
+mkexec "$brew_bin"
+# Fake brew that echoes the prefix for `--prefix gitstatus`.
+cat >"$sandbox3/brew" <<EOF
+#!/bin/bash
+[[ "\$1" == "--prefix" && "\$2" == "gitstatus" ]] && echo "$brew_prefix"
+EOF
+chmod +x "$sandbox3/brew"
+discover "$home3" "$sandbox3"
+check "homebrew binary found via brew --prefix" "$brew_bin" "0"
+
+# ===== 4. PATH =====
+echo "── PATH ──"
+home4="$TMP/h4"
+sandbox4="$TMP/bin4"
+mkdir -p "$home4"
+mkexec "$sandbox4/gitstatusd"
+discover "$home4" "$sandbox4"
+check "gitstatusd found on PATH" "$sandbox4/gitstatusd" "0"
+
+# ===== 5. Precedence: GITSTATUS_DAEMON wins over cache =====
+echo "── Precedence ──"
+home5="$TMP/h5"
+sandbox5="$TMP/bin5"
+mkdir -p "$sandbox5"
+mkexec "$home5/.cache/gitstatus/gitstatusd-${PLATFORM}-arm64"
+daemon5="$TMP/custom5/gitstatusd"
+mkexec "$daemon5"
+discover "$home5" "$sandbox5" "$daemon5"
+check "GITSTATUS_DAEMON takes precedence over cache" "$daemon5" "0"
+
+# ===== 6. Not found =====
+echo "── Not found ──"
+home6="$TMP/h6"
+sandbox6="$TMP/bin6"
+mkdir -p "$home6" "$sandbox6"
+discover "$home6" "$sandbox6"
+check "nothing installed → returns non-zero, empty output" "" "1"
+
+# ===== Summary =====
+echo ""
+echo "Total: $((PASS + FAIL + SKIP))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Fixes gitstatusd discovery in the `statusline` plugin (#112). Discovery only
checked the romkatv self-bootstrap cache path, so a Homebrew install
(`brew install romkatv/gitstatus/gitstatus`), a `$GITSTATUS_DAEMON` override, or
a daemon on `PATH` were all invisible — setup reported "gitstatusd not found"
and the statusline silently used the slow git CLI. The two scripts also
disagreed on the arch suffix (`setup.sh` mapped `arm64 -> aarch64`
unconditionally; `statusline.sh` used raw `uname -m`), so on Apple Silicon they
probed different filenames.

## Changes

- Add `scripts/gitstatusd-discover.sh` with a shared `find_gitstatusd()` that
  checks `$GITSTATUS_DAEMON`, the self-bootstrap cache, the Homebrew prefix, and
  `PATH`, globbing the arch suffix to sidestep `arm64`/`aarch64` differences
- Source the helper in `setup.sh` and `statusline.sh`; remove the duplicated,
  divergent discovery logic from both
- Copy the helper into the install dir during setup; remove it on teardown
- Add `tests/statusline/test-gitstatusd-discover.sh` (7 cases) covering override,
  cache glob, Homebrew, PATH, precedence, and not-found
- Document the auto-detection order in `README.md`; bump plugin version to 1.1.1

## Test plan

- [x] `bash tests/statusline/test-gitstatusd-discover.sh` — 7/7 pass
- [x] `bash tests/test.sh` — 21 suites, 0 failed
- [x] `bash .github/scripts/validate-plugins.sh` — 282 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 109 checks, 0 failures
- [x] `shellcheck --severity=error` on changed scripts — clean
- [x] `rumdl check` on changed README — clean

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
