### PR TITLE
feat(session): integrate git worktrees into the session workflow

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "Work session management — issue-driven branch lifecycle with checkpointing, cross-machine handoffs, resume, reset, and multi-agent orchestration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/catchup
+++ b/plugins-claude/session/scripts/catchup
@@ -69,8 +69,9 @@ if $is_git; then
     fi
 
     # Show linked issue number if branch matches type/NNN-* pattern
-    if [[ "$current_branch" =~ ^[a-z]+/([0-9]+)- ]]; then
-        echo "linked-issue: #${BASH_REMATCH[1]}"
+    # (tolerates an optional worktree- prefix from native worktree branches)
+    if [[ "$current_branch" =~ ^(worktree-)?[a-z]+[/-]([0-9]+)- ]]; then
+        echo "linked-issue: #${BASH_REMATCH[2]}"
     fi
 else
     echo "=== BRANCH ==="

--- a/plugins-claude/session/scripts/handoff
+++ b/plugins-claude/session/scripts/handoff
@@ -121,8 +121,9 @@ else
 fi
 
 # Post issue comment if branch matches type/NNN-* and comment provided
-if [[ -n "$issue_comment" && "$branch" =~ ^[a-z]+/([0-9]+)- ]]; then
-    issue_number="${BASH_REMATCH[1]}"
+# (tolerates an optional worktree- prefix from native worktree branches)
+if [[ -n "$issue_comment" && "$branch" =~ ^(worktree-)?[a-z]+[/-]([0-9]+)- ]]; then
+    issue_number="${BASH_REMATCH[2]}"
     tmp_comment=$(mktemp /tmp/handoff-comment.XXXXXX.md)
     echo "$issue_comment" > "$tmp_comment"
     if bash "${SCRIPT_DIR}/git-cli" issue comment "$issue_number" --body-file "$tmp_comment" 2>&1; then

--- a/plugins-claude/session/scripts/sitrep
+++ b/plugins-claude/session/scripts/sitrep
@@ -86,8 +86,9 @@ if [[ -n "$base_ref" ]]; then
 fi
 
 # Linked issue from branch name
-if [[ -n "$head_branch" && "$head_branch" =~ ^[a-z]+/([0-9]+)- ]]; then
-    echo "linked_issue: #${BASH_REMATCH[1]}"
+# (tolerates an optional worktree- prefix from native worktree branches)
+if [[ -n "$head_branch" && "$head_branch" =~ ^(worktree-)?[a-z]+[/-]([0-9]+)- ]]; then
+    echo "linked_issue: #${BASH_REMATCH[2]}"
 fi
 
 # --- Tier 1: Uncommitted changes ---

--- a/plugins-claude/session/skills/session-end/SKILL.md
+++ b/plugins-claude/session/skills/session-end/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: session-end
 description: "Review, clean up, and open a PR to finalize the work"
-allowed-tools: Bash, Read, AskUserQuestion, Task
+allowed-tools: Bash, Read, AskUserQuestion, Task, ExitWorktree
 ---
 
 Finalize the work: review, clean up commits, push, open a PR,
@@ -164,34 +164,52 @@ watch CI, and return to the default branch.
 
    Parse the key:value stdout output (`status`,
    `pr_number`, `url`, `duration`). Then:
-   - **`merged`** — continue to step 9
-   - **`closed`** — ask via AskUserQuestion:
-     - **Return to default branch** — continue to step 9
-     - **Investigate** — pause the `end` flow for the
-       user to investigate
-   - **`blocked`** — ask via AskUserQuestion:
-     - **Fix conflicts** — pause the `end` flow for the
-       user to resolve conflicts and re-invoke
-     - **Skip wait** — continue to step 9
-   - **`timeout`** — if auto-merge was detected in
-     step 8a, automatically re-run `pr wait` with
-     `--timeout 600` (up to 2 retries, no prompt).
-     If auto-merge was NOT detected, ask via
-     AskUserQuestion:
-     - **Wait longer** — re-run `pr wait` with a
-       longer `--timeout`
-     - **Return now** — continue to step 9
-   - **`no-pr`** — note that no PR was found;
-     continue to step 9
 
-9. **Return to default branch:**
+- **`merged`** — continue to step 9
+- **`closed`** — ask via AskUserQuestion:
+  - **Return to default branch** — continue to step 9
+  - **Investigate** — pause the `end` flow for the
+    user to investigate
+- **`blocked`** — ask via AskUserQuestion:
+  - **Fix conflicts** — pause the `end` flow for the
+    user to resolve conflicts and re-invoke
+  - **Skip wait** — continue to step 9
+- **`timeout`** — if auto-merge was detected in
+  step 8a, automatically re-run `pr wait` with
+  `--timeout 600` (up to 2 retries, no prompt).
+  If auto-merge was NOT detected, ask via
+  AskUserQuestion:
+  - **Wait longer** — re-run `pr wait` with a
+    longer `--timeout`
+  - **Return now** — continue to step 9
+- **`no-pr`** — note that no PR was found;
+  continue to step 9
 
-   ```bash
-   bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch default \
-     && git pull
-   ```
+9. **Return to the main checkout / default branch:**
 
-   Skip if already on the default branch.
+   - **If this session is in a worktree** (entered via
+     `EnterWorktree` this session): call `ExitWorktree`. Use
+     `action: remove` **only** when the PR merged (step 8b
+     returned `merged`) — this returns to the main checkout
+     and deletes the now-merged worktree and branch.
+     Otherwise use `action: keep` to preserve the work. If
+     `remove` reports uncommitted changes or unmerged
+     commits, fall back to `keep` (or confirm with the user
+     before re-invoking with `discard_changes: true`). Then
+     run `git pull` in the main checkout.
+   - **If `ExitWorktree` reports no active worktree session**
+     (the worktree was created in an earlier session): `cd`
+     to the main worktree root (first entry of
+     `git worktree list`), then — only if merged — run
+     `git worktree remove <path>` and `git branch -d <branch>`.
+   - **Otherwise** (in-place branch):
+
+     ```bash
+     bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch default \
+       && git pull
+     ```
+
+   Skip if already on the default branch in the main checkout.
 
 10. **Final summary** — present to the user:
     - PR URL (if created)

--- a/plugins-claude/session/skills/session-orchestrate/SKILL.md
+++ b/plugins-claude/session/skills/session-orchestrate/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: session-orchestrate
 description: "Multi-phase, multi-agent feature workflow: spec → plan → refine → divide → execute → review"
-allowed-tools: Bash, Agent, Read, Glob, Grep, AskUserQuestion
+allowed-tools: Bash, Agent, Read, Glob, Grep, AskUserQuestion, EnterWorktree
 ---
 
 Run a complex feature through a structured multi-agent workflow with explicit model tiering, user gates, and an automated review pass. Use this when work is non-trivial — multiple files, design ambiguity, cross-cutting concerns, or correctness-critical paths. For small fixes, prefer `/session:session-start` directly.
@@ -28,7 +28,16 @@ Before starting Phase 1, check whether prior phases of this workflow have alread
    - **Resume from Review** — execution done, run review pass only
    - **Start fresh** — discard prior context and run all phases
 
-   Otherwise proceed to Phase 1 with a fresh run.
+   Otherwise proceed to Phase 0b with a fresh run.
+
+### Phase 0b — Isolate in a worktree (default for fresh runs)
+
+Orchestrate runs are heavy and long-lived — **isolate them in a git worktree by default** so the main checkout stays clean and parallel sessions can coexist.
+
+- **Already isolated** — if the session is already in a worktree, or a feature branch is already checked out (inherited from `/session:session-start`'s escalation, or the current branch is not the default), proceed in the current checkout. Do **not** create another worktree.
+- **Fresh run on the default branch** — create the work's branch as a worktree by default. Derive a dash-form name: `<type>-<NNN>-<slug>` from the issue, or `wip-<slug>` from the description. **Before** creating, provision dependencies exactly as in `/session:session-start` Phase 2a (detect heavy gitignored dirs via `git check-ignore`; offer to write `worktree.symlinkDirectories` + `.worktreeinclude` to **project** config, asking first). Then call `EnterWorktree` with `name: <dash-form-name>` (yields branch `worktree-<name>`, provisions deps, switches the session in). Offer a one-key opt-out (work in place) via `AskUserQuestion`, but default to the worktree.
+
+Then proceed to Phase 1.
 
 ### Phase 1 — Spec exploration
 
@@ -197,6 +206,8 @@ Goal: summarize and route to the appropriate finalization flow.
    - **Pause here** — do nothing further; user will finalize manually
 
 Do NOT auto-commit, push, or open a PR — always go through the user's choice in this final gate.
+
+If this run created a worktree (Phase 0b), note that its teardown is deferred: `/session:session-end` removes it after the PR merges, or the user can leave it and exit later with `ExitWorktree`. Do not tear it down here.
 
 ### Notes
 

--- a/plugins-claude/session/skills/session-reset/SKILL.md
+++ b/plugins-claude/session/skills/session-reset/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: session-reset
 description: "Reset workspace to a clean state on the default branch"
-allowed-tools: Bash
+allowed-tools: Bash, ExitWorktree, AskUserQuestion
 ---
 
 Reset the workspace to a clean state on the default branch. Use this between tasks or to abandon in-progress work.
@@ -17,7 +17,9 @@ Reset the workspace to a clean state on the default branch. Use this between tas
    bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo default-branch
    ```
 
-3. **Switch to the default branch and update:**
+3. **Leave any worktree first.** If this session is in a worktree (entered via `EnterWorktree` this session), call `ExitWorktree action: keep` to return to the main checkout — this preserves the branch and worktree. Only use `action: remove` (with `discard_changes: true` if needed) when the user explicitly wants that worktree and its work destroyed. If `ExitWorktree` no-ops (worktree from an earlier session), `cd` to the main worktree root (first entry of `git worktree list`) instead.
+
+4. **Switch to the default branch and update** (in the main checkout):
 
    ```bash
    bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch default
@@ -25,4 +27,4 @@ Reset the workspace to a clean state on the default branch. Use this between tas
    git pull
    ```
 
-4. **Confirm.** Print the current branch and latest commit (`git log --oneline -1`).
+5. **Confirm.** Print the current branch and latest commit (`git log --oneline -1`).

--- a/plugins-claude/session/skills/session-start/SKILL.md
+++ b/plugins-claude/session/skills/session-start/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: session-start
 description: "Show available work and pick something to start"
-allowed-tools: Bash, Agent, EnterPlanMode, AskUserQuestion
+allowed-tools: Bash, Agent, EnterPlanMode, AskUserQuestion, EnterWorktree
 ---
 
 Generic entry point. Shows available work, lets the user pick, then explores the codebase and produces an implementation plan.
@@ -50,9 +50,35 @@ Generic entry point. Shows available work, lets the user pick, then explores the
 
 4. **Act on the user's response:**
 
-   - **Issue number mentioned** (e.g. "#42" or "42") — fetch the full issue with `bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue show <N>`, determine branch type from labels (`bug/fix` → `bug/`, `enhancement/feature/improvement` → `enhancement/`, `docs/chore/refactor/maintenance` → `chore/`, fallback → `feature/`), create the branch (`bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch create <type>/<N>-<slug>`), print the branch name and issue title, then proceed to Phase 3.
-   - **Branch name mentioned** — follow the `resume` action (context extraction). Phase 3 does not apply.
-   - **Freeform description** — create a `wip/<kebab-slug>` branch: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch create wip/<slug>`. No issue is linked. Proceed to Phase 3 using the user's description as the investigation context.
+   - **Issue number mentioned** (e.g. "#42" or "42") — fetch the full issue with `bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue show <N>`, determine branch type from labels (`bug/fix` → `bug/`, `enhancement/feature/improvement` → `enhancement/`, `docs/chore/refactor/maintenance` → `chore/`, fallback → `feature/`), then **create the branch via Phase 2a** (in-place or worktree) using base name `<type>/<N>-<slug>`. Print the branch name and issue title, then proceed to Phase 3.
+   - **Branch name mentioned** — follow the `resume` action (context extraction). Phases 2a and 3 do not apply.
+   - **Freeform description** — **create the branch via Phase 2a** using base name `wip/<kebab-slug>`. No issue is linked. Proceed to Phase 3 using the user's description as the investigation context.
+
+### Phase 2a — Isolate in a worktree? (new work only)
+
+Applies to the issue and freeform paths. **Skip entirely** when resuming an existing branch, or when already inside a worktree (`git rev-parse --git-common-dir` resolves outside the current `--show-toplevel`, or `git worktree list` shows you are not in the main worktree).
+
+Decide whether to isolate the new branch in a git worktree. **Default to a worktree for substantial new work** — it keeps the main checkout clean and lets parallel sessions coexist. Lean toward a worktree when any hold: the current branch has uncommitted changes that would be disturbed, the user asked for parallel/isolated work, or the work is a non-trivial feature. Create the branch **in place** for trivial one-file fixes, or if the user prefers to stay in the current checkout. If genuinely unsure, offer the choice via `AskUserQuestion` (Worktree / In place).
+
+**If creating in place:** `bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch create <base-name>` (where `<base-name>` is `<type>/<N>-<slug>` or `wip/<slug>`).
+
+**If using a worktree:**
+
+1. **Provision dependencies first (one-time per repo).** A fresh worktree is a clean checkout — gitignored build artifacts and deps don't carry over. Native provisioning fills the gap but only runs at creation time and is empty by default, so configure it **before** creating the worktree. Detect heavy gitignored directories present:
+
+   ```bash
+   for d in node_modules .venv venv target build dist .next vendor .gradle .tox; do
+     [ -e "$d" ] && git check-ignore -q "$d" && echo "$d"
+   done
+   ```
+
+   If any are found and not already listed in `worktree.symlinkDirectories`, offer via `AskUserQuestion` to write them to that key in the **project** `.claude/settings.json`, and to add common local files (`.env`, `.env.*`) to a root `.worktreeinclude`. Ask before writing; only touch project-level config, never global. Recommended shape:
+
+   ```json
+   { "worktree": { "symlinkDirectories": ["node_modules", ".venv"] } }
+   ```
+
+2. **Create + enter the worktree:** call `EnterWorktree` with `name` set to a dash-form of the base name — `<type>-<N>-<slug>` for issues, `wip-<slug>` for freeform. This creates branch `worktree-<name>`, runs native provisioning, and switches the session into the worktree. Do **not** also run `branch create` — `EnterWorktree` creates the branch. (The `worktree-` prefix is expected; the session scripts parse the issue number through it.)
 
 ### Phase 2b — Offer orchestration (escalation gate)
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "Work session management — issue-driven branch lifecycle with checkpointing, cross-machine handoffs, resume, reset, and multi-agent orchestration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/commands/session-end.md
+++ b/plugins-copilot/session/commands/session-end.md
@@ -21,8 +21,8 @@ watch CI, and return to the default branch.
 
 1b. Check for an existing open PR for the current branch:
 
-   - on GitHub repos, prefer `gh pr list --head "$CURRENT" --state open --json number,url,headRefName`
-   - otherwise use the equivalent host-native PR listing command if available
+- on GitHub repos, prefer `gh pr list --head "$CURRENT" --state open --json number,url,headRefName`
+- otherwise use the equivalent host-native PR listing command if available
 
    If found, extract the PR URL and number, skip steps 3-7, and jump directly to step 8 (CI watch) using the existing PR info.
 
@@ -111,7 +111,9 @@ watch CI, and return to the default branch.
 - **`timeout`** — ask via AskUserQuestion whether to keep waiting or return now
 - **`no-pr`** — note that no PR was found; continue to step 9
 
-9. **Return to default branch:**
+9. **Return to the main checkout / default branch:**
+
+   If you worked in a worktree (under `.github/worktrees/`) and the PR merged, tear it down first with the `git-worktree` plugin's `worktree-remove` flow — from the main worktree root run `git worktree remove .github/worktrees/<slug>`, then `git branch -d <branch>` (use `--force`/`-D` only for a dirty or unmerged branch the user agrees to discard). If the PR did **not** merge, leave the worktree in place. Then switch to the default branch in the main checkout:
 
    ```bash
    git switch "$DEFAULT" && git pull --ff-only

--- a/plugins-copilot/session/commands/session-orchestrate.md
+++ b/plugins-copilot/session/commands/session-orchestrate.md
@@ -28,7 +28,16 @@ Before starting Phase 1, check whether prior phases of this workflow have alread
    - **Resume from Review** — execution done, run review pass only
    - **Start fresh** — discard prior context and run all phases
 
-   Otherwise proceed to Phase 1 with a fresh run.
+   Otherwise proceed to Phase 0b with a fresh run.
+
+### Phase 0b — Isolate in a worktree (default for fresh runs)
+
+Orchestrate runs are heavy and long-lived — **isolate them in a git worktree by default** (assumes the `git-worktree` plugin is installed) so the main checkout stays clean.
+
+- **Already isolated** — if the session is already in a worktree, or a feature branch is already checked out (inherited from `/session:session-start`, or the current branch is not the default), proceed in the current checkout. Do **not** create another worktree.
+- **Fresh run on the default branch** — create the work's branch as a worktree by default. Derive a branch name (`<type>/<NNN>-<slug>` from the issue, or `wip/<slug>` from the description) and create it with the plugin's `worktree-create` flow: `git worktree add .github/worktrees/<slug> -b <branch>`. Then run **all** subsequent phases from inside the worktree by prefixing commands with `cd .github/worktrees/<slug> && …`; the plugin's whitelist hook auto-approves operations on the worktree path. A fresh worktree is a clean checkout — reinstall or symlink heavy gitignored deps if the work needs them. Offer a one-key opt-out (work in place) via `AskUserQuestion`, but default to the worktree.
+
+Then proceed to Phase 1.
 
 ### Phase 1 — Spec exploration
 

--- a/plugins-copilot/session/commands/session-reset.md
+++ b/plugins-copilot/session/commands/session-reset.md
@@ -17,7 +17,9 @@ Reset the workspace to a clean state on the default branch. Use this between tas
 
    If that fails, fall back to `main` or `master` (whichever exists locally).
 
-3. **Switch to the default branch and update:**
+3. **Leave any worktree first.** If you are inside a worktree (under `.github/worktrees/`), `cd` to the main worktree root (first entry of `git worktree list`) before switching branches — this leaves the worktree and its branch intact. Only remove it (via the `git-worktree` plugin's `worktree-remove` flow) if the user explicitly wants that work discarded.
+
+4. **Switch to the default branch and update** (in the main checkout):
 
    ```bash
    git checkout <default-branch>
@@ -25,4 +27,4 @@ Reset the workspace to a clean state on the default branch. Use this between tas
    git pull
    ```
 
-4. **Confirm.** Print the current branch and latest commit (`git log --oneline -1`).
+5. **Confirm.** Print the current branch and latest commit (`git log --oneline -1`).

--- a/plugins-copilot/session/commands/session-start.md
+++ b/plugins-copilot/session/commands/session-start.md
@@ -35,13 +35,19 @@ Generic entry point. Shows available work and lets the user pick what to focus o
 
 4. **Act on the selection:**
 
-   - **Issue selected** — fetch the full issue, choose the branch prefix from labels, create a local branch with `git switch -c`, and continue with the issue context
-   - **Branch selected** — switch to that branch if needed, then follow the `resume` flow from the context-building step onward
-   - **Freeform selected** — ask the user to describe the task, then:
-     - Create and switch to a `wip/<kebab-slug>` branch with `git switch -c`
-     - No issue is linked; proceed with the free-form task description as context
+   - **Issue selected** — fetch the full issue, choose the branch prefix from labels, then **create the branch via step 4a** (in place or worktree) using base name `<type>/<N>-<slug>`, and continue with the issue context
+   - **Branch selected** — switch to that branch if needed, then follow the `resume` flow from the context-building step onward (step 4a does not apply)
+   - **Freeform selected** — ask the user to describe the task, then **create the branch via step 4a** using base name `wip/<kebab-slug>`. No issue is linked; proceed with the free-form task description as context
+
+4a. **Isolate in a worktree? (new work only — assumes the `git-worktree` plugin is installed.)** Skip when resuming an existing branch or when already inside a worktree (`git worktree list` shows you are not in the main worktree).
+
+   Default to a worktree for substantial new work — it keeps the main checkout clean and lets parallel work coexist. Lean toward one when the current branch has uncommitted changes, the user asked for parallel/isolated work, or the work is a non-trivial feature. Create the branch **in place** for trivial one-file fixes. If genuinely unsure, offer the choice via AskUserQuestion (Worktree / In place).
+
+- **In place:** `git switch -c <base-name>`.
+- **Worktree (via the `git-worktree` plugin):** create it with the plugin's `worktree-create` flow — `git worktree add .github/worktrees/<slug> -b <base-name>` (the base dir is auto-gitignored on first use; slug = the branch name with `/` and other non-`[A-Za-z0-9._-]` chars replaced by `-`). Then run **all** subsequent steps from inside the worktree by prefixing commands with `cd .github/worktrees/<slug> && …`; the plugin's whitelist hook auto-approves operations on the worktree path. A fresh worktree is a clean checkout — reinstall or symlink heavy gitignored deps (e.g. `node_modules`, `.venv`) if the work needs them.
 
 5. Confirm the starting context to the user:
-   - Branch name (new or existing)
-   - Linked issue number and title (if any)
-   - First suggested steps based on context
+
+- Branch name (new or existing)
+- Linked issue number and title (if any)
+- First suggested steps based on context


### PR DESCRIPTION
## Summary

Encourage isolated worktree use across the session lifecycle, handled separately per CLI:

- **Claude** uses the native `EnterWorktree`/`ExitWorktree` tools, leaning on `worktree.symlinkDirectories` + `.worktreeinclude` for dependency provisioning (no custom provisioning code).
- **Copilot** points at the `git-worktree` plugin (assumed installed): `git worktree add .github/worktrees/<slug>` + `cd <path> &&`, teardown via the plugin's `worktree-remove` flow.

### Changes

- `catchup`/`handoff`/`sitrep`: issue-number regex now tolerates an optional `worktree-` branch prefix (`^(worktree-)?[a-z]+[/-]([0-9]+)-`), so native worktree branches still link to issues.
- Claude `session-start`: new **Phase 2a** worktree gate — detect heavy gitignored dirs and offer to write `symlinkDirectories`/`.worktreeinclude` to project config **before** creating, then `EnterWorktree`.
- Claude `session-orchestrate`: new **Phase 0b** — worktree by default for fresh runs, opt-out gate, skips if already isolated.
- Claude `session-end`/`session-reset`: `ExitWorktree` teardown (remove on merge, keep otherwise) with a manual `git worktree remove` fallback for cross-session worktrees.
- Copilot `session-start`/`orchestrate`/`end`/`reset`: same gates via the git-worktree plugin (clean branch name, no prefix).
- Both `session` `plugin.json` bumped `3.11.1` → `3.12.0`.

## Test plan

- [x] `bash test.sh` — 1575 passed, 0 failed
- [x] `bash .github/scripts/validate-plugins.sh` — 282 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 109 checks, 0 failures
- [x] `rumdl check .` — 0 issues, 87 files
- [x] Tolerant issue-number regex verified against both `feature/42-…` and `worktree-feature-42-…`
