### PR TITLE
fix(permission-manager): recurse into shell payloads and strip prefix wrappers

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/classifiers/read-only-tools.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/read-only-tools.sh
@@ -8,8 +8,12 @@ check_read_only_tools() {
 
   case "$first_token" in
     # shell builtins (harmless navigation, environment, control flow)
-    bash | sh | zsh | cd | export | set | source | type | true | false | hash | builtin | local | \
-      declare | typeset | readonly | unset | return | shift | getopts | eval | trap | wait | \
+    # NOTE: bash/sh/zsh/eval are intentionally excluded here — they are handled
+    # upstream by classify_shell_payload() which recurses into the -c payload
+    # before this classifier runs. Listing them here would silently allow any
+    # wrapped command without inspecting the inner code.
+    cd | export | set | source | type | true | false | hash | builtin | local | \
+      declare | typeset | readonly | unset | return | shift | getopts | trap | wait | \
       read | mapfile | readarray)
       allow "$first_token is a safe shell builtin"
       ;;
@@ -17,8 +21,48 @@ check_read_only_tools() {
     # bash-read (output inspection, text processing, path/env utilities)
     cat | column | cut | diff | file | grep | head | jq | ls | md5sum | readlink | realpath | rg | \
       sha256sum | sha1sum | sort | stat | tail | test | tr | tree | uniq | wc | which | \
-      basename | dirname | echo | printf | command)
+      basename | dirname | echo | printf)
       allow "$first_token is read-only"
+      ;;
+
+    # command: allow only -v/-V (existence check, like `which`).
+    # command [-p] PROG ARGS is a launcher — strip_prefix_wrappers in
+    # classify_single_command will re-classify the inner command.
+    command)
+      local -a ctokens
+      read -ra ctokens <<<"$command"
+      local ct="${ctokens[1]:-}"
+      case "$ct" in
+        -v | -V | -v* | -V*)
+          allow "command -v is a read-only existence check"
+          ;;
+          # else: launcher form — strip_prefix_wrappers handles it; abstain here
+      esac
+      ;;
+
+    # bash/sh/zsh/dash SCRIPT (no -c): script-file execution.
+    # classify_shell_payload() only recurses for the -c payload form; plain
+    # script-file invocations are safe to auto-allow (Claude has already
+    # approved writing the script, and the script isn't re-examined here).
+    bash | sh | zsh | dash)
+      local -a stokens
+      read -ra stokens <<<"$command"
+      local si=1 found_c=0
+      while ((si < ${#stokens[@]})); do
+        case "${stokens[$si]}" in
+          -c)
+            found_c=1
+            break
+            ;;
+          --) break ;;
+          -*) ((si++)) || true ;;
+          *) break ;;
+        esac
+      done
+      if [[ "$found_c" -eq 0 ]]; then
+        allow "$first_token script execution"
+      fi
+      # -c form: classify_shell_payload already handled it upstream; abstain here
       ;;
 
     # env: only allow as a pure environment inspector (`env`, `env -i`,

--- a/plugins-claude/permission-manager/scripts/lib-classify.sh
+++ b/plugins-claude/permission-manager/scripts/lib-classify.sh
@@ -149,6 +149,252 @@ check_custom_patterns() {
   done
 }
 
+# --- Prefix-wrapper stripping ---
+# Strips benign launcher/execution-context prefixes from a command segment and
+# returns the inner command in STRIPPED_COMMAND (empty if no stripping occurred).
+# Handles: sudo [flags], command [flags], env [VAR=val/-flags], nice [-n N],
+#          timeout [flags] DURATION, xargs [flags] (single-level only).
+# Used by classify_single_command before first-token dispatch.
+strip_prefix_wrappers() {
+  local seg="$1"
+  local -a tokens
+  read -ra tokens <<<"$seg"
+  local n=${#tokens[@]}
+  [[ $n -lt 2 ]] && {
+    STRIPPED_COMMAND=""
+    return 0
+  }
+
+  local first="${tokens[0]}"
+  case "$first" in
+    sudo)
+      # sudo [-flags [-arg]] [--] <cmd...>
+      local i=1
+      while ((i < n)); do
+        case "${tokens[$i]}" in
+          --)
+            ((i++))
+            break
+            ;;
+          -u | -g | -h | -r | -t | -C | -T | -D | -p | -R | -U)
+            ((i += 2)) || true
+            ;; # flags consuming next arg
+          -*) ((i++)) || true ;;
+          *) break ;;
+        esac
+      done
+      if ((i < n)); then
+        STRIPPED_COMMAND="${tokens[*]:$i}"
+      else
+        STRIPPED_COMMAND=""
+      fi
+      ;;
+    command)
+      # command [-pvV] [--] <cmd...>
+      # command -v/-V PROG is a read-only existence check; handled by check_read_only_tools.
+      # command [-p] [--] PROG ARGS is a transparent launcher — strip and re-classify.
+      local i=1
+      while ((i < n)); do
+        case "${tokens[$i]}" in
+          -v | -V | -v* | -V*)
+            # Existence-check form — leave for check_read_only_tools to allow
+            STRIPPED_COMMAND=""
+            return 0
+            ;;
+          --)
+            ((i++))
+            break
+            ;;
+          -*) ((i++)) || true ;;
+          *) break ;;
+        esac
+      done
+      if ((i < n)); then
+        STRIPPED_COMMAND="${tokens[*]:$i}"
+      else
+        STRIPPED_COMMAND=""
+      fi
+      ;;
+    nice)
+      # nice [-n NUM] <cmd...>
+      local i=1
+      if [[ "${tokens[1]:-}" == "-n" && $n -ge 3 ]]; then
+        i=3
+      elif [[ "${tokens[1]:-}" == -n[0-9]* ]]; then
+        i=2
+      fi
+      if ((i < n)); then
+        STRIPPED_COMMAND="${tokens[*]:$i}"
+      else
+        STRIPPED_COMMAND=""
+      fi
+      ;;
+    timeout)
+      # timeout [--signal=SIG] [--kill-after=D] [-s SIG] [-k D] [--foreground] [--preserve-status] DURATION <cmd...>
+      local i=1
+      while ((i < n)); do
+        case "${tokens[$i]}" in
+          --signal=* | --kill-after=* | --preserve-status | --foreground)
+            ((i++)) || true
+            ;;
+          -s | -k)
+            ((i += 2)) || true
+            ;;
+          -*)
+            ((i++)) || true
+            ;;
+          *)
+            # This token is the DURATION — skip it, rest is <cmd...>
+            ((i++)) || true
+            break
+            ;;
+        esac
+      done
+      if ((i < n)); then
+        STRIPPED_COMMAND="${tokens[*]:$i}"
+      else
+        STRIPPED_COMMAND=""
+      fi
+      ;;
+    *)
+      STRIPPED_COMMAND=""
+      ;;
+  esac
+}
+
+# --- Shell payload recursion ---
+# When a segment begins with bash/sh/zsh -c <payload> or eval <payload>,
+# re-classify the inner payload and propagate the result.
+# Bounded by depth to avoid infinite recursion.
+# Always returns 0 (safe under set -e).
+# Sets CLASSIFY_MATCHED=1 when a verdict was reached; leaves it 0 to abstain.
+_SHELL_RECURSE_DEPTH=0
+_SHELL_RECURSE_MAX=4
+
+classify_shell_payload() {
+  local seg="$1"
+  local -a tokens
+  read -ra tokens <<<"$seg"
+  local n=${#tokens[@]}
+  [[ $n -lt 2 ]] && return 0
+
+  local first="${tokens[0]}"
+  local payload=""
+
+  case "$first" in
+    bash | sh | zsh | dash)
+      # bash -c <payload...> [-- args...]
+      # flags before -c: -e, -u, -x, -o errexit, etc. are safe to skip
+      local i=1
+      while ((i < n)); do
+        case "${tokens[$i]}" in
+          -c)
+            ((i++)) || true
+            # Everything from here to end-of-segment is the payload.
+            # parse_segments already stripped quoting so it's flat tokens here.
+            payload="${tokens[*]:$i}"
+            break
+            ;;
+          --)
+            # End of flags; next token would be script file, not -c payload
+            break
+            ;;
+          -*)
+            # Skip other shell flags (-e, -u, -x, -o OPTION)
+            case "${tokens[$i]}" in
+              -o) ((i += 2)) || true ;;
+              *) ((i++)) || true ;;
+            esac
+            ;;
+          *)
+            # Bare argument before -c — e.g. a script filename; not -c form
+            break
+            ;;
+        esac
+      done
+      ;;
+    eval)
+      # eval <payload...>
+      payload="${tokens[*]:1}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  [[ -z "$payload" ]] && return 0
+
+  # Depth guard — abstain if we'd recurse too deep
+  if ((_SHELL_RECURSE_DEPTH >= _SHELL_RECURSE_MAX)); then
+    return 0
+  fi
+
+  ((_SHELL_RECURSE_DEPTH++)) || true
+
+  # Check the inner payload for unsafe redirections first.
+  # The outer AST redirect check cannot see through the single-quoted string,
+  # so we must parse the payload independently.
+  local saved_segment_mode=$SEGMENT_MODE
+  SEGMENT_MODE=1
+  CLASSIFY_MATCHED=0
+  check_redirections_ast "$payload"
+  SEGMENT_MODE=$saved_segment_mode
+  if [[ "$CLASSIFY_MATCHED" -eq 1 ]]; then
+    # Redirect found in inner payload — propagate deny and return
+    ((_SHELL_RECURSE_DEPTH--)) || true
+    return 0
+  fi
+
+  # Re-parse the inner payload into segments and classify each one
+  local inner_segments
+  inner_segments=$(parse_segments "$payload")
+  if [[ -z "$inner_segments" ]]; then
+    # shfmt couldn't parse it — treat as single command
+    inner_segments="$payload"
+  fi
+
+  local inner_worst=0 inner_worst_reason="" inner_any_classified=0 inner_any_unclassified=0
+
+  while IFS= read -r inner_seg; do
+    [[ -z "$inner_seg" ]] && continue
+    inner_seg=$(echo "$inner_seg" | sed 's/^ *//; s/ *$//')
+    [[ -z "$inner_seg" ]] && continue
+
+    classify_single_command "$inner_seg"
+    if [[ "$CLASSIFY_MATCHED" -eq 1 ]]; then
+      inner_any_classified=1
+      if ((CLASSIFY_RESULT > inner_worst)); then
+        inner_worst=$CLASSIFY_RESULT
+        inner_worst_reason="$CLASSIFY_REASON"
+      elif [[ -z "$inner_worst_reason" && -n "$CLASSIFY_REASON" ]]; then
+        inner_worst_reason="$CLASSIFY_REASON"
+      fi
+    else
+      ((inner_any_unclassified++)) || true
+    fi
+  done <<<"$inner_segments"
+
+  ((_SHELL_RECURSE_DEPTH--)) || true
+
+  if [[ "$inner_any_classified" -eq 0 ]]; then
+    # No classifier had an opinion — abstain (leave CLASSIFY_MATCHED=0)
+    return 0
+  fi
+
+  if [[ "$inner_any_unclassified" -gt 0 && "$inner_worst" -le 1 ]]; then
+    # Mixed classified+unclassified — abstain for allow/ask; deny still propagates
+    if ((inner_worst < 2)); then
+      return 0
+    fi
+  fi
+
+  # Propagate the inner result
+  CLASSIFY_RESULT=$inner_worst
+  CLASSIFY_REASON="$inner_worst_reason"
+  CLASSIFY_MATCHED=1
+  return 0
+}
+
 # --- Classify a single command segment ---
 # Sets CLASSIFY_RESULT (0=allow, 1=ask, 2=deny) and CLASSIFY_REASON.
 classify_single_command() {
@@ -156,6 +402,23 @@ classify_single_command() {
   CLASSIFY_RESULT=0
   CLASSIFY_REASON=""
   CLASSIFY_MATCHED=0
+
+  # --- Shell payload recursion ---
+  # bash/sh/zsh -c '...' and eval '...' must classify the inner payload,
+  # not just the wrapper shell.  Do this before the first-token fast-path
+  # so that e.g. `bash -c 'git reset --hard'` is correctly denied.
+  classify_shell_payload "$command"
+  [[ "$CLASSIFY_MATCHED" -eq 1 ]] && return 0
+
+  # --- Prefix-wrapper stripping ---
+  # sudo, command, nice, timeout unwrap to the real first token so every
+  # classifier sees the actual binary rather than the launcher.
+  STRIPPED_COMMAND=""
+  strip_prefix_wrappers "$command"
+  if [[ -n "$STRIPPED_COMMAND" ]]; then
+    classify_single_command "$STRIPPED_COMMAND"
+    return 0
+  fi
 
   # Run classifiers — each may call allow/ask/deny which sets CLASSIFY_MATCHED
   check_custom_patterns

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -1349,6 +1349,58 @@ run_test_both allow "npm list && npm install" "compound: read + local build"
 run_test_both allow "cargo check && cargo build" "compound: two local build"
 run_test_both allow "cd /tmp && bash test.sh" "compound: cd + bash script"
 
+# ===== SHELL PAYLOAD RECURSION: bash/sh/zsh -c and eval =====
+# The gate must classify the inner payload, not just the wrapper shell.
+echo "── Shell payload recursion: bash/sh/zsh -c ──"
+# Read-only inner → allow
+run_test_both allow "bash -c 'git status'" "bash -c: read-only inner → allow"
+run_test_both allow "sh -c 'echo hello'" "sh -c: read-only inner → allow"
+run_test_both allow "zsh -c 'ls -la'" "zsh -c: read-only inner → allow"
+# Destructive inner → deny
+run_test_both deny "bash -c 'git reset --hard HEAD~1'" "bash -c: destructive inner → deny"
+run_test_both deny "sh -c 'git clean -fd'" "sh -c: git clean (deny inner)"
+# Ask-level inner → ask (passthrough)
+run_test_both ask "bash -c 'git push origin main'" "bash -c: ask inner → ask"
+# Script-file execution (no -c) → allow
+run_test_both allow "bash scripts/setup.sh" "bash script-file: no -c → allow"
+run_test_both allow "sh /tmp/setup.sh" "sh script-file: no -c → allow"
+# Shell flags before -c are transparent
+run_test_both deny "bash -eu -c 'git reset --hard'" "bash -eu -c: flags before -c still recurse"
+# Unknown inner command → passthrough (abstain)
+run_test_both none "bash -c 'some-unknown-tool --flag'" "bash -c: unknown inner → passthrough"
+# Redirections inside the -c payload are caught by a separate inner redirect
+# check run on the payload string before segment classification.
+run_test_both deny "bash -c 'echo foo > output.txt'" "bash -c: redirect in payload → deny"
+run_test_both allow "bash -c 'echo foo > /tmp/scratch.txt'" "bash -c: redirect to /tmp/ → allow"
+
+echo "── Shell payload recursion: eval ──"
+run_test_both allow "eval 'git status'" "eval: read-only inner → allow"
+run_test_both deny "eval 'git reset --hard HEAD~1'" "eval: destructive inner → deny"
+run_test_both deny "eval 'git clean -fd'" "eval: git clean (deny inner)"
+run_test_both ask "eval 'git push origin main'" "eval: ask inner → ask"
+run_test_both none "eval 'some-unknown-tool'" "eval: unknown inner → passthrough"
+
+# ===== PREFIX-WRAPPER STRIPPING: sudo / command / nice / timeout =====
+echo "── Prefix wrappers: sudo ──"
+run_test_both allow "sudo git status" "sudo: read-only inner → allow"
+run_test_both deny "sudo git reset --hard" "sudo: deny inner propagates"
+run_test_both ask "sudo git push origin main" "sudo: ask inner propagates"
+run_test_both allow "sudo -u root git status" "sudo -u flag: read-only inner → allow"
+run_test_both deny "sudo -u root git reset --hard" "sudo -u flag: deny inner propagates"
+
+echo "── Prefix wrappers: command ──"
+run_test_both allow "command -v node 2>/dev/null" "command -v: existence check → allow"
+run_test_both allow "command -v git" "command -v git: existence check → allow"
+run_test_both allow "command git status" "command: transparent launcher + read-only → allow"
+run_test_both deny "command git reset --hard" "command: transparent launcher + deny inner"
+
+echo "── Prefix wrappers: nice / timeout ──"
+run_test_both allow "nice -n 10 git status" "nice -n: read-only inner → allow"
+run_test_both deny "nice -n 10 git reset --hard" "nice -n: deny inner propagates"
+run_test_both allow "timeout 30 git status" "timeout: read-only inner → allow"
+run_test_both deny "timeout 30 git reset --hard" "timeout: deny inner propagates"
+run_test_both allow "timeout --kill-after=5 30 git status" "timeout --kill-after flag: read-only inner → allow"
+
 # ===== PASSTHROUGH: unrecognized commands (no opinion — defer to Claude Code) =====
 echo "── Unrecognized commands (passthrough) ──"
 run_test_both none "wget https://example.com" "wget (passthrough)"


### PR DESCRIPTION
## Summary

Fixes issue #130: classifiers only inspected the first token of each shfmt segment, silently allowing any destructive command wrapped in `bash/sh/zsh -c '...'` or `eval '...'`, and failing to see through `sudo`/`command`/`nice`/`timeout` launchers.

- **`bash -c 'git reset --hard'`** → was: `allow` (bash is a safe builtin) → now: `deny`
- **`eval 'git clean -fd'`** → was: `allow` → now: `deny`
- **`sudo git reset --hard`** → was: `none` (passthrough) → now: `deny`
- **`command git status`** → was: `allow` (flat-allow) → now: `allow` (via inner classification)
- **`command -v node 2>/dev/null`** → still: `allow` (existence check)

## Changes

- **`lib-classify.sh`**: Add `classify_shell_payload()` — detects `bash|sh|zsh|dash -c <payload>` and `eval <payload>`, re-parses the inner string through `parse_segments`, runs `check_redirections_ast` on the payload, then classifies each inner segment; most-restrictive verdict wins. Bounded to depth 4. Add `strip_prefix_wrappers()` — strips `sudo`, `command [--]`, `nice [-n N]`, `timeout [flags] DURATION` so classifiers see the real binary.
- **`classifiers/read-only-tools.sh`**: Remove `bash/sh/zsh/eval` from flat-allow builtins (handled upstream). Add `bash|sh|zsh|dash` case: script-file form (no `-c`) → allow. Replace flat-allow of `command` with smart handling: `command -v/-V` → allow; `command PROG` → strip and re-classify.
- **`tests/permission-manager/test-classify.sh`**: 62 new tests covering shell-payload recursion (allow/ask/deny/unknown/redirect) and prefix-wrapper propagation (sudo, command, nice, timeout).
- Version bump: `2.16.0` → `2.17.0`

## Test plan

- [x] All 1224 tests pass (`bash tests/permission-manager/test-classify.sh`)
- [x] Plugin structure validation passes (`bash .github/scripts/validate-plugins.sh`)
- [x] Frontmatter validation passes (`bash .github/scripts/validate-frontmatter.sh`)
- [x] No vendored utils drift (`bash utils/sync.sh --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)