### PR TITLE
fix(agentic-ide): install semgrep engine onto PATH for semgrep-mcp

### DIFF
--- a/plugins-claude/agentic-ide/.claude-plugin/plugin.json
+++ b/plugins-claude/agentic-ide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-ide",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/agentic-ide/skills/setup/SKILL.md
+++ b/plugins-claude/agentic-ide/skills/setup/SKILL.md
@@ -29,6 +29,11 @@ if command -v semgrep-mcp &>/dev/null; then
 else
   echo "✗ semgrep-mcp not installed"
 fi
+if command -v semgrep &>/dev/null; then
+  echo "✓ semgrep     $(semgrep --version 2>&1 | head -1)"
+else
+  echo "✗ semgrep     not on PATH (semgrep-mcp scans will fail)"
+fi
 echo
 echo "MCP servers must also be registered in ~/.claude.json — see sections below."
 ```
@@ -96,14 +101,15 @@ Verify: `ast-grep --version`. No MCP registration — it's a plain CLI.
 
 ## Semgrep (security and dataflow)
 
-The MCP server bundles the scan engine — no separate `semgrep` CLI install required.
+`semgrep-mcp` shells out to the `semgrep` scan engine at runtime, so the `semgrep` binary must be on `PATH`. `uv tool install` only links the primary tool's entry point, so install the engine's executable alongside it:
 
 ```bash
-uv tool install semgrep-mcp
-# equivalent: pipx install semgrep-mcp / uvx semgrep-mcp for on-demand
+uv tool install semgrep-mcp --with-executables-from semgrep
+# --with-executables-from also links the `semgrep` engine binary onto PATH
+# equivalent: pipx install semgrep-mcp && pipx install semgrep
 ```
 
-Verify: `which semgrep-mcp && semgrep-mcp --help | head -3`. Upgrade later with `uv tool upgrade semgrep-mcp`.
+Verify: `which semgrep semgrep-mcp && semgrep --version`. Both binaries must resolve; if `semgrep` is missing, MCP scans will fail. Upgrade later with `uv tool upgrade semgrep-mcp`.
 
 Register in `~/.claude.json`:
 
@@ -133,3 +139,4 @@ If MCP tools don't appear after registration:
 - `which <command>` — binary must be on `PATH`
 - MCP entry uses `"type": "stdio"` and the binary name as `command`
 - Restart the Claude Code session, or toggle the MCP server entry
+- Scans failing with `Semgrep is not installed or not in your PATH` → the `semgrep` engine binary isn't on `PATH`; reinstall with `uv tool install semgrep-mcp --with-executables-from semgrep`

--- a/plugins-copilot/agentic-ide/.claude-plugin/plugin.json
+++ b/plugins-copilot/agentic-ide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-ide",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/agentic-ide/commands/setup.md
+++ b/plugins-copilot/agentic-ide/commands/setup.md
@@ -28,6 +28,11 @@ if command -v semgrep-mcp &>/dev/null; then
 else
   echo "✗ semgrep-mcp not installed"
 fi
+if command -v semgrep &>/dev/null; then
+  echo "✓ semgrep     $(semgrep --version 2>&1 | head -1)"
+else
+  echo "✗ semgrep     not on PATH (semgrep-mcp scans will fail)"
+fi
 echo
 echo "MCP servers must also be registered in ~/.claude.json — see sections below."
 ```
@@ -95,14 +100,15 @@ Verify: `ast-grep --version`. No MCP registration — it's a plain CLI.
 
 ## Semgrep (security and dataflow)
 
-The MCP server bundles the scan engine — no separate `semgrep` CLI install required.
+`semgrep-mcp` shells out to the `semgrep` scan engine at runtime, so the `semgrep` binary must be on `PATH`. `uv tool install` only links the primary tool's entry point, so install the engine's executable alongside it:
 
 ```bash
-uv tool install semgrep-mcp
-# equivalent: pipx install semgrep-mcp / uvx semgrep-mcp for on-demand
+uv tool install semgrep-mcp --with-executables-from semgrep
+# --with-executables-from also links the `semgrep` engine binary onto PATH
+# equivalent: pipx install semgrep-mcp && pipx install semgrep
 ```
 
-Verify: `which semgrep-mcp && semgrep-mcp --help | head -3`. Upgrade later with `uv tool upgrade semgrep-mcp`.
+Verify: `which semgrep semgrep-mcp && semgrep --version`. Both binaries must resolve; if `semgrep` is missing, MCP scans will fail. Upgrade later with `uv tool upgrade semgrep-mcp`.
 
 Register in `~/.claude.json`:
 
@@ -132,3 +138,4 @@ If MCP tools don't appear after registration:
 - `which <command>` — binary must be on `PATH`
 - MCP entry uses `"type": "stdio"` and the binary name as `command`
 - Restart the Claude Code session, or toggle the MCP server entry
+- Scans failing with `Semgrep is not installed or not in your PATH` → the `semgrep` engine binary isn't on `PATH`; reinstall with `uv tool install semgrep-mcp --with-executables-from semgrep`


### PR DESCRIPTION
## Summary

The `agentic-ide:setup` skill wrongly claimed `semgrep-mcp` bundles the scan engine and installed it with a bare `uv tool install semgrep-mcp`. In reality `semgrep-mcp` shells out to the `semgrep` binary via subprocess, and `uv tool install semgrep-mcp` only links the `semgrep-mcp` entry point onto `PATH` — not the `semgrep` binary — so scans fail with `Semgrep is not installed or not in your PATH` even though the package is installed.

- Install with `uv tool install semgrep-mcp --with-executables-from semgrep` so the engine binary is linked onto `PATH`
- Replace the false "bundles the scan engine" claim with accurate guidance
- Add a `semgrep` engine row to the status check
- Update the verify step to confirm the engine is reachable
- Add a troubleshooting bullet for the PATH failure
- Bump `agentic-ide` 1.0.1 -> 1.0.2 (both Claude and Copilot)

Fixes #116

## Test plan

- [x] `bash .github/scripts/validate-plugins.sh` (282 checks, version sync ok)
- [x] `bash .github/scripts/validate-frontmatter.sh` (109 checks)
- [x] `rumdl check` on both edited files (clean)
- [x] `bash test.sh` (1575 passed)
- [x] `--with-executables-from` confirmed valid in uv 0.11.16