### PR TITLE
fix(git-tools): make git-cli --body inline; stop stdin hang

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -7,17 +7,17 @@
 # Usage:
 #   git-tools issue list   [--limit N] [--assignee USER] [--label L] [--state open|closed|all]
 #   git-tools issue show   <N>
-#   git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
-#   git-tools issue comment <N> [--body | --body-file FILE]
+#   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
+#   git-tools issue comment <N> [--body TEXT | --body-file FILE]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
 #   git-tools pr show      <N> | --branch NAME
-#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
-#   git-tools pr comment   <N> [--body | --body-file FILE]
+#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
+#   git-tools pr comment   <N> [--body TEXT | --body-file FILE]
 #
-#   (--body reads from stdin; --body-file FILE reads from disk, or "-" for stdin)
+#   (--body TEXT is inline; --body-file FILE reads from disk, or "-" for stdin)
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
@@ -80,17 +80,30 @@ cli_json() {
 # Read body from --body or --body-file flags. Sets BODY variable.
 # Call: parse_body_args "$@" then access $BODY and $REMAINING_ARGS.
 #
-# --body reads from stdin. This is the only stdin-capable flag: no --body TEXT,
-# no temp-file pattern required. Multi-line structured content uses heredoc;
-# short comments pipe in via printf. --body-file FILE (or --body-file -) remains
-# for callers that already have content on disk.
-#   git-cli pr create --title "..." --head branch --body <<'EOF'
+# --body TEXT takes an inline argument (matches gh/tea); it never reads stdin.
+# --body-file FILE reads from disk. --body-file - reads from stdin (heredoc or
+# pipe) via a bounded read that errors instead of hanging when stdin is an open
+# pipe with no data/EOF (the situation that hung agent/CI callers, see #114).
+#   git-cli pr create --title "..." --head branch --body "Short summary"
+#   git-cli issue create --title "..." --body-file - <<'EOF'
 #   ## Summary
 #   ...
 #   EOF
-#   printf 'LGTM' | git-cli pr comment 42 --body
+#   printf 'LGTM' | git-cli pr comment 42 --body-file -
 BODY=""
 REMAINING_ARGS=()
+
+# Read all of stdin into BODY without blocking forever on an open, silent pipe.
+# A non-TTY pipe with no data and no EOF errors after GIT_CLI_STDIN_TIMEOUT
+# seconds rather than hanging. read -r -d '' returns non-zero (<=128) at EOF
+# with the full payload in $data; a timeout returns >128.
+read_body_from_stdin() {
+  [[ ! -t 0 ]] || die "--body-file - requires piped input (pipe or heredoc), not a terminal"
+  local timeout_secs="${GIT_CLI_STDIN_TIMEOUT:-10}" data="" rc=0
+  IFS= read -r -d '' -t "$timeout_secs" data || rc=$?
+  [[ $rc -le 128 ]] || die "timed out after ${timeout_secs}s reading body from stdin (no data/EOF) — pass --body TEXT or --body-file FILE, or pipe content to --body-file -"
+  BODY="$data"
+}
 
 parse_body_args() {
   BODY=""
@@ -98,7 +111,8 @@ parse_body_args() {
   local read_stdin=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --body)        read_stdin=1 ;;
+      --body)        [[ $# -gt 1 ]] || die "--body requires a value — pass text inline (--body \"...\") or use --body-file - to read stdin"
+                     shift; BODY="$1" ;;
       --body-file)   [[ $# -gt 1 ]] || die "--body-file requires a file path"; shift
                      if [[ "$1" == "-" ]]; then read_stdin=1
                      else [[ -f "$1" ]] || die "body-file not found: $1"; BODY="$(cat "$1")"
@@ -108,8 +122,7 @@ parse_body_args() {
     shift
   done
   if [[ "$read_stdin" == "1" ]]; then
-    [[ ! -t 0 ]] || die "--body requires body on stdin (pipe or heredoc)"
-    BODY="$(cat)"
+    read_body_from_stdin
   fi
 }
 
@@ -1264,22 +1277,22 @@ git-tools — unified issue/PR/CI wrapper for GitHub and Gitea
 Platform is auto-detected from the git remote using tea login configuration.
 
 BODY INPUT
-  --body            read body from stdin (heredoc or pipe)
+  --body TEXT       body text (inline; matches gh/tea)
   --body-file FILE  read body from FILE (use "-" for stdin)
 
 ISSUE COMMANDS
   git-tools issue list   [--limit N] [--assignee U] [--label L] [--state open|closed|all]
   git-tools issue show   <N>
-  git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
-  git-tools issue comment <N> [--body | --body-file FILE]
+  git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
+  git-tools issue comment <N> [--body TEXT | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
   git-tools pr show      <N> | --branch NAME
-  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
-  git-tools pr comment   <N> [--body | --body-file FILE]
+  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
+  git-tools pr comment   <N> [--body TEXT | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]

--- a/plugins-claude/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-tools/skills/git-cli/SKILL.md
@@ -24,18 +24,27 @@ Run `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli --help` for the full subcommand list 
 
 ## Body input
 
-`--body` reads from stdin (heredoc or pipe). No temp files, no `--body TEXT` form:
+`--body TEXT` takes an inline argument (matches `gh`/`tea`) and never reads stdin —
+use it for short, single-line bodies:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body <<'EOF'
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment 42 --body "LGTM"
+```
+
+For multi-line bodies, read from stdin with `--body-file -` (heredoc or pipe), or
+from disk with `--body-file FILE`:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue create --title "Bug: ..." --label bug --body-file - <<'EOF'
 ## Problem
 ...
 EOF
 
-printf 'LGTM' | ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr comment 42 --body
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "..." --head my-branch --body-file /tmp/pr-body.md
 ```
 
-`--body-file FILE` is also available (`--body-file -` is equivalent to `--body`).
+`--body-file -` never hangs: if stdin is an open pipe with no data/EOF it errors
+after `GIT_CLI_STDIN_TIMEOUT` seconds (default 10) instead of blocking.
 
 ## Normalized JSON output
 

--- a/plugins-claude/git-tools/skills/ship/SKILL.md
+++ b/plugins-claude/git-tools/skills/ship/SKILL.md
@@ -87,7 +87,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr list --state open --limit 50 \
 If no PR exists for the current branch:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "..." --head "$(git rev-parse --abbrev-ref HEAD)" --body <<'EOF'
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr create --title "..." --head "$(git rev-parse --abbrev-ref HEAD)" --body-file - <<'EOF'
 ## Summary
 ...
 

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Work session management — issue-driven branch lifecycle with checkpointing, cross-machine handoffs, resume, reset, and multi-agent orchestration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -7,17 +7,17 @@
 # Usage:
 #   git-tools issue list   [--limit N] [--assignee USER] [--label L] [--state open|closed|all]
 #   git-tools issue show   <N>
-#   git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
-#   git-tools issue comment <N> [--body | --body-file FILE]
+#   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
+#   git-tools issue comment <N> [--body TEXT | --body-file FILE]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
 #   git-tools pr show      <N> | --branch NAME
-#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
-#   git-tools pr comment   <N> [--body | --body-file FILE]
+#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
+#   git-tools pr comment   <N> [--body TEXT | --body-file FILE]
 #
-#   (--body reads from stdin; --body-file FILE reads from disk, or "-" for stdin)
+#   (--body TEXT is inline; --body-file FILE reads from disk, or "-" for stdin)
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
@@ -80,17 +80,30 @@ cli_json() {
 # Read body from --body or --body-file flags. Sets BODY variable.
 # Call: parse_body_args "$@" then access $BODY and $REMAINING_ARGS.
 #
-# --body reads from stdin. This is the only stdin-capable flag: no --body TEXT,
-# no temp-file pattern required. Multi-line structured content uses heredoc;
-# short comments pipe in via printf. --body-file FILE (or --body-file -) remains
-# for callers that already have content on disk.
-#   git-cli pr create --title "..." --head branch --body <<'EOF'
+# --body TEXT takes an inline argument (matches gh/tea); it never reads stdin.
+# --body-file FILE reads from disk. --body-file - reads from stdin (heredoc or
+# pipe) via a bounded read that errors instead of hanging when stdin is an open
+# pipe with no data/EOF (the situation that hung agent/CI callers, see #114).
+#   git-cli pr create --title "..." --head branch --body "Short summary"
+#   git-cli issue create --title "..." --body-file - <<'EOF'
 #   ## Summary
 #   ...
 #   EOF
-#   printf 'LGTM' | git-cli pr comment 42 --body
+#   printf 'LGTM' | git-cli pr comment 42 --body-file -
 BODY=""
 REMAINING_ARGS=()
+
+# Read all of stdin into BODY without blocking forever on an open, silent pipe.
+# A non-TTY pipe with no data and no EOF errors after GIT_CLI_STDIN_TIMEOUT
+# seconds rather than hanging. read -r -d '' returns non-zero (<=128) at EOF
+# with the full payload in $data; a timeout returns >128.
+read_body_from_stdin() {
+  [[ ! -t 0 ]] || die "--body-file - requires piped input (pipe or heredoc), not a terminal"
+  local timeout_secs="${GIT_CLI_STDIN_TIMEOUT:-10}" data="" rc=0
+  IFS= read -r -d '' -t "$timeout_secs" data || rc=$?
+  [[ $rc -le 128 ]] || die "timed out after ${timeout_secs}s reading body from stdin (no data/EOF) — pass --body TEXT or --body-file FILE, or pipe content to --body-file -"
+  BODY="$data"
+}
 
 parse_body_args() {
   BODY=""
@@ -98,7 +111,8 @@ parse_body_args() {
   local read_stdin=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --body)        read_stdin=1 ;;
+      --body)        [[ $# -gt 1 ]] || die "--body requires a value — pass text inline (--body \"...\") or use --body-file - to read stdin"
+                     shift; BODY="$1" ;;
       --body-file)   [[ $# -gt 1 ]] || die "--body-file requires a file path"; shift
                      if [[ "$1" == "-" ]]; then read_stdin=1
                      else [[ -f "$1" ]] || die "body-file not found: $1"; BODY="$(cat "$1")"
@@ -108,8 +122,7 @@ parse_body_args() {
     shift
   done
   if [[ "$read_stdin" == "1" ]]; then
-    [[ ! -t 0 ]] || die "--body requires body on stdin (pipe or heredoc)"
-    BODY="$(cat)"
+    read_body_from_stdin
   fi
 }
 
@@ -1264,22 +1277,22 @@ git-tools — unified issue/PR/CI wrapper for GitHub and Gitea
 Platform is auto-detected from the git remote using tea login configuration.
 
 BODY INPUT
-  --body            read body from stdin (heredoc or pipe)
+  --body TEXT       body text (inline; matches gh/tea)
   --body-file FILE  read body from FILE (use "-" for stdin)
 
 ISSUE COMMANDS
   git-tools issue list   [--limit N] [--assignee U] [--label L] [--state open|closed|all]
   git-tools issue show   <N>
-  git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
-  git-tools issue comment <N> [--body | --body-file FILE]
+  git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
+  git-tools issue comment <N> [--body TEXT | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
   git-tools pr show      <N> | --branch NAME
-  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
-  git-tools pr comment   <N> [--body | --body-file FILE]
+  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
+  git-tools pr comment   <N> [--body TEXT | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Work session management — issue-driven branch lifecycle with checkpointing, cross-machine handoffs, resume, reset, and multi-agent orchestration",
   "author": {
     "name": "Logan Gagne"

--- a/tests/git-cli/test-body-args.sh
+++ b/tests/git-cli/test-body-args.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# test-body-args.sh — Test harness for git-cli parse_body_args().
+# Covers --body TEXT (inline), --body-file - (stdin via pipe/heredoc), the
+# no-value error, and the no-hang guard on an open/silent stdin pipe (#114).
+# Uses mock gh/git scripts via PATH injection.
+#
+# Usage: bash tests/git-cli/test-body-args.sh [filter]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GIT_CLI="$SCRIPT_DIR/../../utils/git-cli"
+
+PASS=0
+FAIL=0
+SKIP=0
+FILTER="${1:-}"
+
+MOCK_DIR=""
+cleanup() { [[ -n "$MOCK_DIR" ]] && rm -rf "$MOCK_DIR"; }
+trap cleanup EXIT
+MOCK_DIR=$(mktemp -d)
+
+BODY_FILE="$MOCK_DIR/.captured_body"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  printf "  \033[32m✓\033[0m %s\n" "$1"
+  ((PASS++)) || true
+}
+
+fail() {
+  printf "  \033[31m✗\033[0m %s  (%s)\n" "$1" "$2"
+  ((FAIL++)) || true
+}
+
+skip_filtered() {
+  # Returns 0 (skip) when a filter is set and does not match the label.
+  [[ -n "$FILTER" ]] && ! echo "$1" | grep -qi "$FILTER"
+}
+
+# Mock git so platform detection resolves to github.
+cat >"$MOCK_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") echo "https://github.com/owner/repo.git" ;;
+  "config user.name") echo "testuser" ;;
+  *) command git "$@" ;;
+esac
+EOF
+chmod +x "$MOCK_DIR/git"
+
+# Mock gh: capture the value passed to --body into BODY_FILE for any subcommand.
+cat >"$MOCK_DIR/gh" <<MOCK_EOF
+#!/usr/bin/env bash
+args=("\$@")
+case "\$1:\$2" in
+  repo:view) echo "main" ;;
+  api:*)     echo '{"login":"testuser"}' ;;
+  *)
+    for ((i=0; i<\${#args[@]}; i++)); do
+      if [[ "\${args[\$i]}" == "--body" ]]; then
+        printf '%s' "\${args[\$((i+1))]}" > "$BODY_FILE"
+      fi
+    done
+    echo "https://github.com/owner/repo/pull/1"
+    ;;
+esac
+MOCK_EOF
+chmod +x "$MOCK_DIR/gh"
+
+run_gh() {
+  # run_gh <stdin-source> -- <git-cli args...>; sets EXIT, captures stderr.
+  rm -f "$BODY_FILE"
+  local stdin_src="$1"
+  shift
+  [[ "$1" == "--" ]] && shift
+  EXIT=0
+  if [[ "$stdin_src" == "none" ]]; then
+    PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" "$@" </dev/null >/dev/null 2>"$MOCK_DIR/stderr" || EXIT=$?
+  else
+    printf '%s' "$stdin_src" | PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" "$@" >/dev/null 2>"$MOCK_DIR/stderr" || EXIT=$?
+  fi
+  STDERR=$(cat "$MOCK_DIR/stderr")
+}
+
+# ---------------------------------------------------------------------------
+# Test: --body TEXT is inline and never reads stdin
+# ---------------------------------------------------------------------------
+
+echo "── parse_body_args: --body TEXT inline ──"
+
+label="--body TEXT → inline value reaches gh (pr create)"
+if ! skip_filtered "$label"; then
+  run_gh none -- pr create --title "T" --head "feature" --body "inline body text"
+  if [[ "$EXIT" == "0" ]] && [[ -f "$BODY_FILE" ]] && grep -qx "inline body text" "$BODY_FILE"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT body='$(cat "$BODY_FILE" 2>/dev/null)' stderr=$STDERR"
+  fi
+else ((SKIP++)) || true; fi
+
+label="--body TEXT → inline value reaches gh (issue create, shared parse_body_args)"
+if ! skip_filtered "$label"; then
+  run_gh none -- issue create --title "T" --body "issue inline"
+  if [[ "$EXIT" == "0" ]] && [[ -f "$BODY_FILE" ]] && grep -qx "issue inline" "$BODY_FILE"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT body='$(cat "$BODY_FILE" 2>/dev/null)' stderr=$STDERR"
+  fi
+else ((SKIP++)) || true; fi
+
+label="--body TEXT → inline value reaches gh (pr comment)"
+if ! skip_filtered "$label"; then
+  run_gh none -- pr comment 42 --body "looks good"
+  if [[ "$EXIT" == "0" ]] && [[ -f "$BODY_FILE" ]] && grep -qx "looks good" "$BODY_FILE"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT body='$(cat "$BODY_FILE" 2>/dev/null)' stderr=$STDERR"
+  fi
+else ((SKIP++)) || true; fi
+
+label="--body with no inline value → exit 1 (requires a value)"
+if ! skip_filtered "$label"; then
+  run_gh none -- pr create --title "T" --head "feature" --body
+  if [[ "$EXIT" == "1" ]] && echo "$STDERR" | grep -q "requires a value"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT stderr=$STDERR"
+  fi
+else ((SKIP++)) || true; fi
+
+# ---------------------------------------------------------------------------
+# Test: --body-file - reads stdin
+# ---------------------------------------------------------------------------
+
+echo "── parse_body_args: --body-file - stdin ──"
+
+label="--body-file - reads piped stdin"
+if ! skip_filtered "$label"; then
+  run_gh "piped via stdin" -- pr create --title "T" --head "feature" --body-file -
+  if [[ "$EXIT" == "0" ]] && [[ -f "$BODY_FILE" ]] && grep -q "piped via stdin" "$BODY_FILE"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT body='$(cat "$BODY_FILE" 2>/dev/null)' stderr=$STDERR"
+  fi
+else ((SKIP++)) || true; fi
+
+label="--body-file - reads multi-line heredoc from stdin"
+if ! skip_filtered "$label"; then
+  rm -f "$BODY_FILE"
+  EXIT=0
+  PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
+    --title "T" --head "feature" --body-file - >/dev/null 2>"$MOCK_DIR/stderr" <<'BODY_EOF' || EXIT=$?
+## Summary
+line one
+line two
+BODY_EOF
+  if [[ "$EXIT" == "0" ]] && [[ -f "$BODY_FILE" ]] &&
+    grep -q "line one" "$BODY_FILE" && grep -q "line two" "$BODY_FILE"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT body='$(cat "$BODY_FILE" 2>/dev/null)' stderr=$(cat "$MOCK_DIR/stderr")"
+  fi
+else ((SKIP++)) || true; fi
+
+label="--body-file - with EOF stdin (/dev/null) → empty body, succeeds (pr create)"
+if ! skip_filtered "$label"; then
+  rm -f "$BODY_FILE"
+  EXIT=0
+  PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
+    --title "T" --head "feature" --body-file - </dev/null >/dev/null 2>"$MOCK_DIR/stderr" || EXIT=$?
+  # Empty BODY means git-cli passes no --body to gh, so BODY_FILE is never written.
+  if [[ "$EXIT" == "0" ]] && [[ ! -f "$BODY_FILE" ]]; then
+    pass "$label"
+  else
+    fail "$label" "exit=$EXIT body='$(cat "$BODY_FILE" 2>/dev/null)' stderr=$(cat "$MOCK_DIR/stderr")"
+  fi
+else ((SKIP++)) || true; fi
+
+# ---------------------------------------------------------------------------
+# Test: no-hang guard — open/silent stdin pipe errors fast instead of blocking
+# ---------------------------------------------------------------------------
+
+echo "── parse_body_args: no-hang guard (#114) ──"
+
+label="--body-file - with open silent pipe → errors within timeout, does not hang"
+if ! skip_filtered "$label"; then
+  EXIT=0
+  start=$(date +%s)
+  # < <(sleep 8) gives a non-TTY pipe with no data and no EOF for 8s. With a 1s
+  # timeout the read must error (~1s); the old cat-based code would block ~8s.
+  GIT_CLI_STDIN_TIMEOUT=1 PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
+    --title "T" --head "feature" --body-file - >/dev/null 2>"$MOCK_DIR/stderr" < <(sleep 8) || EXIT=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+  if [[ "$EXIT" == "1" ]] && [[ "$elapsed" -lt 5 ]] && echo "$(cat "$MOCK_DIR/stderr")" | grep -q "timed out"; then
+    pass "$label (exited in ${elapsed}s)"
+  else
+    fail "$label" "exit=$EXIT elapsed=${elapsed}s stderr=$(cat "$MOCK_DIR/stderr")"
+  fi
+else ((SKIP++)) || true; fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Total: $((PASS + FAIL))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/tests/git-cli/test-pr-create.sh
+++ b/tests/git-cli/test-pr-create.sh
@@ -238,10 +238,10 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test: --body reads from stdin (heredoc)
+# Test: --body-file - reads from stdin (heredoc)
 # ---------------------------------------------------------------------------
 
-echo "── pr create: --body stdin ──"
+echo "── pr create: --body-file - stdin ──"
 
 BODY_FILE="$MOCK_DIR/.gh_body"
 
@@ -267,7 +267,7 @@ chmod +x "$MOCK_DIR/gh"
 exit_code=0
 output=$(
   PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
-    --title "Stdin PR" --head "feature" --body <<'BODY_EOF' 2>"$MOCK_DIR/stderr"
+    --title "Stdin PR" --head "feature" --body-file - <<'BODY_EOF' 2>"$MOCK_DIR/stderr"
 ## Summary
 multi-line body from stdin
 
@@ -279,22 +279,20 @@ BODY_EOF
 if [[ "$exit_code" == "0" ]] && [[ -f "$BODY_FILE" ]] &&
   grep -q "multi-line body from stdin" "$BODY_FILE" &&
   grep -q "bullet one" "$BODY_FILE"; then
-  pass "--body reads heredoc from stdin and passes to gh"
+  pass "--body-file - reads heredoc from stdin and passes to gh"
 else
-  fail "--body reads heredoc from stdin" \
+  fail "--body-file - reads heredoc from stdin" \
     "exit=$exit_code body=$(cat "$BODY_FILE" 2>/dev/null) stderr=$(cat "$MOCK_DIR/stderr")"
 fi
 
-# --body with no stdin (terminal) should error
+# --body with no inline value should error (no longer reads stdin)
 exit_code=0
 PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr create \
-  --title "No stdin" --head "feature" --body </dev/null 2>"$MOCK_DIR/stderr" >/dev/null || exit_code=$?
-# /dev/null satisfies the `-t 0` check (not a terminal), so gh will be called with empty body.
-# The real "terminal" path can't be exercised non-interactively, so we skip that assertion.
-if [[ "$exit_code" == "0" ]]; then
-  pass "--body with empty stdin (pipe from /dev/null) succeeds with empty body"
+  --title "No value" --head "feature" --body </dev/null 2>"$MOCK_DIR/stderr" >/dev/null || exit_code=$?
+if [[ "$exit_code" == "1" ]] && grep -q "requires a value" "$MOCK_DIR/stderr"; then
+  pass "--body with no inline value → exit 1 (requires a value)"
 else
-  fail "--body with empty stdin" "exit=$exit_code stderr=$(cat "$MOCK_DIR/stderr")"
+  fail "--body with no inline value → exit 1" "exit=$exit_code stderr=$(cat "$MOCK_DIR/stderr")"
 fi
 
 # --body-file - is an alias for stdin

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -7,17 +7,17 @@
 # Usage:
 #   git-tools issue list   [--limit N] [--assignee USER] [--label L] [--state open|closed|all]
 #   git-tools issue show   <N>
-#   git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
-#   git-tools issue comment <N> [--body | --body-file FILE]
+#   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
+#   git-tools issue comment <N> [--body TEXT | --body-file FILE]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
 #   git-tools pr list      [--state open|closed|merged|all] [--assignee USER]
 #   git-tools pr show      <N> | --branch NAME
-#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
-#   git-tools pr comment   <N> [--body | --body-file FILE]
+#   git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
+#   git-tools pr comment   <N> [--body TEXT | --body-file FILE]
 #
-#   (--body reads from stdin; --body-file FILE reads from disk, or "-" for stdin)
+#   (--body TEXT is inline; --body-file FILE reads from disk, or "-" for stdin)
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
@@ -80,17 +80,30 @@ cli_json() {
 # Read body from --body or --body-file flags. Sets BODY variable.
 # Call: parse_body_args "$@" then access $BODY and $REMAINING_ARGS.
 #
-# --body reads from stdin. This is the only stdin-capable flag: no --body TEXT,
-# no temp-file pattern required. Multi-line structured content uses heredoc;
-# short comments pipe in via printf. --body-file FILE (or --body-file -) remains
-# for callers that already have content on disk.
-#   git-cli pr create --title "..." --head branch --body <<'EOF'
+# --body TEXT takes an inline argument (matches gh/tea); it never reads stdin.
+# --body-file FILE reads from disk. --body-file - reads from stdin (heredoc or
+# pipe) via a bounded read that errors instead of hanging when stdin is an open
+# pipe with no data/EOF (the situation that hung agent/CI callers, see #114).
+#   git-cli pr create --title "..." --head branch --body "Short summary"
+#   git-cli issue create --title "..." --body-file - <<'EOF'
 #   ## Summary
 #   ...
 #   EOF
-#   printf 'LGTM' | git-cli pr comment 42 --body
+#   printf 'LGTM' | git-cli pr comment 42 --body-file -
 BODY=""
 REMAINING_ARGS=()
+
+# Read all of stdin into BODY without blocking forever on an open, silent pipe.
+# A non-TTY pipe with no data and no EOF errors after GIT_CLI_STDIN_TIMEOUT
+# seconds rather than hanging. read -r -d '' returns non-zero (<=128) at EOF
+# with the full payload in $data; a timeout returns >128.
+read_body_from_stdin() {
+  [[ ! -t 0 ]] || die "--body-file - requires piped input (pipe or heredoc), not a terminal"
+  local timeout_secs="${GIT_CLI_STDIN_TIMEOUT:-10}" data="" rc=0
+  IFS= read -r -d '' -t "$timeout_secs" data || rc=$?
+  [[ $rc -le 128 ]] || die "timed out after ${timeout_secs}s reading body from stdin (no data/EOF) — pass --body TEXT or --body-file FILE, or pipe content to --body-file -"
+  BODY="$data"
+}
 
 parse_body_args() {
   BODY=""
@@ -98,7 +111,8 @@ parse_body_args() {
   local read_stdin=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --body)        read_stdin=1 ;;
+      --body)        [[ $# -gt 1 ]] || die "--body requires a value — pass text inline (--body \"...\") or use --body-file - to read stdin"
+                     shift; BODY="$1" ;;
       --body-file)   [[ $# -gt 1 ]] || die "--body-file requires a file path"; shift
                      if [[ "$1" == "-" ]]; then read_stdin=1
                      else [[ -f "$1" ]] || die "body-file not found: $1"; BODY="$(cat "$1")"
@@ -108,8 +122,7 @@ parse_body_args() {
     shift
   done
   if [[ "$read_stdin" == "1" ]]; then
-    [[ ! -t 0 ]] || die "--body requires body on stdin (pipe or heredoc)"
-    BODY="$(cat)"
+    read_body_from_stdin
   fi
 }
 
@@ -1264,22 +1277,22 @@ git-tools — unified issue/PR/CI wrapper for GitHub and Gitea
 Platform is auto-detected from the git remote using tea login configuration.
 
 BODY INPUT
-  --body            read body from stdin (heredoc or pipe)
+  --body TEXT       body text (inline; matches gh/tea)
   --body-file FILE  read body from FILE (use "-" for stdin)
 
 ISSUE COMMANDS
   git-tools issue list   [--limit N] [--assignee U] [--label L] [--state open|closed|all]
   git-tools issue show   <N>
-  git-tools issue create --title T [--body | --body-file FILE] [--label L] [--assignee U]
-  git-tools issue comment <N> [--body | --body-file FILE]
+  git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
+  git-tools issue comment <N> [--body TEXT | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
 PR COMMANDS
   git-tools pr list      [--state open|closed|merged|all] [--assignee U] [--limit N]
   git-tools pr show      <N> | --branch NAME
-  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body | --body-file FILE]
-  git-tools pr comment   <N> [--body | --body-file FILE]
+  git-tools pr create    --title T --head BRANCH [--base BRANCH] [--body TEXT | --body-file FILE]
+  git-tools pr comment   <N> [--body TEXT | --body-file FILE]
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]


### PR DESCRIPTION
## Summary

`git-cli --body` was stdin-only — it set `read_stdin=1` and ran `BODY="$(cat)"`, which blocks until stdin EOF. The only guard was `[[ ! -t 0 ]]`, which distinguishes a TTY from a non-TTY but **not** "data was piped in (will EOF)" from "stdin is an open pipe with no data and no EOF" (the normal situation for agent/CI shells). Two failures resulted:

1. **Hang** — a non-TTY caller whose stdin is an open silent pipe blocked forever on `cat` (observed: 15+ min PR-create hangs from Claude Code on macOS).
2. **Surprising API** — `--body "text"` (how `gh`/`tea` work) was silently ignored; the text landed in `REMAINING_ARGS` and stdin was read instead, then hung.

This affected every subcommand using `parse_body_args`: `pr create`, `pr comment`, `issue create`, `issue comment`.

### Fix (matches the issue author's recommendation)

- `--body TEXT` now takes an **inline argument** (matching `gh`/`tea`) and never touches stdin; bare `--body` with no value errors clearly instead of hanging.
- stdin reads go exclusively through `--body-file -`, via a new `read_body_from_stdin()` that uses a bounded `read -r -d '' -t` (bash builtin, macOS bash 3.2 safe). An open/silent pipe errors after `GIT_CLI_STDIN_TIMEOUT` seconds (default 10) instead of blocking forever.
- `--body-file FILE` (disk) is unchanged.

### Changes

- **`utils/git-cli`** — rewrite `parse_body_args` `--body` arm; add `read_body_from_stdin`; update header synopsis, block comment, and `--help` text.
- **`git-tools` `git-cli` + `ship` skills** — document `--body TEXT`; migrate the in-repo bare-`--body` heredoc usage to `--body-file -`.
- **Tests** — new `tests/git-cli/test-body-args.sh` (inline value across pr-create/issue-create/pr-comment, no-value error, `--body-file -` pipe/heredoc/`/dev/null`, and a no-hang guard asserting exit 1 in <5s); update `tests/git-cli/test-pr-create.sh` for the new semantics.
- **Vendoring + versions** — re-vendor `git-cli` into `git-tools` and `session`; bump `git-tools` 2.0.9 → 2.0.10 and `session` 3.11.0 → 3.11.1 (claude + copilot).

## Test plan

- [x] `bash tests/git-cli/test-body-args.sh` — 8/8 pass
- [x] `bash tests/git-cli/test-pr-create.sh` — 8/8 pass
- [x] `bash test.sh` — 1575 passed, 0 failed (22 suites)
- [x] `bash .github/scripts/validate-plugins.sh` — 282 checks, 0 failures (version sync + vendored drift clean)
- [x] `bash .github/scripts/validate-frontmatter.sh` — 109 checks, 0 failures
- [x] `rumdl check` on edited markdown — clean
- [x] Live no-hang smoke: `GIT_CLI_STDIN_TIMEOUT=2 git-cli pr create ... --body-file - < <(sleep 30)` errors in 2s, exit 1

Fixes #114