### PR TITLE
feat(session): scale session-issue picker with issue count

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -15,15 +15,15 @@ begin-work spine (explore → plan). To start from your own description instead,
 
 ### Phase 1 — Pick an issue
 
-1. **Fetch and rank issues using a subagent.** Launch an `Agent`
+1. **Fetch and rank ALL open issues using a subagent.** Launch an `Agent`
    (`subagent_type: general-purpose`) with this prompt:
 
-   > Fetch open issues and return the top 3 by priority.
+   > Fetch open issues, rank them, and return ALL of them (not a top-N subset).
    >
    > Run this command:
    >
    > ```bash
-   > bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue list --limit 20 --state open
+   > bash ${CLAUDE_PLUGIN_ROOT}/scripts/git-cli issue list --limit 50 --state open
    > ```
    >
    > From the returned JSON array, rank by priority using these criteria:
@@ -32,17 +32,37 @@ begin-work spine (explore → plan). To start from your own description instead,
    > - More comments → higher priority (community signal)
    > - Older issues rank higher than newer (age as proxy for neglect)
    >
-   > Return ONLY the top 3 issues. For each, include: number, title, and labels
-   > (comma-separated). Format each as a single line:
-   > `#N — Title [label1, label2]`
+   > Return EVERY open issue, highest priority first. Start your reply with a single
+   > line `COUNT: <n>` giving the total number of open issues. Then, for each issue,
+   > emit a two-line block:
+   >
+   > ```text
+   > #N — Title [label1, label2]
+   >     <one-sentence summary of the issue body, ≤25 words>
+   > ```
+   >
+   > Derive the summary from each issue's `body` field in the JSON (it is already
+   > included — do not fetch issues individually). If a body is empty, write
+   > `(no description)`.
 
-2. **Pick the issue** based on how many open issues came back:
-   - **None** — tell the user there are no open issues and suggest
+2. **Pick the issue** based on the total `COUNT` of open issues:
+   - **0** — tell the user there are no open issues and suggest
      `/session:session-start` to begin from your own description. Stop here.
-   - **Exactly one** — skip the menu (`AskUserQuestion` needs ≥2 options). State the
-     single issue (`#N — Title`) and proceed with it directly into Phase 2.
-   - **Two or more** — present the top 3 via `AskUserQuestion`. Each option label is
-     `#N — Title`; the description lists the labels.
+   - **1** — state the single issue (`#N — Title`) plus its one-line summary, then
+     **ask the user to confirm** before starting (e.g. "This is the only open issue —
+     work on it now?"). Do not auto-proceed: the user may want to defer it, do it from
+     a specific machine/node, or start from their own description instead. Only enter
+     Phase 2 once they confirm.
+   - **2–4** — present them via `AskUserQuestion` (the picker caps at 4 options, so the
+     whole set fits). Each option label is `#N — Title`; the description carries the
+     labels and the one-line summary.
+   - **5 or more** — too many for the picker. Do NOT use `AskUserQuestion`. Print the
+     full ranked list as plain text — every issue, each as its `#N — Title [labels]`
+     line followed by its one-line summary — then ask the user to **type the number** of
+     the issue they want to work on. Wait for their text reply and use that number.
+     (Forcing dozens of issues through a picker, or pre-truncating to a "top N", buries
+     real choices behind the agent's guess at what "top" means — let the user scan the
+     whole list and pick.)
 
 3. **Fetch the full issue** (save the body and labels — the spine needs them as
    context):

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/commands/session-issue.md
+++ b/plugins-copilot/session/commands/session-issue.md
@@ -17,14 +17,24 @@ propose a plan. To start from your own description instead, use
      `gh issue list --limit 20 --state open --json number,title,labels,milestone,comments,createdAt`
    - on other hosts, use the equivalent host-native issue command if available
 
-2. **Rank and select.** From the returned JSON array, pick the top 3 by priority:
+2. **Rank.** From the returned JSON array, rank ALL issues by priority (do not
+   pre-truncate to a top-N):
    - Labels indicating urgency: `critical`, `blocker`, `high-priority`, `bug` rank higher
    - Issues with a milestone set rank higher than those without
    - More comments -> higher priority (community signal)
    - Older issues rank higher than newer (age as proxy for neglect)
 
-   Display the top 3 as choices via AskUserQuestion. Include issue number, title, and
-   labels for each.
+   **Select** based on the total number of open issues:
+   - **0** — tell the user there are none and suggest `/session:session-start`. Stop.
+   - **1** — state the single `#N — Title` plus a one-line summary, then ask the user
+     to confirm before starting (they may want to defer it or do it from a specific
+     machine). Only proceed once they confirm.
+   - **2–4** — present them via AskUserQuestion (the picker caps at 4 options). Include
+     issue number, title, and labels for each.
+   - **5 or more** — too many for the picker. Do NOT use AskUserQuestion. Print the full
+     ranked list as plain text — every issue as `#N — Title [labels]` followed by a
+     one-line summary of its body — then ask the user to type the number of the issue to
+     work on, and wait for their reply.
 
 3. **Fetch the full issue** details and recent discussion for the selection. Keep the
    body + labels as context.


### PR DESCRIPTION
## Summary

Reworks `/session:session-issue` so the picker scales with how many issues are
open, instead of always ranking and showing a "top 3". Picking from a fixed
top-N buries real choices behind the agent's guess at what "top" means.

Selection now branches on the **total** open-issue count:

| Open issues | Behavior |
|---|---|
| 0 | Suggest `/session:session-start`, stop |
| 1 | State it + summary, **confirm before starting** (may need a specific machine, or user wants to defer) |
| 2–4 | `AskUserQuestion` picker (tool caps at 4 options) |
| 5+ | Plain-text ranked list, user types the issue number |

The ranking subagent now returns **every** open issue (ranked, with a one-line
body summary and a leading `COUNT:` line) rather than a pre-truncated subset.
Mirrored in the Copilot `commands/session-issue.md` variant.

## Test plan

- `validate-frontmatter.sh` — 98 checks, 0 failures
- `rumdl check` on both changed files — no issues
- Picker threshold (≤4) verified against `AskUserQuestion` schema `maxItems: 4`
