### PR TITLE
fix(permission-manager): complete #130 — env/xargs wrappers + explain.sh sync

### DIFF
--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/classifiers/read-only-tools.sh
+++ b/plugins-claude/permission-manager/scripts/classifiers/read-only-tools.sh
@@ -65,13 +65,13 @@ check_read_only_tools() {
       # -c form: classify_shell_payload already handled it upstream; abstain here
       ;;
 
-    # env: only allow as a pure environment inspector (`env`, `env -i`,
-    # `env --help`, etc.). When followed by a program (`env python3 -c "..."`,
-    # `env VAR=val cmd`), env is acting as a launcher and the inner command
-    # must be classified — we abstain here so other classifiers see it, but
-    # since the classifier chain matches by first_token, the wrapped command
-    # falls through to passthrough → ask. That's the correct conservative
-    # default for an inline launcher.
+    # env: only the pure-inspector form reaches here (`env`, `env -i`,
+    # `env FOO=bar`, etc.). The launcher form (`env VAR=val cmd`, `env python3 …`)
+    # is stripped upstream by strip_prefix_wrappers() in classify_single_command,
+    # which re-classifies the real inner binary (mirroring the `command)` note
+    # above). The has_program==1 fall-through below is therefore effectively
+    # unreachable in normal dispatch — kept as a conservative no-opinion default
+    # so this arm stays correct even if dispatch order changes.
     env)
       local -a etokens
       read -ra etokens <<<"$command"

--- a/plugins-claude/permission-manager/scripts/explain.sh
+++ b/plugins-claude/permission-manager/scripts/explain.sh
@@ -116,8 +116,10 @@ deny() {
 }
 
 # --- Instrumented classify_single_command ---
-# Mirrors the dispatch order in lib-classify.sh (lines 123-168).
-# If classifiers are added or reordered there, update this list too.
+# Mirrors classify_single_command in lib-classify.sh: two pre-dispatch steps
+# (classify_shell_payload, strip_prefix_wrappers) run before the classifier
+# chain below. If classifiers are added/reordered there — or the pre-dispatch
+# steps change — update this file to match.
 CLASSIFIERS=(
   check_custom_patterns
   check_allow_edit
@@ -131,6 +133,7 @@ CLASSIFIERS=(
   check_curl
   check_npm
   check_pip
+  check_uv
   check_cargo
   check_jvm_tools
 )
@@ -140,6 +143,24 @@ explain_classify_single_command() {
   CLASSIFY_RESULT=0
   CLASSIFY_REASON=""
   CLASSIFY_MATCHED=0
+
+  # Pre-dispatch step 1: shell payload recursion (bash/sh/zsh/dash -c '…', eval '…').
+  # classify_shell_payload re-parses the inner payload and drives the (instrumented)
+  # allow/ask/deny, so inner verdicts are recorded under the classify_shell_payload
+  # label and the final propagated verdict is correct.
+  EXPLAIN_LAST_CLASSIFIER="classify_shell_payload"
+  classify_shell_payload "$command"
+  [[ "$CLASSIFY_MATCHED" -eq 1 ]] && return 0
+
+  # Pre-dispatch step 2: prefix-wrapper stripping (sudo/command/env/nice/timeout/xargs).
+  # Re-trace the unwrapped command so the real binary's classifiers are shown.
+  STRIPPED_COMMAND=""
+  strip_prefix_wrappers "$command"
+  if [[ -n "$STRIPPED_COMMAND" ]]; then
+    EXPLAIN_TRACE+=("STRIP|strip_prefix_wrappers|unwrapped to: $STRIPPED_COMMAND")
+    explain_classify_single_command "$STRIPPED_COMMAND"
+    return 0
+  fi
 
   for clf in "${CLASSIFIERS[@]}"; do
     EXPLAIN_LAST_CLASSIFIER="$clf"

--- a/plugins-claude/permission-manager/scripts/lib-classify.sh
+++ b/plugins-claude/permission-manager/scripts/lib-classify.sh
@@ -256,6 +256,61 @@ strip_prefix_wrappers() {
         STRIPPED_COMMAND=""
       fi
       ;;
+    env)
+      # env [-i] [-0] [-v] [-u NAME] [-C DIR] [VAR=val ...] <cmd...>
+      # Strip to the launched program so the real binary is classified.
+      # -S/--split-string re-splits its value into a whole command line; too
+      # risky to parse here, so abstain (conservative passthrough, as before).
+      local i=1
+      while ((i < n)); do
+        case "${tokens[$i]}" in
+          -S | --split-string | -S* | --split-string=*)
+            STRIPPED_COMMAND=""
+            return 0
+            ;;
+          --)
+            ((i++))
+            break
+            ;;
+          -u | -C | --unset | --chdir)
+            ((i += 2)) || true
+            ;;                    # flags consuming next arg (space-separated form)
+          -*) ((i++)) || true ;;  # other env flags (-i, -0, -v, --unset=…, --chdir=…)
+          *=*) ((i++)) || true ;; # VAR=val assignment
+          *) break ;;             # first bare token = program
+        esac
+      done
+      if ((i < n)); then
+        STRIPPED_COMMAND="${tokens[*]:$i}"
+      else
+        STRIPPED_COMMAND=""
+      fi
+      ;;
+    xargs)
+      # xargs [flags] [cmd [args]]  (defaults to echo when no cmd given)
+      # Strip to the command so the real binary is classified. Flags that take
+      # a separate argument are skipped in pairs; glued (-n1, -I{}) and
+      # optional-arg flags are single tokens so the command is never eaten.
+      local i=1
+      while ((i < n)); do
+        case "${tokens[$i]}" in
+          --)
+            ((i++))
+            break
+            ;;
+          -I | -n | -P | -d | -E | -L | -s | -a)
+            ((i += 2)) || true
+            ;; # flags consuming next arg (space-separated form)
+          -*) ((i++)) || true ;;
+          *) break ;;
+        esac
+      done
+      if ((i < n)); then
+        STRIPPED_COMMAND="${tokens[*]:$i}"
+      else
+        STRIPPED_COMMAND=""
+      fi
+      ;;
     *)
       STRIPPED_COMMAND=""
       ;;

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/tests/permission-manager/test-classify.sh
+++ b/tests/permission-manager/test-classify.sh
@@ -1401,6 +1401,30 @@ run_test_both allow "timeout 30 git status" "timeout: read-only inner → allow"
 run_test_both deny "timeout 30 git reset --hard" "timeout: deny inner propagates"
 run_test_both allow "timeout --kill-after=5 30 git status" "timeout --kill-after flag: read-only inner → allow"
 
+echo "── Prefix wrappers: env (launcher) ──"
+run_test_both deny "env git reset --hard" "env launcher: deny inner propagates"
+run_test_both deny "env GIT_DIR=/tmp git reset --hard" "env VAR=val launcher: deny inner propagates"
+run_test_both allow "env FOO=bar cat foo.txt" "env VAR=val launcher: read-only inner → allow"
+run_test_both ask "env FOO=bar git push origin main" "env VAR=val launcher: ask inner propagates"
+run_test_both allow "env -u FOO git status" "env -u flag launcher: read-only inner → allow"
+# Regression: pure-inspector env (no program) still allowed
+run_test_both allow "env FOO=bar" "env VAR=val only (no program) → allow"
+# -S/--split-string re-splits its value into a command line: abstain (passthrough)
+run_test_both none "env -S 'git reset --hard'" "env -S split-string: conservative abstain"
+
+echo "── Prefix wrappers: xargs (launcher) ──"
+run_test_both deny "xargs git reset --hard" "xargs launcher: deny inner propagates"
+run_test_both allow "xargs cat foo.txt" "xargs launcher: read-only inner → allow"
+run_test_both deny "xargs -n1 git reset --hard" "xargs -n flag: deny inner propagates"
+run_test_both deny "xargs -I {} git reset --hard {}" "xargs -I flag: deny inner propagates"
+# Bare xargs (defaults to echo) and unclassified inner → passthrough
+run_test_both none "xargs" "bare xargs → abstain"
+run_test_both none "xargs rm -rf /tmp/x" "xargs rm (unclassified inner) → passthrough"
+
+echo "── Wrappers: nested + composed ──"
+run_test_both deny "bash -c 'env GIT_DIR=/tmp git reset --hard'" "bash -c wrapping env launcher → deny"
+run_test_both ask "sudo env FOO=bar git push origin main" "sudo wrapping env launcher → ask"
+
 # ===== PASSTHROUGH: unrecognized commands (no opinion — defer to Claude Code) =====
 echo "── Unrecognized commands (passthrough) ──"
 run_test_both none "wget https://example.com" "wget (passthrough)"

--- a/tests/permission-manager/test-explain.sh
+++ b/tests/permission-manager/test-explain.sh
@@ -140,6 +140,35 @@ else
   fi
 fi
 
+# ===== Shell payload + prefix-wrapper traces (must mirror cmd-gate.sh) =====
+# Regression guard for #130 follow-up: before these pre-dispatch steps were
+# wired into explain.sh, the tracer reported NONE for every wrapped command
+# while cmd-gate.sh actually denied it.
+echo "── Shell payload traces ──"
+run_test "bash -c 'git reset --hard' → DENY via classify_shell_payload" \
+  "bash -c 'git reset --hard'" \
+  "classify_shell_payload" "DENY"
+
+echo "── Prefix-wrapper traces ──"
+run_test "sudo git reset --hard → DENY via strip_prefix_wrappers → check_git" \
+  "sudo git reset --hard" \
+  "strip_prefix_wrappers" "unwrapped to" "check_git" "DENY"
+run_test "env git reset --hard → DENY via strip_prefix_wrappers" \
+  "env git reset --hard" \
+  "strip_prefix_wrappers" "check_git" "DENY"
+run_test "command git reset --hard → DENY via strip_prefix_wrappers" \
+  "command git reset --hard" \
+  "strip_prefix_wrappers" "DENY"
+run_test "nice -n 10 git reset --hard → DENY via strip_prefix_wrappers" \
+  "nice -n 10 git reset --hard" \
+  "strip_prefix_wrappers" "DENY"
+run_test "timeout 30 git reset --hard → DENY via strip_prefix_wrappers" \
+  "timeout 30 git reset --hard" \
+  "strip_prefix_wrappers" "DENY"
+run_test "xargs git reset --hard → DENY via strip_prefix_wrappers" \
+  "xargs git reset --hard" \
+  "strip_prefix_wrappers" "DENY"
+
 # ===== Summary =====
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

Completes issue #130. PR #136 closed the core (shell-payload recursion and
`sudo`/`command`/`nice`/`timeout` prefix-stripping) but an independent review
found two gaps it left behind:

1. **`env`/`xargs` were never actually stripped** — `strip_prefix_wrappers`'
   header comment claimed it handled them, but the `case` had no arm, so they
   fell through to passthrough. `env … git reset --hard` and `xargs git reset
   --hard` were invisible to the gate.
2. **`explain.sh` was never wired to the new pre-dispatch logic** — the debug
   tracer reported `NONE` for every command `cmd-gate.sh` actually denies (e.g.
   `bash -c '…'`, `sudo …`), a silently misleading trace. It also still omitted
   `check_uv` from its classifier list.

Verified-sound code from #136 is untouched; nothing is reverted.

| command | before | after |
|---|---|---|
| `env git reset --hard` | passthrough | **deny** |
| `env FOO=bar git push origin main` | passthrough | **ask** |
| `env FOO=bar cat foo.txt` | passthrough | **allow** |
| `xargs git reset --hard` | passthrough | **deny** |
| `env` / `env -i` / `env FOO=bar` | allow | allow (unchanged) |

## Changes

- **`lib-classify.sh`** — add `env)` and `xargs)` arms to `strip_prefix_wrappers`
  (skip flags + `VAR=val`, strip to the real program; `env -S`/`--split-string`
  abstains rather than parse an embedded command line).
- **`classifiers/read-only-tools.sh`** — correct the `env)` comment: launcher
  form is stripped upstream; the arm now only allows the pure-inspector form.
- **`explain.sh`** — run `classify_shell_payload` + `strip_prefix_wrappers`
  before the classifier loop; add `check_uv` to `CLASSIFIERS`; refresh stale comment.
- Version bump `2.17.0` → `2.17.1` (claude + copilot).
- Tests: `+30` in `test-classify.sh`, `+7` in `test-explain.sh`.

## Test plan

- [x] `bash test.sh` — 1747 passed / 0 failed
- [x] `bash .github/scripts/validate-plugins.sh` — 281 checks, 0 failures (version-sync + utils-drift incl.)
- [x] `bash .github/scripts/validate-frontmatter.sh` — 98 checks, 0 failures
- [x] `rumdl check .` — clean
- [x] `shellcheck -x` — no new findings

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
