### PR TITLE
feat(session): run orchestrate build+review as a deterministic Workflow

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/orchestrate-build.workflow.js
+++ b/plugins-claude/session/scripts/orchestrate-build.workflow.js
@@ -1,0 +1,298 @@
+export const meta = {
+  name: 'session-orchestrate-build',
+  description:
+    'Execute an approved chunk plan in dependency waves with per-chunk failure escalation, then review executed chunks and auto-fix blockers (cap 2). Returns structured findings {perChunk, clean, concerns, unresolvedBlockers, nits, filesChanged} for the calling skill to gate on.',
+  phases: [
+    { title: 'Execute', detail: 'dispatch chunks in dependency waves, escalating failures (3 attempts, tier bump)' },
+    { title: 'Review', detail: 'review executed chunks; auto-fix blockers and re-review (cap 2)' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// session-orchestrate-build — Phase 5 (Execute) + Phase 6 (Review/auto-fix).
+//
+// This is the HEADLESS half of the session-orchestrate workflow. The skill
+// runs the interactive halves (explore, refine gate, divide, execute gate,
+// concerns gate, hand-off) and calls this script after the user approves the
+// chunk plan. Blockers are objective (tests/lint/spec), so the auto-fix loop
+// is safe to run without a human; CONCERNS are deliberately NOT auto-fixed —
+// they are returned for the skill's interactive gate.
+//
+// args contract (constructed by the skill from the approved chunk plan):
+//   {
+//     description:   string,   // the user's feature description
+//     plan:          string,   // the agreed implementation plan (markdown)
+//     testsRequired: boolean,  // from Phase 4 test-infra detection
+//     waves: [                 // dependency-ordered; waves run serially
+//       [ chunk, chunk, ... ], // wave 0 — chunks here have no intra-wave deps
+//       [ chunk, ... ],        // wave 1 — may depend on completed wave 0
+//     ],
+//   }
+// chunk:
+//   {
+//     id:         string,                       // stable identifier, e.g. "c1"
+//     scope:      string,                        // one-line description
+//     files:      string[],                      // paths this chunk owns
+//     model:      'haiku' | 'sonnet' | 'opus',   // tier from the chunk plan
+//     tests:      boolean,                        // write/update tests here?
+//     testScope?: string,                         // optional test guidance
+//     opusReview?: boolean,                       // include in Opus review pass
+//   }
+// ---------------------------------------------------------------------------
+
+if (!args || !Array.isArray(args.waves) || args.waves.length === 0) {
+  throw new Error('orchestrate-build: args.waves must be a non-empty array of chunk arrays')
+}
+
+const TIERS = ['haiku', 'sonnet', 'opus']
+const bump = (m) => TIERS[Math.min(TIERS.indexOf(m) + 1, TIERS.length - 1)]
+
+const allChunks = args.waves.flat()
+const findChunk = (id) => allChunks.find((c) => c.id === id)
+
+const EXEC_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['status', 'summary'],
+  properties: {
+    status: { type: 'string', enum: ['done', 'blocked'] },
+    summary: { type: 'string', description: 'Concise description of what was changed' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+    testsPassed: {
+      type: 'boolean',
+      description: 'true if tests were run and passed, false if run and failed; omit if not applicable',
+    },
+    blocker: { type: 'string', description: 'If status=blocked, describe the blocker precisely' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['chunkId', 'severity', 'title'],
+        properties: {
+          chunkId: { type: 'string' },
+          severity: { type: 'string', enum: ['blocker', 'concern', 'nit'] },
+          title: { type: 'string' },
+          detail: { type: 'string' },
+          file: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const execPrompt = (chunk, extra) =>
+  [
+    `You are implementing ONE chunk of an approved feature plan. Stay strictly within this chunk's scope.`,
+    ``,
+    `## Feature`,
+    args.description,
+    ``,
+    `## Agreed plan (context — do not re-litigate)`,
+    args.plan,
+    ``,
+    `## Your chunk: ${chunk.id}`,
+    `Scope: ${chunk.scope}`,
+    `Files you own: ${(chunk.files || []).join(', ') || '(determine from scope; touch nothing owned by other chunks)'}`,
+    chunk.tests
+      ? `Tests: write/update tests for this chunk. ${chunk.testScope || ''}`.trim()
+      : args.testsRequired
+        ? `Tests: ensure existing tests still pass; you need not add new ones.`
+        : `Tests: this project has no test suite requirement.`,
+    ``,
+    `## Rules`,
+    `- Implement only this chunk. Do NOT modify files owned by other chunks.`,
+    `- Follow existing codebase conventions: naming, file layout, imports, idioms.`,
+    args.testsRequired ? `- Run the relevant tests/lint before reporting status="done".` : null,
+    `- If you cannot complete it, set status="blocked" and describe the blocker precisely — do not guess or fake completion.`,
+    extra ? `\n## Context for this attempt\n${extra}` : null,
+  ]
+    .filter((l) => l !== null)
+    .join('\n')
+
+// Execute one chunk with failure escalation (cap 3):
+//   attempt 1 — original model + base prompt
+//   attempt 2 — original model + prompt refined from the failure
+//   attempt 3 — bumped tier + refined prompt
+async function executeChunk(chunk, seedContext) {
+  const baseModel = chunk.model || 'sonnet'
+  let extra = seedContext || ''
+  let last = null
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const useModel = attempt === 3 ? bump(baseModel) : baseModel
+    const res = await agent(execPrompt(chunk, extra), {
+      label: `exec:${chunk.id}#${attempt}`,
+      phase: 'Execute',
+      model: useModel,
+      agentType: 'general-purpose',
+      schema: EXEC_SCHEMA,
+    })
+    last = res
+    if (res && res.status === 'done') {
+      return { chunkId: chunk.id, ok: true, attempts: attempt, model: useModel, result: res }
+    }
+    const why = res ? res.blocker || res.summary : 'agent returned no result'
+    extra = `Attempt ${attempt} did not complete. Reported blocker: ${why}\nClarify the success criteria and address this blocker directly.`
+  }
+  return {
+    chunkId: chunk.id,
+    ok: false,
+    attempts: 3,
+    model: bump(baseModel),
+    result: last,
+    blocker: last ? last.blocker || last.summary : 'no result after 3 attempts',
+  }
+}
+
+const reviewPrompt = (id) => {
+  const chunk = findChunk(id)
+  const exec = execByChunk.get(id)
+  return [
+    `Review the implementation of ONE chunk for correctness, convention compliance, and spec adherence. You may read files and run tests/lint. Do NOT modify code.`,
+    ``,
+    `## Feature`,
+    args.description,
+    ``,
+    `## Chunk under review: ${id}`,
+    `Scope: ${chunk.scope}`,
+    `Files: ${(chunk.files || []).join(', ')}`,
+    `Implementer reported: ${exec && exec.result ? exec.result.summary : '(no summary)'}`,
+    exec && !exec.ok ? `NOTE: the implementer reported this chunk as BLOCKED/incomplete after ${exec.attempts} attempts.` : null,
+    ``,
+    `## Check`,
+    `- Codebase conventions: naming, file layout, imports, idioms`,
+    args.testsRequired ? `- Tests pass; lint/type checks are clean` : `- (no test suite required for this project)`,
+    `- Spec compliance: does it implement what the chunk asked for?`,
+    `- Pitfalls: error paths, null/empty handling, dead code, stale TODOs, leftover debug output`,
+    `- No regressions in unrelated code`,
+    ``,
+    `Tag each finding's severity: "blocker" (broken/wrong/tests fail — must fix), "concern" (should consider), "nit" (trivial). Set chunkId="${id}" on every finding. Return an empty findings array if clean.`,
+  ]
+    .filter((l) => l !== null)
+    .join('\n')
+}
+
+const opusReviewPrompt = (ids) =>
+  [
+    `Senior correctness/security review of the following chunks ONLY. Read the code and reason hard about edge cases, concurrency, data integrity, auth, and security. Do NOT modify code.`,
+    ``,
+    `## Feature`,
+    args.description,
+    ``,
+    `## Chunks in scope`,
+    ...ids.map((id) => {
+      const c = findChunk(id)
+      return `- ${id}: ${c.scope} [${(c.files || []).join(', ')}]`
+    }),
+    ``,
+    `Tag findings blocker/concern/nit and set chunkId to the relevant chunk. Empty findings array if clean.`,
+  ].join('\n')
+
+// Review a set of chunk ids: one Sonnet reviewer per chunk plus a single Opus
+// reviewer over the warranted subset, all dispatched concurrently. Returns a
+// deduped, flattened findings array.
+async function reviewChunks(ids) {
+  const warranted = ids.filter((id) => findChunk(id) && findChunk(id).opusReview)
+  const thunks = ids.map((id) => () =>
+    agent(reviewPrompt(id), {
+      label: `review:${id}`,
+      phase: 'Review',
+      model: 'sonnet',
+      agentType: 'general-purpose',
+      schema: REVIEW_SCHEMA,
+    }).then((r) => (r && r.findings) || []),
+  )
+  if (warranted.length) {
+    thunks.push(() =>
+      agent(opusReviewPrompt(warranted), {
+        label: 'review:opus',
+        phase: 'Review',
+        model: 'opus',
+        agentType: 'general-purpose',
+        schema: REVIEW_SCHEMA,
+      }).then((r) => (r && r.findings) || []),
+    )
+  }
+  const results = await parallel(thunks)
+  const merged = results.filter(Boolean).flat()
+  const seen = new Set()
+  const deduped = []
+  for (const f of merged) {
+    const key = `${f.chunkId}|${f.severity}|${(f.title || '').toLowerCase().slice(0, 60)}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(f)
+  }
+  return deduped
+}
+
+// --- Phase 5: Execute waves serially; chunks within a wave run in parallel.
+// The barrier between waves is intentional — later waves may depend on earlier
+// ones, so each wave must fully complete before the next dispatches.
+phase('Execute')
+const execByChunk = new Map()
+for (let w = 0; w < args.waves.length; w++) {
+  const wave = args.waves[w]
+  log(`Wave ${w + 1}/${args.waves.length}: ${wave.length} chunk(s) — ${wave.map((c) => c.id).join(', ')}`)
+  const results = await parallel(wave.map((chunk) => () => executeChunk(chunk)))
+  results.filter(Boolean).forEach((r) => execByChunk.set(r.chunkId, r))
+}
+
+// --- Phase 6: Review + blocker auto-fix loop (cap 2 iterations).
+phase('Review')
+let findings = await reviewChunks([...execByChunk.keys()])
+let iteration = 0
+const MAX_ITERS = 2
+while (findings.some((f) => f.severity === 'blocker') && iteration < MAX_ITERS) {
+  iteration++
+  const blockerIds = [...new Set(findings.filter((f) => f.severity === 'blocker').map((f) => f.chunkId))]
+  log(`Review iteration ${iteration}: ${blockerIds.length} chunk(s) with blockers — re-dispatching with reviewer feedback`)
+  await parallel(
+    blockerIds.map((id) => () => {
+      const chunk = findChunk(id)
+      const fb = findings
+        .filter((f) => f.chunkId === id && f.severity === 'blocker')
+        .map((f) => `- ${f.title}${f.detail ? ': ' + f.detail : ''}${f.file ? ' (' + f.file + ')' : ''}`)
+        .join('\n')
+      return executeChunk(chunk, `A reviewer flagged blocking issues with your earlier implementation:\n${fb}\nFix these specifically.`).then(
+        (r) => execByChunk.set(r.chunkId, r),
+      )
+    }),
+  )
+  // Re-review ONLY the re-dispatched chunks; keep clean chunks' findings as-is.
+  const reFindings = await reviewChunks(blockerIds)
+  findings = findings.filter((f) => !blockerIds.includes(f.chunkId)).concat(reFindings)
+}
+
+const blockers = findings.filter((f) => f.severity === 'blocker')
+const concerns = findings.filter((f) => f.severity === 'concern')
+const nits = findings.filter((f) => f.severity === 'nit')
+const filesChanged = [...new Set([...execByChunk.values()].flatMap((r) => (r.result && r.result.filesChanged) || []))]
+const flaggedIds = new Set(findings.map((f) => f.chunkId))
+
+return {
+  iterations: iteration,
+  hitReviewCap: blockers.length > 0,
+  perChunk: [...execByChunk.values()].map((r) => ({
+    chunkId: r.chunkId,
+    ok: r.ok,
+    attempts: r.attempts,
+    model: r.model,
+    summary: r.result ? r.result.summary : null,
+    testsPassed: r.result ? r.result.testsPassed : undefined,
+    blocker: r.ok ? undefined : r.blocker,
+  })),
+  filesChanged,
+  clean: [...execByChunk.keys()].filter((id) => !flaggedIds.has(id)),
+  unresolvedBlockers: blockers, // non-empty only if the cap was hit — surface to user
+  concerns, // skill gates on these (address now / defer)
+  nits,
+}

--- a/plugins-claude/session/skills/session-orchestrate/SKILL.md
+++ b/plugins-claude/session/skills/session-orchestrate/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: session-orchestrate
 description: "Multi-phase, multi-agent feature workflow: spec → plan → refine → divide → execute → review. Invoke when the user escalates a session-start/session-issue flow to orchestration, or asks to run a non-trivial feature (multiple files, design ambiguity, cross-cutting concerns, correctness-critical paths) through the full multi-agent workflow. For small fixes, prefer session-start."
-allowed-tools: Bash, Agent, Read, Glob, Grep, AskUserQuestion, EnterWorktree
+allowed-tools: Bash, Agent, Read, Glob, Grep, AskUserQuestion, EnterWorktree, Workflow
 ---
 
 Run a complex feature through a structured multi-agent workflow with explicit model tiering, user gates, and an automated review pass. Use this when work is non-trivial — multiple files, design ambiguity, cross-cutting concerns, or correctness-critical paths. For small fixes, prefer `/session:session-start` directly.
 
-The workflow has seven phases. Two have hard user gates (Refine and Execute). The Review phase auto-loops on blockers up to a cap.
+The workflow has seven phases. Two have hard user gates (Refine and Execute). The build-and-verify half (Execute + Review) runs as a single deterministic `Workflow` call.
 
-> **CRITICAL**: You MUST drive every phase to completion. Do NOT collapse the workflow into a single in-line plan. Sub-agent dispatch is the point — the user is paying for parallelism and model tiering, not for you to do everything serially in the main session.
+This skill is split across two execution surfaces, and the split is deliberate:
+
+- **Interactive, in the main session** — Phases 0–4, the Phase 3/5 gates, the Phase 6 concerns gate, and Phase 7. These need a human in the loop (refinement conversation, approvals, free-text hand-off), so they stay in the main session where you can call `AskUserQuestion` and talk to the user.
+- **Headless, in a `Workflow`** — the Execute waves and the Review/blocker-auto-fix loop (`scripts/orchestrate-build.workflow.js`). This is a closed-loop machine — fan out by wave, escalate failures, review, re-dispatch blockers, re-review, cap the loop — with no human decision inside it. Expressing it as JS makes the control flow deterministic instead of something you have to police by hand.
+
+> **CRITICAL**: You MUST drive every phase to completion. Do NOT collapse the workflow into a single in-line plan, and do NOT hand-roll the build loop in the main session — Phase 5 dispatches the `Workflow` and Phase 6 consumes its structured result. Sub-agent dispatch is the point — the user is paying for parallelism and model tiering, not for you to do everything serially in the main session.
 
 ### Inputs
 
@@ -119,22 +124,24 @@ Goal: break the approved plan into discrete chunks that can be dispatched to exe
    If any positive signal — test directories, conventional test files, CI workflows referencing tests, or a `test`/`check` script in package manifests — record `tests_required=true`. Otherwise `tests_required=false`.
 
 2. **Chunk the plan** into discrete tasks. For each chunk record:
+   - **ID** — a short stable identifier (`c1`, `c2`, …). The Workflow keys execution, review, and re-dispatch on it, so it must be unique and stable across the run.
    - **Scope** — one-line description of the change
-   - **Files** — specific paths touched
+   - **Files** — specific paths touched. Chunks **within the same wave must own disjoint files** — they run in parallel against one working tree, so overlapping files would clobber each other. If two chunks must touch the same file, put them in different waves with a dependency.
    - **Dependencies** — list of other chunk IDs this one depends on (for serial ordering)
-   - **Tests** — if `tests_required=true` AND the chunk is not purely cosmetic, add a paired test chunk OR include test work in the chunk's scope. Skip if cosmetic-only or `tests_required=false`.
+   - **Tests** — if `tests_required=true` AND the chunk is not purely cosmetic, add a paired test chunk OR include test work in the chunk's scope (set its `tests` flag, with optional `testScope` guidance). Skip if cosmetic-only or `tests_required=false`.
    - **Suggested model tier** — Haiku / Sonnet / Opus, applying these heuristics:
      - **Haiku** — mechanical change, well-established pattern in the codebase, single-file scope, clear acceptance criteria (rename, add import, simple test case, copy-pattern)
      - **Sonnet (default)** — standard dev work: new feature following codebase conventions, moderate refactor, multi-file but bounded
      - **Opus** — novel algorithm, complex state machine, critical correctness path (auth, crypto, payments, transactions, migrations, concurrency primitives), deep refactor touching many subsystems, or chunks requiring lots of context
+   - **Opus review** — set an `opusReview` flag on the chunk when it warrants the senior review pass in Phase 6: it was tagged Opus-tier above, its paths match correctness-critical patterns (auth, crypto, payments, transactions, migrations, concurrency primitives), the spec called out correctness/security, or it involves a novel algorithm or non-trivial state machine. Leave it off for trivial chunks.
 
 3. **Identify parallelization** — group chunks into waves. A wave is a set of chunks with no dependencies on each other (within the wave); they will be dispatched in parallel. Waves run serially, with each later wave allowed to depend on completed earlier waves.
 
 4. **Hold the chunk plan** for the Phase 5 gate. Do not present yet — present at the gate.
 
-### Phase 5 — Execute [USER GATE]
+### Phase 5 — Execute [USER GATE → Workflow]
 
-Goal: dispatch sub-agents to execute the chunk plan, with failure escalation.
+Goal: get the user's approval, then hand the approved chunk plan to the build-and-verify `Workflow`.
 
 1. **Present the chunk plan** to the user. Use `AskUserQuestion` with options:
    - **Approve and dispatch** — proceed to step 2
@@ -142,51 +149,58 @@ Goal: dispatch sub-agents to execute the chunk plan, with failure escalation.
    - **Adjust model tiers** — let the user override per-chunk model picks
    - **Cancel** — abort the workflow
 
-2. **Dispatch each wave**:
-   - Within a wave, dispatch all chunks **in parallel** by issuing all `Agent` calls in a single message. Each `Agent` call uses:
-     - `subagent_type: general-purpose`
-     - `model: <tier from chunk plan>`
-     - `prompt`: a self-contained brief including the user description, the agreed plan, this chunk's scope/files/test requirements, success criteria, and the convention "report what you did and any issues encountered; if blocked, describe the blocker rather than guessing"
-   - **Wait for the wave to complete**, then dispatch the next wave. Never start a later wave before its dependencies finish.
+   This gate is also the spend gate: approving here is what authorizes the `Workflow` to spin up a background fleet. Do not dispatch without it — even if this skill was auto-invoked by the model rather than the user.
 
-3. **Per-chunk failure escalation** (cap 3 attempts per chunk):
-   - **Attempt 1**: original model + original prompt
-   - **Attempt 2**: same model + parent-refined prompt — read the failure output, add context about why it failed, clarify the success criteria, point at the specific blocker
-   - **Attempt 3**: bumped tier (Haiku→Sonnet→Opus) + refined prompt
-   - After Attempt 3 fails, surface the chunk to the user with the full failure context. Do not silently retry beyond the cap.
+2. **Construct the Workflow `args`** from the approved chunk plan. Build a JSON object:
 
-4. **After all waves complete**, proceed to Phase 6.
+   ```json
+   {
+     "description": "<the user's feature description>",
+     "plan": "<the agreed implementation plan, as markdown>",
+     "testsRequired": <true|false from Phase 4 step 1>,
+     "waves": [
+       [ { "id": "c1", "scope": "...", "files": ["..."], "model": "sonnet", "tests": false, "opusReview": false } ],
+       [ { "id": "c2", "scope": "...", "files": ["..."], "model": "opus",   "tests": true, "testScope": "...", "opusReview": true } ]
+     ]
+   }
+   ```
 
-### Phase 6 — Review (automated, auto-loops)
+   `waves` is dependency-ordered: each inner array is one wave, dispatched in parallel; waves run serially. Carry every field from the Phase 4 chunk record (`id`, `scope`, `files`, `model`, `tests`, optional `testScope`, `opusReview`).
 
-Goal: validate the executed work with reviewer sub-agents and auto-loop on blockers.
+3. **Dispatch the Workflow.** Call the `Workflow` tool with:
+   - `scriptPath: ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrate-build.workflow.js`
+   - `args: <the object from step 2>` (pass it as an actual JSON value, not a stringified blob)
 
-1. **Dispatch Sonnet bulk reviewers in parallel**, one per executed chunk (or one per logical group if chunks are tightly coupled). Each reviewer uses:
-   - `subagent_type: general-purpose`
-   - `model: sonnet`
-   - `prompt` covering: codebase conventions (naming, file layout, imports, idioms), lint/type checks pass, test suite passes if `tests_required=true`, spec compliance (does it implement what the divide phase asked for?), obvious pitfalls (error paths, null/empty handling, dead code, stale TODOs, leftover debug), no regressions touching unrelated code. Reviewer must tag findings as `blocker`, `concern`, or `nit`.
+   The Workflow runs headless: it executes the waves with per-chunk failure escalation (attempt 1 = chunk tier; attempt 2 = same tier + failure-refined prompt; attempt 3 = bumped tier), then reviews every executed chunk (one Sonnet reviewer each, plus one Opus reviewer over the `opusReview` subset), and **auto-fixes blockers** by re-dispatching affected chunks with the reviewer feedback and re-reviewing only those — capped at 2 review iterations. Concerns and nits are reported, never auto-fixed. It edits the session's working tree (the Phase 0b worktree, if one was created), so no per-agent isolation is needed. You can watch progress via `/workflows`.
 
-2. **Dispatch Opus selective reviewer** in parallel with the bulk reviewers, ONLY when at least one of these warrants apply:
-   - A chunk was tagged Opus-tier in Phase 4
-   - Touched paths match correctness-critical patterns (auth, crypto, payments, transactions, migrations, concurrency primitives)
-   - The spec called out correctness or security concerns
-   - A chunk involved a novel algorithm or non-trivial state machine
+4. **When the Workflow returns**, it gives you a structured result — proceed to Phase 6 to consume it:
 
-   Use `subagent_type: general-purpose`, `model: opus`. The Opus reviewer's prompt scopes to ONLY the warranted subset (don't have it review trivial chunks).
+   ```json
+   {
+     "iterations": 1,
+     "hitReviewCap": false,
+     "perChunk": [ { "chunkId": "c1", "ok": true, "attempts": 1, "model": "sonnet", "summary": "...", "testsPassed": true } ],
+     "filesChanged": ["..."],
+     "clean": ["c1"],
+     "unresolvedBlockers": [],
+     "concerns": [ { "chunkId": "c2", "severity": "concern", "title": "...", "detail": "...", "file": "..." } ],
+     "nits": [ { "chunkId": "c1", "severity": "nit", "title": "..." } ]
+   }
+   ```
 
-3. **Consolidate findings** in the parent session:
-   - Collect findings from all reviewers
-   - Dedupe across reviewers (same blocker reported twice → one entry)
-   - Sort: blockers first, concerns next, nits last
-   - Group by chunk for re-dispatch clarity
+### Phase 6 — Consume review findings
 
-4. **Auto-loop policy** (cap: 2 review iterations per execution batch):
-   - **Blockers present** → for each affected chunk, refine its prompt with the reviewer feedback and re-dispatch via Phase 5's escalation rules (refine prompt → bump tier → surface). After re-dispatch completes, re-run Phase 6 review on the re-dispatched chunks ONLY (don't re-review clean chunks). Increment the iteration counter.
-   - **Concerns only** → present to the user via `AskUserQuestion`:
-     - **Address now** — convert each concern into a fix chunk and dispatch
-     - **Defer** — record concerns for the hand-off summary and proceed
-   - **Only nits or clean** → proceed to Phase 7
-   - If iteration counter hits 2 with blockers still present, surface all remaining findings to the user with full context and stop the auto-loop.
+Goal: act on the `Workflow`'s structured result. The blocker auto-fix loop already ran headlessly inside the Workflow; this phase handles only the decisions that need a human.
+
+1. **If `unresolvedBlockers` is non-empty** (`hitReviewCap` is true — the auto-fix loop hit its 2-iteration cap with blockers still standing): surface every remaining blocker to the user with full context (chunk, title, detail, file, and the chunk's `perChunk` summary). Do not silently retry beyond the cap. Let the user decide — fix manually, re-run a targeted Workflow on those chunks, or accept and move on.
+
+2. **Else if `concerns` is non-empty**: present them via `AskUserQuestion`:
+   - **Address now** — treat the concerns as a fresh, small chunk plan (one wave, one chunk per concern fix, tiers as appropriate) and re-dispatch the Workflow with those chunks. Then re-enter Phase 6 on the new result.
+   - **Defer** — record the concerns for the Phase 7 hand-off summary and proceed.
+
+3. **Else (only `nits` or fully clean)**: note any nits for the hand-off summary and proceed to Phase 7.
+
+Carry `perChunk`, `filesChanged`, `clean`, deferred `concerns`, and `nits` forward — Phase 7's summary draws on them.
 
 ### Phase 7 — Hand-off
 
@@ -206,6 +220,8 @@ If this run created a worktree (Phase 0b), note that its teardown is deferred: `
 ### Notes
 
 - **Always think about whether the workflow is the right tool.** If the user invoked this for a small, well-scoped change, gently suggest `/session:session-start` instead before kicking off Phase 1.
-- **Do not skip the user gates.** Phases 3 and 5 must use `AskUserQuestion`. The auto-loop in Phase 6 is the only place the workflow advances without an explicit gate.
-- **Sub-agent prompts are self-contained.** Every `Agent` call's prompt must include enough context that the agent can succeed without seeing the parent conversation.
-- **Parallel dispatch matters.** Within a Phase 1 angle set, a Phase 5 wave, or a Phase 6 reviewer batch, issue all `Agent` calls in a single message so they run concurrently.
+- **Do not skip the user gates.** Phases 3 and 5 must use `AskUserQuestion`, and Phase 5's gate is the spend gate for the `Workflow`. The Phase 6 concerns step also gates via `AskUserQuestion`. The blocker auto-fix loop inside the `Workflow` is the only place work advances without an explicit gate.
+- **The build loop lives in the `Workflow`, not the main session.** Do not re-implement Execute or the review/blocker loop with inline `Agent` calls — construct the `args` and dispatch `scripts/orchestrate-build.workflow.js`. Self-contained prompts (full context per agent), parallel wave dispatch, failure escalation, and review dedupe are all handled inside the script.
+- **Sub-agent prompts are self-contained.** This still applies to the phases that *do* dispatch inline — every Phase 1 research `Agent` and the Phase 2 planning `Agent` must carry enough context to succeed without seeing the parent conversation.
+- **Parallel dispatch matters for the inline phases.** Within a Phase 1 angle set, issue all `Agent` calls in a single message so they run concurrently. (Phase 5/6 parallelism is the `Workflow`'s job.)
+- **Keep `args` and the script in sync.** If you change the chunk-record shape in Phase 4, update both the Phase 5 `args` contract and the `args` documentation at the top of `orchestrate-build.workflow.js`.

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

Moves the headless half of `session-orchestrate` (Phase 5 Execute + Phase 6 Review) out of prose-driven main-session dispatch and into a deterministic `Workflow` script. The interactive phases stay in the main session where a human is in the loop; the closed-loop build-and-verify machine becomes JS so its control flow is enforced by the runtime instead of policed by hand.

**Split:**
- **Interactive (main session):** P0 resume, P0b worktree, P1 explore (inline parallel `Agent` calls), P2 plan, P3 refine gate, P4 divide, P5 execute gate, P6 concerns gate, P7 hand-off.
- **Headless (one `Workflow`):** P5 execute + P6 review/blocker-fix via `scripts/orchestrate-build.workflow.js`.

**`orchestrate-build.workflow.js`** — dependency-ordered waves (barrier between waves), per-chunk failure escalation (attempt → refined prompt → tier bump), Sonnet-per-chunk + selective-Opus review fired concurrently, finding dedupe, and a **blocker-only** auto-fix loop (cap 2). Returns structured findings `{perChunk, clean, concerns, unresolvedBlockers, nits, filesChanged}`. Concerns and nits are reported, never auto-fixed — preserving the P6 human gate that a headless Workflow can't host.

**SKILL.md** — P4 now stamps each chunk with a stable `id`, an `opusReview` flag (warrants moved up from old P6), and a disjoint-files-per-wave rule. P5 builds the Workflow `args` and dispatches the script; that gate doubles as the spend gate now that the skill is model-invocable (#129). P6 consumes the structured result. Phase 1 stays inline (small fan-out the parent synthesizes for the refine conversation anyway).

Bumps `session` 4.0.2 → 4.1.0 (claude + copilot).

## Test plan

- `node --check` (ESM, wrapped in the async runtime context) — script body syntactically valid
- `.github/scripts/validate-plugins.sh` — 282/0
- `.github/scripts/validate-frontmatter.sh` — 98/0
- `utils/sync.sh --check` — no vendored-utils drift
- `rumdl` — clean on the edited skill
- `test.sh` — 1634/0
