### PR TITLE
fix(session): replace forced commit/PR menu with plain-text wrap-up

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Work session management — issue-driven branch lifecycle with checkpointing, cross-machine handoffs, resume, reset, and multi-agent orchestration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -88,10 +88,12 @@ Select an open issue, create a branch, explore the codebase, and produce an impl
    **Risks & open questions:**
    - Flag edge cases, breaking changes, or unknowns
 
-   **Post-implementation steps:**
-   - Summarize all changes (overall summary + per-file change summary)
-   - Present the user with options: (a) commit, push, and create PR, or (b) provide input to make adjustments
-   - When creating a commit or PR for an issue, include `Closes #N` (or `Fixes #N` for bugs) in the commit message or PR body so the issue is auto-closed on merge
-   - Do NOT auto-commit — always ask first
+   **Post-implementation wrap-up (do NOT force a menu):**
+   - When the work is done, do NOT use `AskUserQuestion` and do NOT auto-commit. Print a plain-text wrap-up, then wait for the user's response in the normal chat input.
+   - The wrap-up MUST cover:
+     - **Summary** — one-line outcome plus a per-file list of what changed
+     - **Current state** — branch name, what's committed vs. still uncommitted, and test/build status
+     - **Caveats** — known risks, uncovered edge cases, incomplete pieces, or follow-ups
+   - Then stop and let the user decide what's next (they may run `/ship`, request adjustments, etc.). If they later have you commit or open a PR for the issue, include `Closes #N` (or `Fixes #N` for bugs) in the commit message or PR body so the issue auto-closes on merge.
 
    Present the plan for user approval before any implementation begins.

--- a/plugins-claude/session/skills/session-orchestrate/SKILL.md
+++ b/plugins-claude/session/skills/session-orchestrate/SKILL.md
@@ -196,16 +196,11 @@ Goal: summarize and route to the appropriate finalization flow.
 1. **Produce a final summary** for the user covering:
    - One-line outcome of the feature
    - Files changed (grouped by chunk)
+   - Current state — branch name, what's committed vs. still uncommitted, test/build status
    - Test coverage added (if any)
-   - Deferred concerns from Phase 6 (if any)
-   - Any chunks surfaced for manual handling (if any)
+   - Caveats — deferred concerns from Phase 6, chunks surfaced for manual handling, and any known risks or follow-ups
 
-2. **Offer hand-off** via `AskUserQuestion`:
-   - **Ship it** — invoke `/git-tools:ship` to commit, push, open PR, watch CI
-   - **End session** — invoke `/session:session-end` for the review-then-PR flow
-   - **Pause here** — do nothing further; user will finalize manually
-
-Do NOT auto-commit, push, or open a PR — always go through the user's choice in this final gate.
+2. **Then stop and wait for the user's free-text response.** Do NOT use `AskUserQuestion` and do NOT auto-commit, push, or open a PR. Let the user decide what's next — they may run `/git-tools:ship` (commit, push, PR, watch CI), `/session:session-end` (review-then-PR flow), ask for adjustments, or finalize manually. Just present the summary and wait in the normal chat input.
 
 If this run created a worktree (Phase 0b), note that its teardown is deferred: `/session:session-end` removes it after the PR merges, or the user can leave it and exit later with `ExitWorktree`. Do not tear it down here.
 

--- a/plugins-claude/session/skills/session-start/SKILL.md
+++ b/plugins-claude/session/skills/session-start/SKILL.md
@@ -127,10 +127,12 @@ If the user escalates, hand off to orchestrate and stop the `start` flow. Otherw
    **Risks & open questions:**
    - Flag edge cases, breaking changes, or unknowns
 
-   **Post-implementation steps:**
-   - Summarize all changes (overall summary + per-file change summary)
-   - Present the user with options: (a) commit, push, and create PR, or (b) provide input to make adjustments
-   - When creating a commit or PR for an issue, include `Closes #N` (or `Fixes #N` for bugs) in the commit message or PR body so the issue is auto-closed on merge
-   - Do NOT auto-commit — always ask first
+   **Post-implementation wrap-up (do NOT force a menu):**
+   - When the work is done, do NOT use `AskUserQuestion` and do NOT auto-commit. Print a plain-text wrap-up, then wait for the user's response in the normal chat input.
+   - The wrap-up MUST cover:
+     - **Summary** — one-line outcome plus a per-file list of what changed
+     - **Current state** — branch name, what's committed vs. still uncommitted, and test/build status
+     - **Caveats** — known risks, uncovered edge cases, incomplete pieces, or follow-ups
+   - Then stop and let the user decide what's next (they may run `/ship`, request adjustments, etc.). If they later have you commit or open a PR and an issue is linked, include `Closes #N` (or `Fixes #N` for bugs) in the commit message or PR body so the issue auto-closes on merge.
 
    Present the plan for user approval before any implementation begins.

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Work session management — issue-driven branch lifecycle with checkpointing, cross-machine handoffs, resume, reset, and multi-agent orchestration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/commands/session-orchestrate.md
+++ b/plugins-copilot/session/commands/session-orchestrate.md
@@ -161,15 +161,11 @@ Goal: summarize and route to the appropriate finalization flow.
 1. **Produce a final summary** for the user covering:
    - One-line outcome of the feature
    - Files changed (grouped by chunk)
+   - Current state — branch name, what's committed vs. still uncommitted, test/build status
    - Test coverage added (if any)
-   - Deferred concerns from Phase 6 (if any)
+   - Caveats — deferred concerns from Phase 6 and any known risks or follow-ups
 
-2. **Offer hand-off** via `AskUserQuestion`:
-   - **Ship it** — invoke `/git-tools:ship` to commit, push, open PR, watch CI
-   - **End session** — invoke `/session:session-end` for the review-then-PR flow
-   - **Pause here** — do nothing further; user will finalize manually
-
-Do NOT auto-commit, push, or open a PR — always go through the user's choice in this final gate.
+2. **Then stop and wait for the user's free-text response.** Do NOT use `AskUserQuestion` and do NOT auto-commit, push, or open a PR. Let the user decide what's next — they may run `/git-tools:ship` (commit, push, PR, watch CI), `/session:session-end` (review-then-PR flow), ask for adjustments, or finalize manually. Just present the summary and wait in the normal chat input.
 
 ### Notes
 


### PR DESCRIPTION
## Summary

When planned work finished, the session skills forced the user into an `AskUserQuestion` menu (commit/push/PR vs. adjust) that conveyed nothing about what was done or the current state. This replaces that menu with a plain-text wrap-up that then waits for normal chat input, so the user can run `/ship`, ask for adjustments, or finalize however they like.

- **session-issue / session-start**: the post-implementation step now prints a **Summary / Current state / Caveats** wrap-up and stops — no `AskUserQuestion`, no auto-commit.
- **session-orchestrate** (Claude + Copilot): Phase 7 hand-off folds current state and caveats into the summary, then waits for free-text instead of offering a Ship/End/Pause menu.
- Mid-workflow gates (orchestrate Phases 3/5 plan & dispatch approval) and `session-end` are intentionally unchanged — those are real decision points.
- Bumped `session` plugin `3.12.0 -> 3.12.1` (both Claude and Copilot variants).

## Test plan

- [x] `validate-plugins.sh` — 282 checks, 0 failures
- [x] `validate-frontmatter.sh` — 109 checks, 0 failures
- [x] `rumdl check` on the four edited markdown files — clean
