### PR TITLE
add sf-code-review Copilot plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -136,6 +136,15 @@
         "name": "Logan Gagne"
       },
       "category": "development",
+      "description": "Chunked cross-family code review orchestration for Copilot CLI — dual Sonnet 4.6 + GPT-5.4 review with targeted Opus 4.6 adjudication",
+      "name": "sf-code-review",
+      "source": "./plugins-copilot/sf-code-review"
+    },
+    {
+      "author": {
+        "name": "Logan Gagne"
+      },
+      "category": "development",
       "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
       "name": "agentic-ide",
       "source": "./plugins-copilot/agentic-ide"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,7 @@ A handful of plugins are intentionally CLI-specific and listed in only one marke
 |---|---|---|
 | `statusline` | Claude only | Configures the Claude Code status line — no Copilot equivalent |
 | `git-worktree` | Copilot only | Copilot lacks Claude's built-in worktree management |
+| `sf-code-review` | Copilot only | Depends on Copilot CLI cross-family multi-model review orchestration |
 
 ```text
 plugins-copilot/<name>/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A collection of Claude Code and GitHub Copilot CLI plugins for development workf
 | Plugin | Type | Description |
 |--------|------|-------------|
 | [`git-worktree`](plugins-copilot/git-worktree/) | Commands | Git worktree lifecycle management for parallel agentic work — create, list, remove worktrees with auto-whitelisting and proactive context-mismatch detection |
+| [`sf-code-review`](plugins-copilot/sf-code-review/) | Commands + Skill | Chunked cross-family code review orchestration for Copilot CLI — dual Sonnet 4.6 + GPT-5.4 review with targeted Opus 4.6 adjudication |
 
 ## Installation
 
@@ -125,7 +126,7 @@ plugins-claude/<name>/
 
 Both marketplaces list nearly all plugins. Copilot CLI entries point to `plugins-copilot/` variants so hook-enabled plugins can use Copilot-format `hooks.json`, while shared directories (`scripts/`, `skills/`, etc.) are symlinked back to canonical `plugins-claude/` sources. The `commands/` directory only exists in `plugins-copilot/` — Copilot CLI requires it for slash commands, while Claude uses skills with the `disable-model-invocation: true` frontmatter flag instead.
 
-A few plugins are intentionally CLI-specific: `statusline` is Claude-only (no Copilot equivalent surface), and `git-worktree` is Copilot-only (Claude has built-in worktree management).
+A few plugins are intentionally CLI-specific: `statusline` is Claude-only (no Copilot equivalent surface), while `git-worktree` and `sf-code-review` are Copilot-only (`git-worktree` fills a missing worktree surface; `sf-code-review` depends on cross-family review orchestration).
 
 ```text
 plugins-copilot/<name>/

--- a/plugins-copilot/sf-code-review/.claude-plugin/plugin.json
+++ b/plugins-copilot/sf-code-review/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "sf-code-review",
+  "version": "0.1.0",
+  "description": "Chunked cross-family code review orchestration for Copilot CLI — dual Sonnet 4.6 + GPT-5.4 review with targeted Opus 4.6 adjudication",
+  "author": {
+    "name": "Logan Gagne"
+  }
+}

--- a/plugins-copilot/sf-code-review/README.md
+++ b/plugins-copilot/sf-code-review/README.md
@@ -1,0 +1,63 @@
+# sf-code-review
+
+Chunked cross-family code review for GitHub Copilot CLI — dual mid-range review with targeted high-end adjudication and triage-ready output.
+
+> **Copilot CLI only.** This workflow depends on mixing model families inside one review pipeline.
+
+## Installation
+
+Install from the Copilot CLI plugin marketplace:
+
+```text
+sf-code-review plugin from St0nefish/agent-toolkit
+```
+
+## Slash command
+
+```text
+/sf-code-review:review [--base <ref>] [--staged] [--scope <path> ...] [--focus "<item>; <item>"] [--exception "<false-positive class>; <false-positive class>"]
+```
+
+Examples:
+
+```text
+/sf-code-review:review --focus "pega model as source of truth; syncDown source-set rollback"
+/sf-code-review:review --base origin/master --focus "backward compatibility; migration safety"
+/sf-code-review:review --staged --scope services/model services/sync --focus "config only via pega"
+```
+
+## How it works
+
+1. Scopes the review from the staged diff, an explicit base ref, or the current branch against the default branch merge-base.
+2. Collects review-specific focus items plus named false-positive exceptions.
+3. Builds coherent chunks by semantic unit first, then diff size.
+4. Runs a diff-wide cross-cutting sweep for architectural and integration risks.
+5. Dual-reviews each chunk with **Claude Sonnet 4.6** and **GPT-5.4**.
+6. Uses **Claude Opus 4.6** only to adjudicate candidate findings and disagreements — not to redo the whole review.
+7. Consolidates a triage-ready report with confirmed issues, cross-cutting concerns, open questions, and rejected findings.
+
+## Model roles
+
+| Model | Role |
+|---|---|
+| `claude-sonnet-4.6` | First-pass chunk reviewer |
+| `gpt-5.4` | First-pass chunk reviewer + default whole-diff cross-cutting sweep |
+| `claude-opus-4.6` | Targeted adjudicator for candidate findings only |
+
+## Review contract
+
+- Custom focus items **add to** baseline review; they do not replace correctness, regression, compatibility, or test-gap checks.
+- Exceptions only suppress named false-positive classes or intentional deviations; they do not waive real correctness, auth, security, or data-loss risks.
+- Opus is an adjudicator, not a third full reviewer.
+- Opus must be **exactly** `claude-opus-4.6`; do not substitute `claude-opus-4.7` or `claude-opus-4.8`.
+
+## Output
+
+The review report is organized for human triage:
+
+1. Review metadata — base, scope mode, focus items, exceptions, chunk count
+2. Confirmed issues — severity, confidence, file:line, reviewers, impact, recommended fix
+3. Open questions / uncertain items
+4. Cross-cutting concerns
+5. Rejected findings
+6. Counts and overall merge risk

--- a/plugins-copilot/sf-code-review/commands/review.md
+++ b/plugins-copilot/sf-code-review/commands/review.md
@@ -1,0 +1,33 @@
+---
+description: "Run a chunked multi-model code review with dual Sonnet/GPT reviewers and targeted Opus adjudication"
+argument-hint: "[--base <ref>] [--staged] [--scope <path> ...] [--focus \"<item>; <item>\"] [--exception \"<false-positive class>; <false-positive class>\"]"
+allowed-tools: Bash, Read, AskUserQuestion, Task
+---
+
+Run the Stonefish code-review workflow over the current changeset: scope the diff,
+collect review-specific focus items, split the review into coherent chunks, dual-review
+each chunk with Claude Sonnet 4.6 and GPT-5.4, use Claude Opus 4.6 only to adjudicate
+candidate findings, then consolidate a triage-ready report.
+
+This command invokes the `sf-code-review` skill — use that skill's full procedure.
+
+## Argument handling
+
+- `--staged` — review the staged snapshot with `git diff --cached`; if present, ignore `--base`
+- `--base <ref>` — review `<ref>...HEAD`
+- `--scope <path> ...` — restrict review to one or more paths
+- `--focus "A; B; C"` — add review-specific priorities or architectural invariants
+- `--exception "A; B"` — name specific false-positive classes or intentional deviations
+
+If `$ARGUMENTS` contains freeform text beyond these flags, preserve it as additional
+review context instead of dropping it.
+
+## Rules
+
+1. Custom focus areas add to the baseline review; they do not replace correctness,
+   compatibility, regression, or testing checks.
+2. Opus is an adjudicator, not a third reviewer.
+3. If no reviewer flags a candidate issue and there is no disagreement, skip Opus.
+4. Never pass the full diff to Opus unless a candidate cannot be understood otherwise.
+5. Prefer batching candidate findings into as few targeted Opus passes as practical.
+6. When Opus is needed, use **only** `claude-opus-4.6` — never `claude-opus-4.7` or `claude-opus-4.8`.

--- a/plugins-copilot/sf-code-review/skills/sf-code-review/SKILL.md
+++ b/plugins-copilot/sf-code-review/skills/sf-code-review/SKILL.md
@@ -1,0 +1,233 @@
+---
+user-invocable: false
+name: sf-code-review
+description: >-
+  Use this skill for extensive code reviews of current changes when the user
+  wants chunked, cross-family review with dual mid-range reviewers and targeted
+  Opus adjudication. Trigger phrases include "extensive code review", "split
+  the review into chunks", "dual review", "reconcile findings", and
+  "stonefish code review".
+allowed-tools: Bash, Read, AskUserQuestion, Task
+---
+
+# sf-code-review — chunked cross-family review
+
+**Purpose.** Run a repeatable review pipeline over the current changeset: scope the
+diff, collect review-specific focus items, split the work into coherent chunks,
+review each chunk with two different mid-range models, and use a targeted Opus
+pass only to adjudicate candidate findings before producing a triage-ready report.
+
+If the user explicitly invokes `/sf-code-review:review`, use this exact procedure.
+
+## When to use
+
+Use this workflow when the user wants a deeper review than a single-pass code
+review, especially when they ask for any of the following:
+
+- "extensive code review"
+- "split the review into chunks"
+- "dual review"
+- "two reviewers"
+- "reconcile findings"
+- "stonefish code review"
+
+Do **not** use this workflow for tiny quick reviews where a normal single-pass
+review is enough.
+
+## Default review contract
+
+1. **Baseline review always applies.** Even when the user supplies focus items,
+   still check for correctness, regressions, interface/config/schema drift,
+   test gaps, and obvious breakage.
+2. **Custom focus areas add to the baseline.** They do not replace it.
+3. **Exceptions are narrow.** Named exceptions only suppress explicit
+   false-positive classes or intentional deviations. They never waive real
+   correctness, auth, security, or data-loss concerns without evidence.
+4. **Opus is an adjudicator, not a third reviewer.**
+5. **Pin Opus cost.** When Opus is needed, use **only** `claude-opus-4.6`.
+   Never substitute `claude-opus-4.7` or `claude-opus-4.8`.
+
+## Procedure
+
+### 0. Capture scope and review-specific inputs
+
+Parse command arguments if present.
+
+- If `--staged` is present, review `git diff --cached` and ignore `--base`.
+- Else if `--base <ref>` is present, review `<ref>...HEAD`.
+- Else default to the merge-base between `HEAD` and the default branch.
+- If `--scope <path> ...` is present, restrict all diff commands to those paths.
+
+If the user has not already provided review-specific focus items, ask via
+`AskUserQuestion` for:
+
+- focus items / architectural invariants
+- optional named exceptions / known-safe churn
+- optional path narrowing if the scope is too large
+
+### 1. Gather one authoritative git snapshot
+
+Use direct git commands as the source of truth:
+
+```bash
+git status --porcelain=v1 -b
+default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||')
+base=$(git merge-base HEAD "origin/$default")
+git diff --stat "$base"...HEAD
+git diff --name-only "$base"...HEAD
+git diff --numstat "$base"...HEAD
+```
+
+For staged reviews, use the `--cached` equivalents instead. For path-scoped
+reviews, append `-- <paths...>` to every diff command.
+
+Capture:
+
+- scope mode (`staged`, `base-ref`, or `default-merge-base`)
+- base ref or merge-base
+- changed files
+- per-file diff size
+- rough directory grouping
+
+If the scoped diff is empty, report that there is nothing to review and stop.
+
+### 2. Build the chunk plan
+
+Chunk by **semantic unit first**, size second. Keep these together whenever
+possible:
+
+- implementation + touched interface / contract
+- migration / config change + affected callers
+- behavior change + tests
+
+Rules:
+
+- For small diffs (roughly `<= 3` files or `<= 250` changed lines), use a
+  single chunk instead of forcing chunking.
+- Prefer chunks of roughly `150-400` changed lines.
+- Default to at most `6` chunks.
+- If the review would exceed `6` chunks or roughly `2500` changed lines after
+  scoping, show the chunk plan and ask the user whether to narrow the scope or
+  review in phases before dispatching agents.
+
+### 3. Run one diff-wide cross-cutting sweep
+
+Run one whole-diff sweep before chunk-level adjudication. Its job is to look
+for **cross-cutting concerns**, not to replace chunk review.
+
+Prefer a `code-review` agent with model `gpt-5.4`. Only switch this sweep to
+`general-purpose` with `gpt-5.4` if the user's focus items clearly require
+reading surrounding unchanged code or architectural context.
+
+The sweep must check this fixed checklist plus the user-provided focus items:
+
+- interface / schema drift
+- call-site mismatch across files
+- auth / permission boundary changes
+- transaction ordering / idempotency changes
+- config or migration compatibility
+- multi-file behavior changes lacking tests
+
+Return cross-cutting concerns only. Do not use this pass as a second full review.
+
+### 4. Run dual first-pass chunk reviews
+
+For each chunk, launch **two** independent `code-review` agents in parallel:
+
+- one with model `claude-sonnet-4.6`
+- one with model `gpt-5.4`
+
+Give both reviewers the same chunk scope and the same review contract:
+
+- baseline review
+- user focus items
+- named exceptions
+- chunk manifest and relevant diff context
+
+Require each reviewer to return a **strict finding schema**. Free-form prose is
+not acceptable.
+
+If a reviewer finds nothing, it must return exactly:
+
+```text
+chunk_id: <chunk-id>
+NO_FINDINGS
+```
+
+Otherwise require this structure for every finding:
+
+```text
+chunk_id: <chunk-id>
+findings:
+  - finding_id: <stable-id>
+    file:line: <path:line or path>
+    severity: critical|high|medium|low
+    confidence: high|medium|low
+    category: correctness|regression|architecture|security|performance|tests|compatibility
+    claim: <one-sentence issue statement>
+    why_it_matters: <impact>
+    minimal_evidence: <smallest diff/context that supports the claim>
+    suggested_check: <what to verify or change>
+```
+
+### 5. Dedupe and prepare candidate findings
+
+Before invoking Opus:
+
+- dedupe equivalent findings across the two reviewers
+- keep disagreements where one reviewer flags an issue and the other does not
+- keep findings that materially disagree on severity or scope
+- discard noise that clearly does not meet the schema or lacks evidence
+
+### 6. Run targeted Opus adjudication
+
+Use `claude-opus-4.6` **only** as an adjudicator for candidate findings.
+
+Hard rules:
+
+- If no reviewer flags a candidate finding and there is no disagreement, skip Opus.
+- Do not substitute `claude-opus-4.7` or `claude-opus-4.8`; keep Opus pinned to
+  `claude-opus-4.6` for cost control.
+- Batch candidate findings into as few targeted Opus passes as practical.
+- Prefer `code-review` for adjudication when the candidate can be judged from
+  the touched diff and nearby context.
+- Use `general-purpose` with `claude-opus-4.6` only when a candidate cannot be
+  resolved without broader surrounding code or architectural context.
+- Never pass the full diff to Opus unless a candidate cannot be understood otherwise.
+- Opus may only evaluate supplied candidate findings plus minimal supporting context.
+- Opus must not introduce net-new unrelated findings.
+
+Tell Opus explicitly: **you are an adjudicator, not a third reviewer**.
+
+Require one verdict per candidate finding:
+
+```text
+finding_id: <stable-id>
+verdict: confirmed|rejected|uncertain
+severity: critical|high|medium|low
+confidence: high|medium|low
+reason: <why>
+recommended_fix: <specific next step>
+```
+
+### 7. Consolidate the final report
+
+Return a triage-ready report with these sections, in this order:
+
+1. **Review metadata** — base, scope mode, focus items, exceptions, chunk count
+2. **Overall risk** — a short paragraph on merge risk / likely breakage surface
+3. **Confirmed issues** — severity, confidence, file:line, chunk, reviewers involved,
+   why it matters, recommended fix
+4. **Open questions / uncertain items**
+5. **Cross-cutting concerns**
+6. **Rejected findings** — short reason for rejection
+7. **Counts** — candidate, confirmed, rejected, uncertain
+
+## What not to do
+
+- Do **not** let custom focus items replace the baseline review.
+- Do **not** let named exceptions suppress broad categories of real risk.
+- Do **not** turn the cross-cutting sweep into another full review.
+- Do **not** let Opus search for new issues unrelated to supplied candidates.
+- Do **not** automatically run one Opus pass per chunk when a smaller number of
+  targeted adjudication batches will do.

--- a/tests/sf-code-review/test-command-docs.sh
+++ b/tests/sf-code-review/test-command-docs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# test-command-docs.sh — Checks that Copilot-facing sf-code-review command docs
+# encode the intended scope flags and Opus guardrails.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$SCRIPT_DIR/../../plugins-copilot/sf-code-review"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s (missing: %s)\n" "$label" "$needle"
+    ((FAIL++)) || true
+  fi
+}
+
+echo "── command docs include expected arguments and routing ──"
+
+COMMAND_DOC=$(cat "$PLUGIN_DIR/commands/review.md")
+
+assert_contains "command routes to sibling skill" 'invokes the `sf-code-review` skill' "$COMMAND_DOC"
+assert_contains "argument hint includes --base" '--base <ref>' "$COMMAND_DOC"
+assert_contains "argument hint includes --staged" '--staged' "$COMMAND_DOC"
+assert_contains "argument hint includes --scope" '--scope <path> ...' "$COMMAND_DOC"
+assert_contains "argument hint includes --focus" '--focus "' "$COMMAND_DOC"
+assert_contains "argument hint includes --exception" '--exception "' "$COMMAND_DOC"
+
+echo "── command docs encode model pipeline and Opus guardrails ──"
+
+assert_contains "command mentions Sonnet reviewer" 'Claude Sonnet 4.6' "$COMMAND_DOC"
+assert_contains "command mentions GPT reviewer" 'GPT-5.4' "$COMMAND_DOC"
+assert_contains "command mentions Opus adjudicator" 'Claude Opus 4.6' "$COMMAND_DOC"
+assert_contains "command says Opus is adjudicator" 'Opus is an adjudicator, not a third reviewer.' "$COMMAND_DOC"
+assert_contains "command skips Opus when no candidates" 'If no reviewer flags a candidate issue and there is no disagreement, skip Opus.' "$COMMAND_DOC"
+assert_contains "command forbids full diff to Opus" 'Never pass the full diff to Opus unless a candidate cannot be understood otherwise.' "$COMMAND_DOC"
+assert_contains "command pins Opus to 4.6 only" 'use **only** `claude-opus-4.6` — never `claude-opus-4.7` or `claude-opus-4.8`.' "$COMMAND_DOC"
+assert_contains "command preserves freeform context" 'preserve it as additional' "$COMMAND_DOC"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+printf "  \033[32m%d passed\033[0m" "$PASS"
+if [[ $FAIL -gt 0 ]]; then
+  printf "  \033[31m%d failed\033[0m" "$FAIL"
+fi
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit "$FAIL"

--- a/tests/sf-code-review/test-skill.sh
+++ b/tests/sf-code-review/test-skill.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test-skill.sh — Tests for the sf-code-review orchestration skill.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_FILE="$SCRIPT_DIR/../../plugins-copilot/sf-code-review/skills/sf-code-review/SKILL.md"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s\n    expected: %s\n    got:      %s\n" "$label" "$expected" "$actual"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle" 2>/dev/null; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s (missing: %s)\n" "$label" "$needle"
+    ((FAIL++)) || true
+  fi
+}
+
+echo "── skill frontmatter ──"
+
+FRONTMATTER=$(awk '/^---$/{count++; if(count==2) exit} count==1' "$SKILL_FILE")
+SKILL_CONTENT=$(cat "$SKILL_FILE")
+
+assert_eq "name field" "sf-code-review" \
+  "$(echo "$FRONTMATTER" | grep '^name:' | awk '{print $2}')"
+assert_eq "user-invocable false" "false" \
+  "$(echo "$FRONTMATTER" | grep '^user-invocable:' | awk '{print $2}')"
+assert_contains "allowed-tools includes Bash" 'Bash' "$FRONTMATTER"
+assert_contains "allowed-tools includes Read" 'Read' "$FRONTMATTER"
+assert_contains "allowed-tools includes AskUserQuestion" 'AskUserQuestion' "$FRONTMATTER"
+assert_contains "allowed-tools includes Task" 'Task' "$FRONTMATTER"
+assert_contains "description mentions dual review" 'dual' "$FRONTMATTER"
+
+echo "── trigger and scope guidance ──"
+
+assert_contains "trigger: extensive code review" 'extensive code review' "$SKILL_CONTENT"
+assert_contains "trigger: split into chunks" 'split the review into chunks' "$SKILL_CONTENT"
+assert_contains "trigger: dual review" 'dual review' "$SKILL_CONTENT"
+assert_contains "mentions staged precedence" 'review `git diff --cached` and ignore `--base`' "$SKILL_CONTENT"
+assert_contains "mentions semantic chunking" 'semantic unit first' "$SKILL_CONTENT"
+assert_contains "mentions chunk cap" 'at most `6` chunks' "$SKILL_CONTENT"
+assert_contains "mentions phase prompt for large scope" 'review in phases' "$SKILL_CONTENT"
+
+echo "── baseline review and cross-cutting sweep guardrails ──"
+
+assert_contains "focus adds to baseline" 'Custom focus areas add to the baseline.' "$SKILL_CONTENT"
+assert_contains "exceptions are narrow" 'Exceptions are narrow.' "$SKILL_CONTENT"
+assert_contains "cross-cutting checklist includes schema drift" 'interface / schema drift' "$SKILL_CONTENT"
+assert_contains "cross-cutting checklist includes call-site mismatch" 'call-site mismatch across files' "$SKILL_CONTENT"
+assert_contains "cross-cutting checklist includes config compatibility" 'config or migration compatibility' "$SKILL_CONTENT"
+assert_contains "cross-cutting sweep not full review" 'Do not use this pass as a second full review.' "$SKILL_CONTENT"
+
+echo "── reviewer schema and Opus adjudication guardrails ──"
+
+assert_contains "strict finding schema required" 'strict finding schema' "$SKILL_CONTENT"
+assert_contains "reviewer NO_FINDINGS sentinel" 'NO_FINDINGS' "$SKILL_CONTENT"
+assert_contains "finding schema includes finding_id" 'finding_id:' "$SKILL_CONTENT"
+assert_contains "finding schema includes minimal_evidence" 'minimal_evidence:' "$SKILL_CONTENT"
+assert_contains "finding schema includes suggested_check" 'suggested_check:' "$SKILL_CONTENT"
+assert_contains "mentions Sonnet model" 'claude-sonnet-4.6' "$SKILL_CONTENT"
+assert_contains "mentions GPT model" 'gpt-5.4' "$SKILL_CONTENT"
+assert_contains "mentions Opus model" 'claude-opus-4.6' "$SKILL_CONTENT"
+assert_contains "forbids Opus 4.7" 'Never substitute `claude-opus-4.7`' "$SKILL_CONTENT"
+assert_contains "forbids Opus 4.8" '`claude-opus-4.8`' "$SKILL_CONTENT"
+assert_contains "Opus is adjudicator" 'you are an adjudicator, not a third reviewer' "$SKILL_CONTENT"
+assert_contains "skip Opus when no candidates" 'If no reviewer flags a candidate finding and there is no disagreement, skip Opus.' "$SKILL_CONTENT"
+assert_contains "forbid net-new findings" 'Opus must not introduce net-new unrelated findings.' "$SKILL_CONTENT"
+assert_contains "require confirmed rejected uncertain verdicts" 'verdict: confirmed|rejected|uncertain' "$SKILL_CONTENT"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+printf "  \033[32m%d passed\033[0m" "$PASS"
+if [[ $FAIL -gt 0 ]]; then
+  printf "  \033[31m%d failed\033[0m" "$FAIL"
+fi
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit "$FAIL"


### PR DESCRIPTION

Add a Copilot-only code review workflow that formalizes the chunked dual-review
process and keeps high-cost adjudication pinned to Claude Opus 4.6.

* add the sf-code-review Copilot plugin with a slash command and model-only skill
* encode chunk planning, dual Sonnet/GPT review, and targeted Opus adjudication
* document Copilot-only marketplace coverage and add prompt-contract tests

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>