### PR TITLE
feat(git-tools): teach ship to clean up the worktree after merge

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/skills/ship/SKILL.md
+++ b/plugins-claude/git-tools/skills/ship/SKILL.md
@@ -9,14 +9,14 @@ description: >-
   "send it", "ship it", "merge it", or terse single words "watch", "merge",
   "pull" when the context implies finishing a PR. Drives staging → commit →
   push → PR create → CI watch → merge wait → checkout master → pull, using
-  the git-cli wrapper for every GitHub/Gitea call. Skips steps that are
-  already complete instead of redoing them.
+  the git-cli wrapper for every GitHub/Gitea call, and cleans up the worktree
+  if one was used. Skips steps that are already complete instead of redoing them.
 allowed-tools: Bash
 ---
 
 # ship — full merge lifecycle orchestrator
 
-**Purpose.** Take whatever in-progress work exists and drive it through the canonical lifecycle: stage → commit → push → PR → watch CI → wait for merge → return to default branch → pull. Skip any step that's already done.
+**Purpose.** Take whatever in-progress work exists and drive it through the canonical lifecycle: stage → commit → push → PR → watch CI → wait for merge → return to default branch → pull → clean up the worktree if one was used. Skip any step that's already done.
 
 **Always use the `git-cli` wrapper** at `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli` for every GitHub/Gitea call. Never invoke raw `gh` or `tea` directly — the wrapper auto-detects the platform from the git remote so the same procedure works on both. See the sibling `git-cli` skill for full command reference.
 
@@ -47,6 +47,22 @@ git rev-parse --abbrev-ref HEAD
 
 Establish: dirty working tree? on default branch or feature branch? upstream set? Determine the default branch via `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo default-branch`.
 
+Also detect **whether this checkout is a linked git worktree** — this gates the cleanup in step 7:
+
+```bash
+git_dir=$(git rev-parse --git-dir)
+git_common_dir=$(git rev-parse --git-common-dir)
+# Linked worktree iff the two differ. Normalize with realpath first — on macOS
+# /tmp is a symlink to /private/tmp, so a raw string compare can falsely differ.
+if [ "$(realpath "$git_dir")" != "$(realpath "$git_common_dir")" ]; then
+  echo "linked worktree"   # step 7 cleans it up after a confirmed merge
+else
+  echo "main checkout"     # step 7 keeps its current behavior
+fi
+```
+
+This read is non-destructive; it only records context for later.
+
 ### 1. Stage and commit
 
 If there are uncommitted changes:
@@ -59,10 +75,10 @@ Skip this step if the working tree is clean.
 
 ### 2. Ensure feature branch
 
-If on the default branch (`master`/`main`), create a feature branch with a conventional prefix (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`) before pushing:
+If on the default branch (`master`/`main`), create a feature branch with a conventional prefix (`feat-`, `fix-`, `chore-`, `docs-`, `refactor-`, `test-`) before pushing:
 
 ```bash
-git checkout -b <prefix>/<short-description>
+git checkout -b <prefix>-<short-description>
 ```
 
 Skip if already on a non-default branch.
@@ -118,15 +134,68 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr wait --branch "$(git rev-parse --abbrev
 
 Skip this step if the repo does not auto-merge. **Never call `git-cli pr merge` to merge manually unless the user explicitly asks** — that bypasses CI gating and the auto-merge workflow.
 
-### 7. Return to default branch
+### 7. Return to default branch (and clean up the worktree if one was used)
+
+Always determine the default branch first:
 
 ```bash
 default=$(${CLAUDE_PLUGIN_ROOT}/scripts/git-cli repo default-branch)
+```
+
+**Case A — main checkout** (step 0 reported `main checkout`): unchanged behavior.
+
+```bash
 git checkout "$default"
 git pull
 ```
 
-This is the step most often forgotten — always run it after merge unless the user explicitly says otherwise.
+**Case B — linked worktree** (step 0 reported `linked worktree`): only proceed **after the branch has actually merged** (step 6 confirmed the merge). Worktree teardown is destructive and hard to reverse — never run this block on an unmerged branch.
+
+1. Capture identifiers **while still inside the linked worktree** (these are per-worktree):
+
+   ```bash
+   linked_wt=$(git rev-parse --show-toplevel)
+   feature_branch=$(git rev-parse --abbrev-ref HEAD)   # literal "HEAD" if detached
+   main_wt=$(git worktree list --porcelain | awk 'NR==1 && /^worktree /{sub(/^worktree /,""); print}')
+   ```
+
+2. **Cleanliness gate.** If the worktree has uncommitted or untracked changes, do **not** remove it automatically:
+
+   ```bash
+   git -C "$linked_wt" status --porcelain
+   ```
+
+   - Empty output → clean; proceed to remove it automatically.
+   - Non-empty → stop and ask the user whether to discard those changes (`git worktree remove --force`) before doing anything destructive.
+
+3. Move into the main worktree and refresh — you cannot reliably remove the worktree you are standing in (its working directory becomes invalid):
+
+   ```bash
+   cd "$main_wt"
+   git checkout "$default"
+   git pull
+   ```
+
+4. Remove the merged worktree and prune stale metadata:
+
+   ```bash
+   git worktree remove "$linked_wt"   # add --force ONLY after explicit user approval when dirty
+   git worktree prune
+   ```
+
+5. Delete the now-merged local branch (skip when `feature_branch` is `HEAD`, i.e. detached):
+
+   ```bash
+   git branch -d "$feature_branch"
+   ```
+
+   `-d` is the safe form — it refuses if git doesn't see the branch as fully merged. A failure usually means a **squash merge** (the branch tip is not an ancestor of the merge commit). Tell the user and ask before force-deleting:
+
+   ```bash
+   git branch -D "$feature_branch"   # only after the user confirms
+   ```
+
+Returning to the default branch is the step most often forgotten — always run it after merge (in either case) unless the user explicitly says otherwise.
 
 ## Arguments
 
@@ -141,6 +210,8 @@ If `$ARGUMENTS` is empty, infer title and body from the diff and recent commit l
 
 Each step probes state first and skips when there's nothing to do. Re-running the orchestrator after a partial run should pick up from wherever it left off — e.g. if the PR is already open, jump to step 5; if CI is already passing, jump to step 6; if the PR is already merged, jump to step 7.
 
+The step-7 worktree cleanup is gated twice: it runs only when step 0 detected a linked worktree **and** the branch has merged. In the main checkout it is skipped entirely (current behavior preserved), and re-running after the worktree is already removed is a no-op — the worktree detection short-circuits.
+
 ## What NOT to do
 
 - Do **not** invoke raw `gh` or `tea` — always go through `git-cli`.
@@ -148,6 +219,10 @@ Each step probes state first and skips when there's nothing to do. Re-running th
 - Do **not** call `gh pr merge` / `tea pr merge` to manually merge unless the user asked — the auto-merge bot handles this.
 - Do **not** end the session on a feature branch after a merge — return to the default branch and pull.
 - Do **not** invent your own polling loop (`until gh pr view ... | grep MERGED; do sleep`) — `git-cli pr wait` and `git-cli run watch` already handle this with proper timeouts and failure detection.
+- Do **not** `git worktree remove` the worktree you are standing in — `cd` into the main worktree first, then remove.
+- Do **not** `--force`-remove a worktree with uncommitted or untracked changes without explicit user approval.
+- Do **not** `git branch -D` (force-delete) without confirming first — a `git branch -d` refusal usually signals a squash merge, not work that's safe to discard blindly.
+- Do **not** check out a branch that is already live in another worktree (`git` refuses with `already used by worktree at ...`).
 
 ## Reporting back
 

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/README.md
+++ b/plugins-claude/session/README.md
@@ -29,13 +29,13 @@ lightweight spine is the single-session counterpart to this heavyweight flow.
 The shared spine lives in [`reference/spine.md`](reference/spine.md); `start` and
 `issue` read and execute it so there is one source of truth.
 
-When an issue is linked, the branch name encodes its number (`type/NNN-slug`, e.g.
-`bug/42-fix-login-crash`), which is used to fetch context during exploration and to
-auto-close the issue via `Closes #N` when the PR merges.
+When an issue is linked, the branch name uses the issue's type and a slug
+(`type-slug`, e.g. `bug-fix-login-crash`). The issue is auto-closed via `Closes #N`
+in the PR when it merges — the linkage lives there, not in the branch name.
 
 ### Working Without Issues
 
-`/session:session-start` accepts freeform descriptions and creates `wip/<slug>`
+`/session:session-start` accepts freeform descriptions and creates `wip-<slug>`
 branches — no issue tracker required. The `/session:session-end` PR workflow works the
 same either way.
 
@@ -59,11 +59,11 @@ same either way.
 Both take in-flight work through commit → push → PR → CI → merge → return-to-default.
 Pick based on what you need:
 
-- **`/session:session-end`** — adds a pre-PR code-review gate, `Resolves #N` issue
-  linking, and worktree teardown after merge. Worktree-aware.
-- **`/git-tools:ship`** — the quick canonical lifecycle, no review gate. Not
-  worktree-aware (it ends with `git checkout <default>`, which fails inside a
-  worktree), so use `session-end` when working in a worktree.
+- **`/session:session-end`** — adds a pre-PR code-review gate and `Resolves #N`
+  issue linking. Worktree-aware (tears down the worktree after merge).
+- **`/git-tools:ship`** — the quick canonical lifecycle, no review gate. Also
+  worktree-aware: after merge it returns to the main worktree, removes the merged
+  worktree, prunes, and deletes the branch.
 
 ## Typical Workflow
 
@@ -80,10 +80,10 @@ When starting from an issue, the branch type is inferred from issue labels:
 
 | Labels | Branch prefix |
 |--------|--------------|
-| `bug`, `fix` | `bug/` |
-| `enhancement`, `feature`, `improvement` | `enhancement/` |
-| `docs`, `chore`, `refactor`, `maintenance` | `chore/` |
-| (none of the above) | `feature/` |
+| `bug`, `fix` | `bug-` |
+| `enhancement`, `feature`, `improvement` | `enhancement-` |
+| `docs`, `chore`, `refactor`, `maintenance` | `chore-` |
+| (none of the above) | `feature-` |
 
 ## Dependencies
 

--- a/plugins-claude/session/reference/spine.md
+++ b/plugins-claude/session/reference/spine.md
@@ -17,8 +17,9 @@ The calling skill has already established:
 
 - **Context** — a freeform description (from `session-start`) and/or a linked issue
   with its full title, body, and labels (from `session-issue`).
-- **Base branch name** — `<type>/<N>-<slug>` when an issue is linked, or
-  `wip/<slug>` for freeform work.
+- **Base branch name** — `<type>-<slug>` when an issue is linked, or
+  `wip-<slug>` for freeform work. The branch does not carry the issue number; the
+  linkage is the PR's `Closes #N`.
 
 If you reach this spine without a base name or any context, stop and return to the
 calling door — it owns target selection.
@@ -66,12 +67,12 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch create <base-name>
    { "worktree": { "symlinkDirectories": ["node_modules", ".venv"] } }
    ```
 
-2. **Create + enter the worktree:** call `EnterWorktree` with `name` set to a
-   dash-form of the base name — `<type>-<N>-<slug>` for issues, `wip-<slug>` for
-   freeform. This creates branch `worktree-<name>`, runs native provisioning, and
-   switches the session into the worktree. Do **not** also run `branch create` —
-   `EnterWorktree` creates the branch. (The `worktree-` prefix is expected; the
-   session scripts parse the issue number through it.)
+2. **Create + enter the worktree:** call `EnterWorktree` with `name` set to the
+   base name (already in dash form — `<type>-<slug>` or `wip-<slug>` — so it needs
+   no conversion and contains no `/`). This creates branch `worktree-<name>`, runs
+   native provisioning, and switches the session into the worktree. Do **not** also
+   run `branch create` — `EnterWorktree` creates the branch. (The `worktree-` prefix
+   is expected and harmless.)
 
 ## Phase 2 — Escalate to orchestrate? (gate)
 

--- a/plugins-claude/session/scripts/catchup
+++ b/plugins-claude/session/scripts/catchup
@@ -67,12 +67,6 @@ if $is_git; then
         commit_count=$(git rev-list --count "$base_branch..HEAD" 2>/dev/null || echo "0")
         echo "ahead: $commit_count commits"
     fi
-
-    # Show linked issue number if branch matches type/NNN-* pattern
-    # (tolerates an optional worktree- prefix from native worktree branches)
-    if [[ "$current_branch" =~ ^(worktree-)?[a-z]+[/-]([0-9]+)- ]]; then
-        echo "linked-issue: #${BASH_REMATCH[2]}"
-    fi
 else
     echo "=== BRANCH ==="
     echo "(not a git repo)"

--- a/plugins-claude/session/scripts/sitrep
+++ b/plugins-claude/session/scripts/sitrep
@@ -85,12 +85,6 @@ if [[ -n "$base_ref" ]]; then
     fi
 fi
 
-# Linked issue from branch name
-# (tolerates an optional worktree- prefix from native worktree branches)
-if [[ -n "$head_branch" && "$head_branch" =~ ^(worktree-)?[a-z]+[/-]([0-9]+)- ]]; then
-    echo "linked_issue: #${BASH_REMATCH[2]}"
-fi
-
 # --- Tier 1: Uncommitted changes ---
 staged_files="$(gitq diff --name-status --cached --find-renames 2>/dev/null || true)"
 unstaged_files="$(gitq diff --name-status --find-renames 2>/dev/null || true)"

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -49,14 +49,16 @@ begin-work spine (explore → plan). To start from your own description instead,
 ### Phase 2 — Base branch name
 
 4. **Determine the branch type** from the issue labels:
-   - `bug`, `fix` → `bug/`
-   - `enhancement`, `feature`, `improvement` → `enhancement/`
-   - `docs`, `chore`, `refactor`, `maintenance` → `chore/`
-   - No matching label → `feature/`
+   - `bug`, `fix` → `bug`
+   - `enhancement`, `feature`, `improvement` → `enhancement`
+   - `docs`, `chore`, `refactor`, `maintenance` → `chore`
+   - No matching label → `feature`
 
-5. **Build the base name** as `<type>/<N>-<slug>`, where `<slug>` is a kebab-case
+5. **Build the base name** as `<type>-<slug>`, where `<slug>` is a kebab-case
    3-5 word slug from the issue title. Example: issue #42 "Fix login crash on empty
-   password" → `bug/42-fix-login-crash`.
+   password" → `bug-fix-login-crash`. The branch name does not encode the issue
+   number — the linkage lives in the PR's `Closes #N`, which is what auto-closes
+   the issue on merge.
 
 ### Phase 3 — Run the spine
 

--- a/plugins-claude/session/skills/session-orchestrate/SKILL.md
+++ b/plugins-claude/session/skills/session-orchestrate/SKILL.md
@@ -21,7 +21,7 @@ The workflow has seven phases. Two have hard user gates (Refine and Execute). Th
 Before starting Phase 1, check whether prior phases of this workflow have already run on this branch:
 
 1. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/catchup` to gather branch state.
-2. Inspect the most recent commit messages and any `wip/`, `feat/`, `enhancement/`, `chore/`, `bug/` branch names for evidence of prior work — recent commits referencing the spec/plan, or multiple commits since the default branch.
+2. Inspect the most recent commit messages and any `wip-`, `feat-`, `enhancement-`, `chore-`, `bug-` branch names for evidence of prior work — recent commits referencing the spec/plan, or multiple commits since the default branch.
 3. If any signal of prior orchestrate work is present, ask via `AskUserQuestion`:
    - **Resume from Plan** — re-use existing exploration, regenerate the plan
    - **Resume from Divide** — plan is good, re-chunk and execute
@@ -35,7 +35,7 @@ Before starting Phase 1, check whether prior phases of this workflow have alread
 Orchestrate runs are heavy and long-lived — **isolate them in a git worktree by default** so the main checkout stays clean and parallel sessions can coexist.
 
 - **Already isolated** — if the session is already in a worktree, or a feature branch is already checked out (inherited from `/session:session-start`'s escalation, or the current branch is not the default), proceed in the current checkout. Do **not** create another worktree.
-- **Fresh run on the default branch** — create the work's branch as a worktree by default. Derive a dash-form name: `<type>-<NNN>-<slug>` from the issue, or `wip-<slug>` from the description. **Before** creating, provision dependencies exactly as in `/session:session-start` Phase 2a (detect heavy gitignored dirs via `git check-ignore`; offer to write `worktree.symlinkDirectories` + `.worktreeinclude` to **project** config, asking first). Then call `EnterWorktree` with `name: <dash-form-name>` (yields branch `worktree-<name>`, provisions deps, switches the session in). Offer a one-key opt-out (work in place) via `AskUserQuestion`, but default to the worktree.
+- **Fresh run on the default branch** — create the work's branch as a worktree by default. Derive the name: `<type>-<slug>` from the issue (no number — that lives in the PR's `Closes #N`), or `wip-<slug>` from the description. **Before** creating, provision dependencies exactly as in `/session:session-start` Phase 2a (detect heavy gitignored dirs via `git check-ignore`; offer to write `worktree.symlinkDirectories` + `.worktreeinclude` to **project** config, asking first). Then call `EnterWorktree` with `name: <dash-form-name>` (yields branch `worktree-<name>`, provisions deps, switches the session in). Offer a one-key opt-out (work in place) via `AskUserQuestion`, but default to the worktree.
 
 Then proceed to Phase 1.
 

--- a/plugins-claude/session/skills/session-start/SKILL.md
+++ b/plugins-claude/session/skills/session-start/SKILL.md
@@ -43,11 +43,12 @@ issues instead, use `/session:session-issue`; for a read-only status view, use
      bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue show <N>
      ```
 
-     Derive the branch type from labels (`bug`/`fix` → `bug/`,
-     `enhancement`/`feature`/`improvement` → `enhancement/`,
-     `docs`/`chore`/`refactor`/`maintenance` → `chore/`, else `feature/`). Base name:
-     `<type>/<N>-<slug>`. Keep the issue body + labels as context.
-   - **Freeform** → base name `wip/<kebab-slug>` (3-5 word slug from the description).
+     Derive the branch type from labels (`bug`/`fix` → `bug`,
+     `enhancement`/`feature`/`improvement` → `enhancement`,
+     `docs`/`chore`/`refactor`/`maintenance` → `chore`, else `feature`). Base name:
+     `<type>-<slug>` (the issue number lives in the PR's `Closes #N`, not the branch).
+     Keep the issue body + labels as context.
+   - **Freeform** → base name `wip-<kebab-slug>` (3-5 word slug from the description).
      No issue linked; the description is the context.
 
 ### Phase 2 — Run the spine

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-tools/commands/ship.md
+++ b/plugins-copilot/git-tools/commands/ship.md
@@ -8,12 +8,12 @@ Take whatever in-progress work exists in this repo and drive it through the cano
 This command invokes the `ship` skill — see the sibling `ship` skill for the full procedure. The summary:
 
 1. **Stage and commit** any uncommitted changes (specific files only — never `git add -A`/`.`).
-2. **Ensure a feature branch** with a conventional prefix (`feat/`, `fix/`, `chore/`, `docs/`, …); create one if currently on the default branch.
+2. **Ensure a feature branch** with a conventional prefix (`feat-`, `fix-`, `chore-`, `docs-`, …); create one if currently on the default branch.
 3. **Push** to origin (`-u` on first push).
 4. **Create the PR** via `gh pr create` (or the host-native equivalent on Gitea) if one is not already open for the branch.
 5. **Watch CI** until it passes, fails, or merges. On failure, stop and surface the failure; do not push fixes silently.
 6. **Wait for merge** if the repo has an auto-merge bot. Never invoke `gh pr merge` to merge manually unless the user explicitly asks.
-7. **Return to the default branch** and `git pull`.
+7. **Return to the default branch** and `git pull`. If the work was done in a linked git worktree, switch back to the main worktree first, then (after the merge) remove the merged worktree — asking before discarding any uncommitted changes — prune, and delete the merged branch.
 
 On GitHub repos, prefer `gh` for every PR, run, and repo call. On Gitea or other hosts, use the equivalent host-native tooling or API.
 

--- a/plugins-copilot/git-tools/skills/ship/SKILL.md
+++ b/plugins-copilot/git-tools/skills/ship/SKILL.md
@@ -10,13 +10,14 @@ description: >-
   "pull" when the context implies finishing a PR. Drives staging → commit →
   push → PR create → CI watch → merge wait → checkout master → pull, using
   native host tooling (gh on GitHub, host-native equivalent on Gitea) for
-  every call. Skips steps that are already complete instead of redoing them.
+  every call, and cleans up the worktree if one was used. Skips steps that are
+  already complete instead of redoing them.
 allowed-tools: Bash
 ---
 
 # ship — full merge lifecycle orchestrator
 
-**Purpose.** Take whatever in-progress work exists and drive it through the canonical lifecycle: stage → commit → push → PR → watch CI → wait for merge → return to default branch → pull. Skip any step that's already done.
+**Purpose.** Take whatever in-progress work exists and drive it through the canonical lifecycle: stage → commit → push → PR → watch CI → wait for merge → return to default branch → pull → clean up the worktree if one was used. Skip any step that's already done.
 
 Use native host tooling for every GitHub/Gitea call. On GitHub repos, prefer `gh`. On Gitea or other hosts, use the equivalent host-native CLI or API tooling. See the sibling `git-cli` skill for the full command reference.
 
@@ -47,6 +48,22 @@ git rev-parse --abbrev-ref HEAD
 
 Establish: dirty working tree? on default branch or feature branch? upstream set? Determine the default branch via `git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||'`.
 
+Also detect **whether this checkout is a linked git worktree** — this gates the cleanup in step 7:
+
+```bash
+git_dir=$(git rev-parse --git-dir)
+git_common_dir=$(git rev-parse --git-common-dir)
+# Linked worktree iff the two differ. Normalize with realpath first — on macOS
+# /tmp is a symlink to /private/tmp, so a raw string compare can falsely differ.
+if [ "$(realpath "$git_dir")" != "$(realpath "$git_common_dir")" ]; then
+  echo "linked worktree"   # step 7 cleans it up after a confirmed merge
+else
+  echo "main checkout"     # step 7 keeps its current behavior
+fi
+```
+
+This read is non-destructive; it only records context for later.
+
 ### 1. Stage and commit
 
 If there are uncommitted changes:
@@ -59,10 +76,10 @@ Skip this step if the working tree is clean.
 
 ### 2. Ensure feature branch
 
-If on the default branch (`master`/`main`), create a feature branch with a conventional prefix (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`) before pushing:
+If on the default branch (`master`/`main`), create a feature branch with a conventional prefix (`feat-`, `fix-`, `chore-`, `docs-`, `refactor-`, `test-`) before pushing:
 
 ```bash
-git checkout -b <prefix>/<short-description>
+git checkout -b <prefix>-<short-description>
 ```
 
 Skip if already on a non-default branch.
@@ -124,19 +141,74 @@ Stop when `mergedAt` is non-null (status: merged) or `state` becomes `CLOSED` wi
 
 Skip this step if the repo does not auto-merge. **Never call `gh pr merge` to merge manually unless the user explicitly asks** — that bypasses CI gating and the auto-merge workflow.
 
-### 7. Return to default branch
+### 7. Return to default branch (and clean up the worktree if one was used)
+
+Always determine the default branch first:
 
 ```bash
 default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||')
+```
+
+**Case A — main checkout** (step 0 reported `main checkout`): unchanged behavior.
+
+```bash
 git checkout "$default"
 git pull
 ```
 
-This is the step most often forgotten — always run it after merge unless the user explicitly says otherwise.
+**Case B — linked worktree** (step 0 reported `linked worktree`): only proceed **after the branch has actually merged** (step 6 confirmed the merge). Worktree teardown is destructive and hard to reverse — never run this block on an unmerged branch.
+
+1. Capture identifiers **while still inside the linked worktree** (these are per-worktree):
+
+   ```bash
+   linked_wt=$(git rev-parse --show-toplevel)
+   feature_branch=$(git rev-parse --abbrev-ref HEAD)   # literal "HEAD" if detached
+   main_wt=$(git worktree list --porcelain | awk 'NR==1 && /^worktree /{sub(/^worktree /,""); print}')
+   ```
+
+2. **Cleanliness gate.** If the worktree has uncommitted or untracked changes, do **not** remove it automatically:
+
+   ```bash
+   git -C "$linked_wt" status --porcelain
+   ```
+
+   - Empty output → clean; proceed to remove it automatically.
+   - Non-empty → stop and ask the user whether to discard those changes (`git worktree remove --force`) before doing anything destructive.
+
+3. Move into the main worktree and refresh — you cannot reliably remove the worktree you are standing in (its working directory becomes invalid):
+
+   ```bash
+   cd "$main_wt"
+   git checkout "$default"
+   git pull
+   ```
+
+4. Remove the merged worktree and prune stale metadata:
+
+   ```bash
+   git worktree remove "$linked_wt"   # add --force ONLY after explicit user approval when dirty
+   git worktree prune
+   ```
+
+5. Delete the now-merged local branch (skip when `feature_branch` is `HEAD`, i.e. detached):
+
+   ```bash
+   git branch -d "$feature_branch"
+   ```
+
+   `-d` is the safe form — it refuses if git doesn't see the branch as fully merged. A failure usually means a **squash merge** (the branch tip is not an ancestor of the merge commit). Tell the user and ask before force-deleting:
+
+   ```bash
+   git branch -D "$feature_branch"   # only after the user confirms
+   ```
+
+Returning to the default branch is the step most often forgotten — always run it after merge (in either case) unless the user explicitly says otherwise.
 
 ## Idempotency
 
 Each step probes state first and skips when there's nothing to do. Re-running the orchestrator after a partial run should pick up from wherever it left off — e.g. if the PR is already open, jump to step 5; if CI is already passing, jump to step 6; if the PR is already merged, jump to step 7.
+
+The step-7 worktree cleanup is gated twice: it runs only when step 0 detected a linked worktree **and** the branch has merged. In the main checkout it is skipped entirely (current behavior preserved), and re-running after the worktree is already removed is a no-op — the worktree detection short-circuits.
 
 ## What NOT to do
 
@@ -145,6 +217,10 @@ Each step probes state first and skips when there's nothing to do. Re-running th
 - Do **not** call `gh pr merge` / `tea pr merge` to manually merge unless the user asked — the auto-merge bot handles this.
 - Do **not** end the session on a feature branch after a merge — return to the default branch and pull.
 - Do **not** invent your own polling loop without time-boxing — bound every wait with a sensible timeout and a clear "no decision yet" exit.
+- Do **not** `git worktree remove` the worktree you are standing in — `cd` into the main worktree first, then remove.
+- Do **not** `--force`-remove a worktree with uncommitted or untracked changes without explicit user approval.
+- Do **not** `git branch -D` (force-delete) without confirming first — a `git branch -d` refusal usually signals a squash merge, not work that's safe to discard blindly.
+- Do **not** check out a branch that is already live in another worktree (`git` refuses with `already used by worktree at ...`).
 
 ## Reporting back
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/commands/session-issue.md
+++ b/plugins-copilot/session/commands/session-issue.md
@@ -30,16 +30,17 @@ propose a plan. To start from your own description instead, use
    body + labels as context.
 
 4. **Determine branch type** from issue labels:
-   - `bug`, `fix` -> `bug/`
-   - `enhancement`, `feature`, `improvement` -> `enhancement/`
-   - `docs`, `chore`, `refactor`, `maintenance` -> `chore/`
-   - No matching label -> `feature/`
+   - `bug`, `fix` -> `bug`
+   - `enhancement`, `feature`, `improvement` -> `enhancement`
+   - `docs`, `chore`, `refactor`, `maintenance` -> `chore`
+   - No matching label -> `feature`
 
 5. **Isolate.** Default to a worktree for substantial work via the `git-worktree`
-   plugin — `git worktree add .github/worktrees/<slug> -b <type>/<N>-<slug>` — then
+   plugin — `git worktree add .github/worktrees/<slug> -b <type>-<slug>` — then
    run subsequent steps from inside it. Create **in place**
-   (`git switch -c <type>/<N>-<slug>`) for trivial one-file fixes. `<slug>` is a
-   kebab-case 3-5 word slug from the issue title.
+   (`git switch -c <type>-<slug>`) for trivial one-file fixes. `<slug>` is a
+   kebab-case 3-5 word slug from the issue title. The issue number lives in the PR's
+   `Closes #N`, not the branch name.
 
 6. **Offer orchestration.** If the issue suggests non-trivial scope (long body,
    multiple acceptance criteria, keywords like `refactor`, `redesign`, `migration`,

--- a/plugins-copilot/session/commands/session-orchestrate.md
+++ b/plugins-copilot/session/commands/session-orchestrate.md
@@ -21,7 +21,7 @@ The workflow has seven phases. Two have hard user gates (Refine and Execute). Th
 Before starting Phase 1, check whether prior phases of this workflow have already run on this branch:
 
 1. Inspect the current repo directly with `git` — extract the current branch, the default branch (`origin/HEAD`, falling back to `main`/`master`), commits ahead of default, uncommitted changes, and whether the branch matches the default with no diverging commits.
-2. Inspect the most recent commit messages and any `wip/`, `feat/`, `enhancement/`, `chore/`, `bug/` branch names for evidence of prior work — recent commits referencing the spec/plan, or multiple commits since the default branch.
+2. Inspect the most recent commit messages and any `wip-`, `feat-`, `enhancement-`, `chore-`, `bug-` branch names for evidence of prior work — recent commits referencing the spec/plan, or multiple commits since the default branch.
 3. If any signal of prior orchestrate work is present, ask via `AskUserQuestion`:
    - **Resume from Plan** — re-use existing exploration, regenerate the plan
    - **Resume from Divide** — plan is good, re-chunk and execute
@@ -35,7 +35,7 @@ Before starting Phase 1, check whether prior phases of this workflow have alread
 Orchestrate runs are heavy and long-lived — **isolate them in a git worktree by default** (assumes the `git-worktree` plugin is installed) so the main checkout stays clean.
 
 - **Already isolated** — if the session is already in a worktree, or a feature branch is already checked out (inherited from `/session:session-start`, or the current branch is not the default), proceed in the current checkout. Do **not** create another worktree.
-- **Fresh run on the default branch** — create the work's branch as a worktree by default. Derive a branch name (`<type>/<NNN>-<slug>` from the issue, or `wip/<slug>` from the description) and create it with the plugin's `worktree-create` flow: `git worktree add .github/worktrees/<slug> -b <branch>`. Then run **all** subsequent phases from inside the worktree by prefixing commands with `cd .github/worktrees/<slug> && …`; the plugin's whitelist hook auto-approves operations on the worktree path. A fresh worktree is a clean checkout — reinstall or symlink heavy gitignored deps if the work needs them. Offer a one-key opt-out (work in place) via `AskUserQuestion`, but default to the worktree.
+- **Fresh run on the default branch** — create the work's branch as a worktree by default. Derive a branch name (`<type>-<slug>` from the issue — no number, that lives in the PR's `Closes #N` — or `wip-<slug>` from the description) and create it with the plugin's `worktree-create` flow: `git worktree add .github/worktrees/<slug> -b <branch>`. Then run **all** subsequent phases from inside the worktree by prefixing commands with `cd .github/worktrees/<slug> && …`; the plugin's whitelist hook auto-approves operations on the worktree path. A fresh worktree is a clean checkout — reinstall or symlink heavy gitignored deps if the work needs them. Offer a one-key opt-out (work in place) via `AskUserQuestion`, but default to the worktree.
 
 Then proceed to Phase 1.
 

--- a/plugins-copilot/session/commands/session-start.md
+++ b/plugins-copilot/session/commands/session-start.md
@@ -24,10 +24,11 @@ open issues instead, use `/session:session-issue`.
 
 3. **Pick a base branch name:**
    - **References an existing issue** (e.g. "#42") → fetch it, derive the type from
-     labels (`bug`/`fix` → `bug/`, `enhancement`/`feature`/`improvement` →
-     `enhancement/`, `docs`/`chore`/`refactor`/`maintenance` → `chore/`, else
-     `feature/`), name `<type>/<N>-<slug>`. Keep the issue body + labels as context.
-   - **Freeform** → `wip/<kebab-slug>` (3-5 word slug). No issue linked.
+     labels (`bug`/`fix` → `bug`, `enhancement`/`feature`/`improvement` →
+     `enhancement`, `docs`/`chore`/`refactor`/`maintenance` → `chore`, else
+     `feature`), name `<type>-<slug>` (the issue number lives in the PR's `Closes #N`,
+     not the branch). Keep the issue body + labels as context.
+   - **Freeform** → `wip-<kebab-slug>` (3-5 word slug). No issue linked.
 
 4. **Isolate (new work only).** Default to a worktree for substantial work via the
    `git-worktree` plugin — `git worktree add .github/worktrees/<slug> -b <base-name>`

--- a/tests/git-tools/test-worktree-cleanup.sh
+++ b/tests/git-tools/test-worktree-cleanup.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test-worktree-cleanup.sh — Validate the git worktree-detection and cleanup
+# recipe embedded in the `ship` skill (plugins-claude/git-tools/skills/ship/SKILL.md,
+# step 0 detection + step 7 Case B). The skill is Markdown, so this test re-runs
+# the same plain-git commands in throwaway repos to catch git-behavior regressions.
+#
+# Usage: bash tests/git-tools/test-worktree-cleanup.sh
+
+set -euo pipefail
+
+# Hermetic git: ignore the developer's global/system config (gpgsign, templates,
+# init.defaultBranch, …) so commits and branch names are deterministic in CI.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# realpath the temp root: on macOS $TMPDIR/mktemp live under /var → /private/var,
+# so the detection's realpath compare needs a normalized base to avoid a false
+# "linked" reading in the main checkout.
+TMP_ROOT=$(realpath "$(mktemp -d)")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass() {
+  printf "  \033[32m✓\033[0m %s\n" "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf "  \033[31m✗\033[0m %s  (%s)\n" "$1" "$2"
+  FAIL=$((FAIL + 1))
+}
+
+# Create a main repo with one commit on branch `main`. Echoes its absolute path.
+new_repo() {
+  local d="$TMP_ROOT/$1"
+  mkdir -p "$d"
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email test@example.com
+  git -C "$d" config user.name "Test"
+  printf 'seed\n' >"$d/file.txt"
+  git -C "$d" add file.txt
+  git -C "$d" commit -q -m "init"
+  echo "$d"
+}
+
+# The detection recipe, exactly as written in the skill. Echoes "linked" or "main".
+detect() {
+  local gd gcd
+  gd=$(git rev-parse --git-dir)
+  gcd=$(git rev-parse --git-common-dir)
+  if [ "$(realpath "$gd")" != "$(realpath "$gcd")" ]; then
+    echo linked
+  else
+    echo main
+  fi
+}
+
+# The main-worktree-path extraction recipe from the skill.
+main_wt_path() {
+  git worktree list --porcelain | awk 'NR==1 && /^worktree /{sub(/^worktree /,""); print}'
+}
+
+echo "── worktree detection ──"
+
+# Test 1: main checkout → detection reports "main"
+main=$(new_repo t1-main)
+got=$(cd "$main" && detect)
+if [ "$got" = "main" ]; then
+  pass "main checkout detected as 'main'"
+else
+  fail "main checkout detection" "got '$got'"
+fi
+
+# Test 2: linked worktree → detection reports "linked"
+main=$(new_repo t2-main)
+wt="$TMP_ROOT/t2-wt"
+git -C "$main" worktree add -q "$wt" -b feat/x
+got=$(cd "$wt" && detect)
+if [ "$got" = "linked" ]; then
+  pass "linked worktree detected as 'linked'"
+else
+  fail "linked worktree detection" "got '$got'"
+fi
+
+# Test 3: main-path extraction from inside the linked worktree
+got=$(cd "$wt" && main_wt_path)
+if [ "$(realpath "$got")" = "$(realpath "$main")" ]; then
+  pass "main worktree path extracted from porcelain"
+else
+  fail "main worktree path extraction" "got '$got' want '$main'"
+fi
+
+echo "── cleanliness gate ──"
+
+# Test 4: clean → empty status; dirty (untracked) → non-empty status
+if [ -z "$(git -C "$wt" status --porcelain)" ]; then
+  pass "clean worktree → empty status --porcelain"
+else
+  fail "clean worktree status" "expected empty"
+fi
+touch "$wt/untracked.txt"
+if [ -n "$(git -C "$wt" status --porcelain)" ]; then
+  pass "dirty worktree → non-empty status --porcelain"
+else
+  fail "dirty worktree status" "expected non-empty"
+fi
+
+echo "── full clean cleanup (merge-commit) ──"
+
+# Test 5: merge feat into main, then remove worktree + prune + branch -d
+main=$(new_repo t5-main)
+wt="$TMP_ROOT/t5-wt"
+git -C "$main" worktree add -q "$wt" -b feat/y
+printf 'change\n' >>"$wt/file.txt"
+git -C "$wt" commit -q -am "feat work"
+git -C "$main" merge -q --no-ff -m "merge feat/y" feat/y
+git -C "$main" worktree remove "$wt"
+git -C "$main" worktree prune
+git -C "$main" branch -d feat/y >/dev/null 2>&1
+remaining=$(git -C "$main" worktree list --porcelain | grep -c '^worktree ')
+if [ ! -e "$wt" ]; then
+  pass "git worktree remove deleted the worktree directory"
+else
+  fail "worktree remove" "directory still exists"
+fi
+if [ "$remaining" -eq 1 ]; then
+  pass "only the main worktree remains after cleanup"
+else
+  fail "worktree list after cleanup" "expected 1, got $remaining"
+fi
+if [ -z "$(git -C "$main" branch --list feat/y)" ]; then
+  pass "merged branch deleted with 'git branch -d'"
+else
+  fail "branch -d after merge" "feat/y still present"
+fi
+
+echo "── squash-merge caveat ──"
+
+# Test 6: squash merge → branch tip not an ancestor → 'git branch -d' refuses;
+# 'git branch -D' force-deletes.
+main=$(new_repo t6-main)
+wt="$TMP_ROOT/t6-wt"
+git -C "$main" worktree add -q "$wt" -b feat/z
+printf 'squashed change\n' >>"$wt/file.txt"
+git -C "$wt" commit -q -am "feat work to squash"
+git -C "$main" merge -q --squash feat/z
+git -C "$main" commit -q -m "squash merge feat/z"
+git -C "$main" worktree remove "$wt"
+if git -C "$main" branch -d feat/z >/dev/null 2>&1; then
+  fail "branch -d after squash" "expected refusal, but it succeeded"
+else
+  pass "'git branch -d' refuses an unmerged (squashed) branch"
+fi
+if git -C "$main" branch -D feat/z >/dev/null 2>&1 &&
+  [ -z "$(git -C "$main" branch --list feat/z)" ]; then
+  pass "'git branch -D' force-deletes the squashed branch"
+else
+  fail "branch -D after squash" "force delete did not remove feat/z"
+fi
+
+echo "── detached HEAD ──"
+
+# Test 7: detached worktree → abbrev-ref HEAD is literal "HEAD" (skip branch delete)
+main=$(new_repo t7-main)
+wt="$TMP_ROOT/t7-wt"
+git -C "$main" worktree add -q --detach "$wt"
+ref=$(cd "$wt" && git rev-parse --abbrev-ref HEAD)
+if [ "$ref" = "HEAD" ]; then
+  pass "detached worktree → abbrev-ref HEAD == 'HEAD' (branch delete skipped)"
+else
+  fail "detached HEAD detection" "got '$ref'"
+fi
+
+echo ""
+echo "Total: $((PASS + FAIL))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- **`ship` worktree cleanup (#117):** `git-tools:ship` now detects a linked worktree and, after the branch merges, returns to the main worktree, removes the merged worktree, prunes, and deletes the branch — instead of leaving it behind. Step 0 gains worktree detection; step 7 splits into main-checkout vs linked-worktree teardown; Idempotency + What NOT to do updated.
- **Simpler session branch names:** dash-form `<type>-<slug>` with no issue number (the linkage is the PR's `Closes #N`), leaning on the built-in `EnterWorktree` tooling. Updated the shared spine, orchestrate/start/issue skills, the Copilot commands, and the README; `ship`'s conventional prefixes are now dash form (`feat-`, `fix-`, …).
- Dropped the now-dead linked-issue branch parsing in `sitrep`/`catchup`.
- Bumped git-tools `2.0.10` → `2.0.11` and session `4.0.0` → `4.0.1`.

## Test plan

- [x] New `tests/git-tools/test-worktree-cleanup.sh` — 11 cases (detection, main-path extraction, cleanliness gate, full clean cleanup, squash-merge caveat, detached HEAD) — passes
- [x] Full suite `bash test.sh` — 1586 passed / 0 failed
- [x] `validate-plugins.sh` (277/0), `validate-frontmatter.sh` (95/0), `rumdl check` clean
- [x] Exercised the worktree flow live (`git worktree add -b` + `EnterWorktree path:` round-trip)

Closes #117
