### PR TITLE
fix(statusline): show project name instead of worktree name in dir segment

### DIFF
--- a/plugins-claude/statusline/.claude-plugin/plugin.json
+++ b/plugins-claude/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Configurable status line for Claude Code — git status, model, context, API usage, cost segments with ANSI colors",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/statusline/scripts/statusline.sh
+++ b/plugins-claude/statusline/scripts/statusline.sh
@@ -174,7 +174,7 @@ load_config() {
 # ── Utilities ─────────────────────────────────────────────────────────────────
 
 shorten_path() {
-  local full="$1" max="$2" project="${3:-}"
+  local full="$1" max="$2" project="${3:-}" name_override="${4:-}"
   local display=""
 
   # Replace home with ~
@@ -182,7 +182,9 @@ shorten_path() {
 
   if [[ -n "$project" ]]; then
     local proj_short="${project/#$HOME/\~}"
-    local proj_name="${proj_short##*/}"
+    # Display name defaults to the project basename, but callers may override it
+    # (e.g. to show the main repo name when PROJECT_DIR is a git worktree).
+    local proj_name="${name_override:-${proj_short##*/}}"
     if [[ "$full" == "$proj_short"* ]]; then
       local rel="${full#"$proj_short"}"
       rel="${rel#/}"
@@ -568,10 +570,28 @@ seg_user() {
   printf '%b%s%b' "$(c "$color")" "$display" "$(c reset)"
 }
 
+# Resolve the canonical project name for a directory, accounting for git
+# worktrees. For both the main checkout and a linked worktree, --git-common-dir
+# resolves to the MAIN repo's .git, so the basename of its parent is the project
+# name. Returns non-zero on any failure so callers fall back to the path basename.
+resolve_project_name() {
+  local dir="$1"
+  [[ -z "$dir" ]] && return 1
+  local common
+  common=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  [[ -z "$common" ]] && return 1
+  local root="${common%/.git}"
+  [[ "$root" == "$common" ]] && root="${common%/*}" # custom git dir fallback
+  local name="${root##*/}"
+  [[ -z "$name" ]] && return 1
+  printf '%s' "$name"
+}
+
 seg_dir() {
   [[ -z "$CWD" ]] && return
-  local shortened color
-  shortened=$(shorten_path "$CWD" "$PATH_MAX_LENGTH" "$PROJECT_DIR")
+  local shortened color proj_name
+  proj_name=$(resolve_project_name "$PROJECT_DIR") || proj_name=""
+  shortened=$(shorten_path "$CWD" "$PATH_MAX_LENGTH" "$PROJECT_DIR" "$proj_name")
   if [[ -n "$PROJECT_DIR" && "$CWD" != "$PROJECT_DIR" ]]; then
     color="${COLORS[mid]}"
   else
@@ -746,4 +766,6 @@ main() {
   printf '%b' "$output"
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/tests/statusline/test-dir-segment.sh
+++ b/tests/statusline/test-dir-segment.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test-dir-segment.sh — Tests for the statusline `dir` segment helpers.
+# Covers shorten_path() display logic (including the name override that fixes
+# #126) and resolve_project_name(), which derives the canonical project name and
+# must return the MAIN repo name when PROJECT_DIR is a linked git worktree.
+#
+# Usage: bash tests/statusline/test-dir-segment.sh [filter]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUSLINE="$SCRIPT_DIR/../../plugins-claude/statusline/scripts/statusline.sh"
+
+# Source the script for direct function access. The `main` call is guarded by a
+# BASH_SOURCE check, so sourcing defines functions without rendering a statusline.
+# Point XDG dirs at a scratch location and feed empty stdin to avoid touching the
+# real config/cache or reading the terminal.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+export XDG_CONFIG_HOME="$TMP/config"
+export XDG_CACHE_HOME="$TMP/cache"
+# shellcheck source=/dev/null
+source "$STATUSLINE" </dev/null
+
+PASS=0
+FAIL=0
+SKIP=0
+FILTER="${1:-}"
+
+filtered() {
+  [[ -n "$FILTER" ]] && ! echo "$1" | grep -qi "$FILTER"
+}
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if filtered "$label"; then
+    ((SKIP++)) || true
+    return 0
+  fi
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s  (expected: %q, got: %q)\n" "$label" "$expected" "$actual"
+    ((FAIL++)) || true
+  fi
+}
+
+# Run shorten_path with a controlled HOME so tilde substitution is deterministic.
+sp() {
+  local home="$1"
+  shift
+  (
+    export HOME="$home"
+    shorten_path "$@"
+  )
+}
+
+# ===== shorten_path display logic =====
+echo "── shorten_path ──"
+
+check "project root → bare name" "proj" \
+  "$(sp /home/u /home/u/proj 40 /home/u/proj)"
+
+check "subdir → name/abbreviated middle" "proj/p/statusline" \
+  "$(sp /home/u /home/u/proj/plugins-claude/statusline 40 /home/u/proj)"
+
+check "name_override replaces basename" "realproj" \
+  "$(sp /home/u /home/u/proj-wt 40 /home/u/proj-wt realproj)"
+
+check "name_override applies to subdir too" "realproj/p/statusline" \
+  "$(sp /home/u /home/u/proj-wt/plugins-claude/statusline 40 /home/u/proj-wt realproj)"
+
+check "path outside project → full path, home as ~" "~/elsewhere/x" \
+  "$(sp /home/u /home/u/elsewhere/x 40 /home/u/proj)"
+
+check "no project → full path, home as ~" "~/elsewhere" \
+  "$(sp /home/u /home/u/elsewhere 40 "")"
+
+check "over-length display left-truncated with …" "…ongsubdir" \
+  "$(sp /home/u /home/u/proj/verylongsubdir 10 /home/u/proj)"
+
+# ===== resolve_project_name =====
+echo "── resolve_project_name ──"
+
+# Build a real git repo plus a linked worktree in the scratch dir.
+REPO="$TMP/myrepo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name "Test"
+git -C "$REPO" commit -q --allow-empty -m "init"
+WT="$TMP/myrepo-feature-x"
+git -C "$REPO" worktree add -q "$WT" 2>/dev/null
+
+resolve() {
+  local out rc
+  out=$(resolve_project_name "$1") && rc=0 || rc=$?
+  RES_OUT="$out"
+  RES_RC="$rc"
+}
+
+resolve "$REPO"
+check "main checkout → repo basename" "myrepo" "$RES_OUT"
+check "main checkout → rc 0" "0" "$RES_RC"
+
+resolve "$WT"
+check "linked worktree → MAIN repo name (not worktree dir)" "myrepo" "$RES_OUT"
+check "linked worktree → rc 0" "0" "$RES_RC"
+
+NONGIT="$TMP/plain-dir"
+mkdir -p "$NONGIT"
+resolve "$NONGIT"
+check "non-git dir → empty output" "" "$RES_OUT"
+check "non-git dir → rc 1 (fallback)" "1" "$RES_RC"
+
+resolve ""
+check "empty dir arg → rc 1" "1" "$RES_RC"
+
+# ===== Summary =====
+echo ""
+echo "Total: $((PASS + FAIL + SKIP))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

The `statusline` `dir` segment rendered the basename of `PROJECT_DIR`, which for a git worktree is the worktree directory name rather than the canonical project name. This resolves the main repo name via the git common dir so the second field is correct in both the main checkout and any linked worktree.

- add `resolve_project_name()` — worktree-aware name resolution via `git rev-parse --path-format=absolute --git-common-dir`, falling back to the path basename on any git failure or non-git dir
- add optional `name_override` param to `shorten_path()`; `seg_dir()` passes the resolved project name
- guard the bottom `main` call with a `BASH_SOURCE` check so the script is sourceable for unit tests
- bump statusline `1.1.1` → `1.1.2`

Fixes #126

## Test plan

- New `tests/statusline/test-dir-segment.sh` (14 cases): `shorten_path` display logic + `resolve_project_name` across main checkout, linked worktree, and non-git fallback — 14/14 pass
- Full suite: `bash test.sh` → 1648 passed / 0 failed
- `bash .github/scripts/validate-plugins.sh` → 282 checks / 0 failures
- `shellcheck --severity=error` clean

Note: graceful fallback preserves prior behavior on git < 2.31 (no `--path-format` support) and outside git repos.
