### PR TITLE
fix(session): handle <2 open issues in session-issue door

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -36,8 +36,13 @@ begin-work spine (explore → plan). To start from your own description instead,
    > (comma-separated). Format each as a single line:
    > `#N — Title [label1, label2]`
 
-2. **Present the top 3.** Use `AskUserQuestion` with the agent's results as choices.
-   Each option label is `#N — Title`; the description lists the labels.
+2. **Pick the issue** based on how many open issues came back:
+   - **None** — tell the user there are no open issues and suggest
+     `/session:session-start` to begin from your own description. Stop here.
+   - **Exactly one** — skip the menu (`AskUserQuestion` needs ≥2 options). State the
+     single issue (`#N — Title`) and proceed with it directly into Phase 2.
+   - **Two or more** — present the top 3 via `AskUserQuestion`. Each option label is
+     `#N — Title`; the description lists the labels.
 
 3. **Fetch the full issue** (save the body and labels — the spine needs them as
    context):

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

- `session:session-issue` always routed the ranked open issues through `AskUserQuestion`, which requires ≥2 options. With a single open issue (or none) the call failed with an `InputValidationError` ("Too small: expected array to have >=2 items") and dead-ended the discovery flow.
- Phase 1 step 2 now branches on the issue count: **0** → tell the user there are no open issues and suggest `/session:session-start`, then stop; **1** → skip the menu and proceed directly with that issue into Phase 2; **2+** → present the top 3 via `AskUserQuestion` as before.
- Bumped the `session` plugin to `4.0.1` (Claude + Copilot variants).

Fixes #124

## Test plan

- [x] `bash test.sh` — exit 0
- [x] `bash .github/scripts/validate-plugins.sh` — 277 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 95 checks, 0 failures
- [x] `rumdl check` on the edited SKILL.md — no issues