### PR TITLE
feat(session): allow model invocation of session-orchestrate

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/skills/session-orchestrate/SKILL.md
+++ b/plugins-claude/session/skills/session-orchestrate/SKILL.md
@@ -1,7 +1,6 @@
 ---
-disable-model-invocation: true
 name: session-orchestrate
-description: "Multi-phase, multi-agent feature workflow: spec → plan → refine → divide → execute → review"
+description: "Multi-phase, multi-agent feature workflow: spec → plan → refine → divide → execute → review. Invoke when the user escalates a session-start/session-issue flow to orchestration, or asks to run a non-trivial feature (multiple files, design ambiguity, cross-cutting concerns, correctness-critical paths) through the full multi-agent workflow. For small fixes, prefer session-start."
 allowed-tools: Bash, Agent, Read, Glob, Grep, AskUserQuestion, EnterWorktree
 ---
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

The shared begin-work spine (`reference/spine.md`, Phase 2) instructs `session-start` and `session-issue` to hand off to `session-orchestrate` when the user escalates non-trivial work. But `session-orchestrate` was marked `disable-model-invocation: true` (user-only), so the model could never invoke it via the Skill tool — the escalation path was a dead end.

- Remove `disable-model-invocation` from `session-orchestrate` so it is both slash-invocable and model-invocable (the default).
- Expand its `description` with trigger guidance (escalation handoff, direct non-trivial-feature requests) plus a "prefer session-start for small fixes" guard to limit spurious auto-triggering.
- Bump `session` to 4.0.2 on both Claude and Copilot sides.

## Test plan

- `bash .github/scripts/validate-frontmatter.sh` — 95 checks, 0 failures
- `bash .github/scripts/validate-plugins.sh` — 277 checks, 0 failures (session @ 4.0.2, no vendored-util drift)
