### PR TITLE
feat(session): only offer orchestrate escalation for genuinely complex work

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/reference/spine.md
+++ b/plugins-claude/session/reference/spine.md
@@ -76,26 +76,40 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/branch create <base-name>
 
 ## Phase 2 — Escalate to orchestrate? (gate)
 
-Before exploring, decide whether the work warrants the heavier
-`/session:session-orchestrate` workflow (multi-agent dispatch, model tiering, an
-automated review pass):
+Before exploring, judge whether the work is substantial enough to warrant the
+heavier `/session:session-orchestrate` workflow (multi-agent dispatch, model
+tiering, an automated review pass). **Lightweight is the default, and most work
+stays lightweight.** Do not surface this choice on every run — a needless
+lightweight-vs-orchestrate menu on routine work is the exact thing to avoid. Your
+first job is to decide *whether the question is even worth asking*, and only ask
+when the answer is genuinely "this is a big task."
 
-- **Always offer** when the user took the freeform-description path (`session-start`).
-- **Offer for issues** when the body suggests non-trivial scope: long body
-  (≳300 words), multiple acceptance criteria/checkboxes, multiple files implied, or
-  keywords like `refactor`, `redesign`, `system`, `architecture`, `migration`,
-  `feature`.
-- **Skip the offer** for clearly small work: typo fixes, doc tweaks, single-line
-  changes.
+**Step 1 — Assess scope yourself** from everything you already know (the freeform
+description and/or the issue title, body, and labels). Read it as *complex* only
+when **two or more** of these signals hold:
 
-When the criteria say to offer, ask via `AskUserQuestion`:
+- touches multiple files, modules, or subsystems; a cross-cutting concern
+- real design ambiguity — more than one viable approach, or the approach is unclear
+- correctness-critical or security-sensitive path where being wrong is expensive
+- a long or multi-part spec: ≳300-word body, several acceptance criteria/checkboxes
+- keywords like `refactor`, `redesign`, `architecture`, `migration`, `system`, or a
+  multi-step `feature`
 
-- **Stay on lightweight flow** — continue to Phase 3 here.
-- **Escalate to orchestrate** — invoke `/session:session-orchestrate` with the
-  issue/description as context. The branch (and worktree, if created) is already set
-  up, so orchestrate proceeds in this checkout. Do NOT run Phases 3-4 below.
+**Step 2 — Act on the assessment:**
 
-If the user escalates, hand off and stop. Otherwise continue.
+- **Simple or moderate work** (the common case — a bug fix, a single contained
+  feature, a doc change, a scoped edit, anything where the path is reasonably
+  obvious): **do not ask and do not mention orchestrate.** Assume lightweight and
+  continue straight to Phase 3.
+- **Genuinely complex work** (two or more signals above): ask **once** via
+  `AskUserQuestion`:
+  - **Stay on lightweight flow** — continue to Phase 3 here.
+  - **Escalate to orchestrate** — invoke `/session:session-orchestrate` with the
+    issue/description as context. The branch (and worktree, if created) is already
+    set up, so orchestrate proceeds in this checkout. Do NOT run Phases 3-4 below.
+
+If you ask and the user escalates, hand off and stop. Otherwise — whether you
+skipped the question or the user chose to stay — continue to Phase 3.
 
 ## Phase 3 — Explore the codebase (MANDATORY)
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/commands/session-issue.md
+++ b/plugins-copilot/session/commands/session-issue.md
@@ -42,10 +42,14 @@ propose a plan. To start from your own description instead, use
    kebab-case 3-5 word slug from the issue title. The issue number lives in the PR's
    `Closes #N`, not the branch name.
 
-6. **Offer orchestration.** If the issue suggests non-trivial scope (long body,
-   multiple acceptance criteria, keywords like `refactor`, `redesign`, `migration`,
-   `architecture`, `feature`), offer `/session:session-orchestrate`. Skip for clearly
-   small issues. If the user escalates, hand off and stop.
+6. **Maybe offer orchestration.** Lightweight is the default — do NOT surface this
+   on every run. First judge scope yourself; treat the issue as complex only when
+   **two or more** signals hold: multiple files/subsystems, real design ambiguity,
+   correctness-critical path, a long/multi-part spec (≳300-word body, several
+   acceptance criteria/checkboxes), or keywords like `refactor`, `redesign`,
+   `migration`, `architecture`, `system`. For simple or moderate issues, say nothing
+   about orchestrate and continue. Only when genuinely complex, offer
+   `/session:session-orchestrate` once. If the user escalates, hand off and stop.
 
 7. **Explore, then plan.** Investigate the relevant code — read the files, trace the
    call/data flow, find existing tests and conventions. Then present a concrete plan

--- a/plugins-copilot/session/commands/session-start.md
+++ b/plugins-copilot/session/commands/session-start.md
@@ -37,11 +37,15 @@ open issues instead, use `/session:session-issue`.
    for trivial one-file fixes. A fresh worktree is a clean checkout — reinstall or
    symlink heavy gitignored deps (`node_modules`, `.venv`) if needed.
 
-5. **Offer orchestration.** For non-trivial work — freeform, or a large issue (long
-   body, multiple acceptance criteria, keywords like `refactor`, `redesign`,
-   `migration`, `architecture`, `feature`) — offer `/session:session-orchestrate`
-   (multi-agent dispatch, model tiering, automated review). Skip the offer for small
-   fixes. If the user escalates, hand off and stop.
+5. **Maybe offer orchestration.** Lightweight is the default — do NOT surface this
+   on every run. First judge scope yourself; treat the work as complex only when
+   **two or more** signals hold: multiple files/subsystems, real design ambiguity,
+   correctness-critical path, a long/multi-part spec (≳300-word body, several
+   acceptance criteria), or keywords like `refactor`, `redesign`, `migration`,
+   `architecture`, `system`. For simple or moderate work, say nothing about
+   orchestrate and continue. Only when genuinely complex, offer
+   `/session:session-orchestrate` (multi-agent dispatch, model tiering, automated
+   review) once. If the user escalates, hand off and stop.
 
 6. **Explore, then plan.** Investigate the relevant code — read the files, trace the
    call/data flow, find existing tests and conventions. Then present a concrete plan


### PR DESCRIPTION
## Summary

The begin-work spine's **Phase 2** gate always offered the lightweight-vs-orchestrate
choice on the freeform (`session-start`) path and on any whiff of issue scope, so the
prompt surfaced on nearly every run. This inverts the default: the agent now assesses
complexity first and **only asks when the work is genuinely complex**, defaulting to
the lightweight flow silently otherwise.

- `spine.md` Phase 2 restructured into *assess-then-maybe-ask*. The orchestrate offer
  now requires **two or more** complexity signals (multiple files/subsystems, real
  design ambiguity, correctness-critical path, long/multi-part spec, or
  refactor/migration/architecture keywords). The "always offer for freeform" rule is
  removed, so both doors use the same judgment.
- Mirrored the same logic into the Copilot `session-start` / `session-issue` commands
  (Copilot inlines the flow rather than reading the spine).
- Bumped `session` plugin `4.1.0 → 4.2.0` (Claude + Copilot variants).

When the work *is* complex it still asks rather than auto-escalating, matching the
"if complex, then ask" intent.

## Test plan

- `bash .github/scripts/validate-plugins.sh` — 282 checks, 0 failures
- `bash .github/scripts/validate-frontmatter.sh` — 98 checks, 0 failures
- `rumdl check` on the three edited markdown files — no issues
