### PR TITLE
feat(session): enforce stop-and-confirm hand-off + guard PR publishing

### DIFF
--- a/plugins-claude/convert-doc/.claude-plugin/plugin.json
+++ b/plugins-claude/convert-doc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-doc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert documents to/from markdown using pandoc (DOCX, HTML, RST, EPUB, ODT, RTF, LaTeX)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/convert-doc/scripts/approve-own-scripts.sh
+++ b/plugins-claude/convert-doc/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-claude/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/elevated-edit/scripts/approve-own-scripts.sh
+++ b/plugins-claude/elevated-edit/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/format-on-save/.claude-plugin/plugin.json
+++ b/plugins-claude/format-on-save/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "format-on-save",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/format-on-save/scripts/approve-own-scripts.sh
+++ b/plugins-claude/format-on-save/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/approve-own-scripts.sh
+++ b/plugins-claude/git-tools/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/image/.claude-plugin/plugin.json
+++ b/plugins-claude/image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Clipboard paste and screenshot capture for macOS, WSL, and Linux",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/image/scripts/approve-own-scripts.sh
+++ b/plugins-claude/image/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-claude/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-claude/java-toolkit/scripts/approve-own-scripts.sh
+++ b/plugins-claude/java-toolkit/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/kb-capture/.claude-plugin/plugin.json
+++ b/plugins-claude/kb-capture/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-capture",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Research-to-document automation — capture conversation findings as schema-valid markdown with frontmatter, linting, and optional commit",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/kb-capture/scripts/approve-own-scripts.sh
+++ b/plugins-claude/kb-capture/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/markdown/.claude-plugin/plugin.json
+++ b/plugins-claude/markdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Markdown linting and formatting — check, format, setup",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/markdown/scripts/approve-own-scripts.sh
+++ b/plugins-claude/markdown/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/notify-on-stop/.claude-plugin/plugin.json
+++ b/plugins-claude/notify-on-stop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-on-stop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/notify-on-stop/scripts/approve-own-scripts.sh
+++ b/plugins-claude/notify-on-stop/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/scripts/approve-own-scripts.sh
+++ b/plugins-claude/permission-manager/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/session-history-analyzer/.claude-plugin/plugin.json
+++ b/plugins-claude/session-history-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-history-analyzer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session-history-analyzer/scripts/approve-own-scripts.sh
+++ b/plugins-claude/session-history-analyzer/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/reference/spine.md
+++ b/plugins-claude/session/reference/spine.md
@@ -10,6 +10,10 @@ hand-off), without the multi-agent execute/review tail.
 > launch research agents and enter plan mode. NEVER print "suggested first steps"
 > or ask "ready to start?" — the flow does not end until you have called
 > `EnterPlanMode` with a plan built from real code exploration.
+>
+> **EQUALLY CRITICAL — the other end of the flow**: after the approved work is
+> implemented you **STOP** (Phase 5) and wait for the user. You never commit, push,
+> open/merge a PR, or finalize on your own. Plan approval ≠ permission to publish.
 
 ## Inputs (supplied by the calling door)
 
@@ -157,21 +161,42 @@ plan with all of these sections:
 
 - Edge cases, breaking changes, unknowns.
 
-### Post-implementation wrap-up (do NOT force a menu)
+### Post-implementation hand-off
 
-- When the work is done, do NOT use `AskUserQuestion` and do NOT auto-commit. Print a
-  plain-text wrap-up, then wait for the user's response in the normal chat input. It
-  MUST cover:
-  - **Summary** — one-line outcome plus a per-file list of what changed.
-  - **Current state** — branch name, what's committed vs. still uncommitted, and
-    test/build status.
-  - **Caveats** — known risks, uncovered edge cases, incomplete pieces, follow-ups.
-- Then let the user decide what's next (they may run `/git-tools:ship` to push/PR/merge,
-  `/session:session-end` for the review-then-PR flow, request adjustments, or finalize
-  manually). If an issue is linked and they later commit or open a PR, include
-  `Closes #N` (or `Fixes #N` for bugs) so the issue auto-closes on merge.
-- If this run created a worktree, note that teardown is deferred: `/session:session-end`
-  removes it after the PR merges, or the user can exit later with `ExitWorktree`. Do
-  not tear it down here.
+- The plan MUST state that, once the work is implemented, you will run the mandatory
+  STOP gate in Phase 5 below: present a summary plus caveats and wait for the user. Do
+  **not** describe committing, pushing, or opening a PR as part of "the plan" — those
+  are a separate, user-initiated step that happens only after the Phase 5 hand-off.
 
 Present the plan for user approval before any implementation begins.
+
+## Phase 5 — STOP & hand off after implementation (MANDATORY — NO EXCEPTIONS)
+
+> **HARD STOP.** The moment the planned work is implemented, you STOP and hand back to
+> the user. You do **NOT** `git commit`, `git push`, open or merge a pull request,
+> enable auto-merge, or invoke `/git-tools:ship` or `/session:session-end` on your own
+> — **no matter how obvious the next step seems, no matter that the user approved the
+> plan, and even if this skill was auto-invoked.** Approving the plan authorizes
+> *implementation only*, never publication. Finalizing is a separate, explicit,
+> user-initiated act. There is no exception to this; do not rationalize one.
+
+When the work is done:
+
+1. Do **NOT** call `AskUserQuestion` (no menu) and do **NOT** commit / push / PR /
+   merge. Print a plain-text wrap-up, then wait for the user's free-text reply in the
+   normal chat input. The wrap-up MUST contain, in this order:
+   - **Summary** — one-line outcome plus a per-file list of what changed.
+   - **Current state** — branch name, what is committed vs. still uncommitted, and
+     test/build status (say so plainly if tests were not run).
+   - **Caveats** — be up front and specific about known *or potential* problems:
+     known bugs, uncovered edge cases, assumptions you made, incomplete pieces, and
+     follow-up work. If you are unsure something works, say so explicitly. Do not
+     downplay or omit risks to make the result look finished.
+2. Then let the user decide what is next — they may run `/git-tools:ship`
+   (commit → push → PR → watch → merge), `/session:session-end` (the review-gated PR
+   flow), ask for changes, or finalize by hand. If an issue is linked and they later
+   commit or open a PR, include `Closes #N` (or `Fixes #N` for bugs) so the issue
+   auto-closes on merge.
+3. If this run created a worktree, note that teardown is deferred: `/session:session-end`
+   removes it after the PR merges, or the user can exit later with `ExitWorktree`. Do
+   not tear it down here.

--- a/plugins-claude/session/scripts/approve-own-scripts.sh
+++ b/plugins-claude/session/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -11,7 +11,9 @@ begin-work spine (explore → plan). To start from your own description instead,
 
 > **CRITICAL**: You MUST drive this to a plan. NEVER print "suggested first steps"
 > or ask "ready to start?" — the flow does not end until you have explored the code
-> with research agents and called `EnterPlanMode`.
+> with research agents and called `EnterPlanMode`. And once the approved work is
+> implemented you **STOP and hand back to the user** (spine Phase 5) — never commit,
+> push, open/merge a PR, or finalize on your own. Plan approval ≠ permission to publish.
 
 ### Phase 1 — Pick an issue
 

--- a/plugins-claude/session/skills/session-orchestrate/SKILL.md
+++ b/plugins-claude/session/skills/session-orchestrate/SKILL.md
@@ -211,9 +211,9 @@ Goal: summarize and route to the appropriate finalization flow.
    - Files changed (grouped by chunk)
    - Current state — branch name, what's committed vs. still uncommitted, test/build status
    - Test coverage added (if any)
-   - Caveats — deferred concerns from Phase 6, chunks surfaced for manual handling, and any known risks or follow-ups
+   - **Caveats** — be up front and specific about known *or potential* problems: deferred concerns from Phase 6, chunks surfaced for manual handling, assumptions made, uncovered edge cases, and any known risks or follow-ups. If you are unsure something works, say so. Do not downplay risks to make the result look finished.
 
-2. **Then stop and wait for the user's free-text response.** Do NOT use `AskUserQuestion` and do NOT auto-commit, push, or open a PR. Let the user decide what's next — they may run `/git-tools:ship` (commit, push, PR, watch CI), `/session:session-end` (review-then-PR flow), ask for adjustments, or finalize manually. Just present the summary and wait in the normal chat input.
+2. **HARD STOP — then wait for the user's free-text response (NO EXCEPTIONS).** Do NOT use `AskUserQuestion` and do NOT commit, push, open or merge a PR, or enable auto-merge — **no matter how obvious the next step seems, no matter that the gates were approved, and even if this skill was auto-invoked.** The Phase 3/5 approvals authorized *building* the feature, never *publishing* it. Finalizing is a separate, explicit, user-initiated act. Let the user decide what's next — they may run `/git-tools:ship` (commit, push, PR, watch CI), `/session:session-end` (review-then-PR flow), ask for adjustments, or finalize manually. Just present the summary and wait in the normal chat input.
 
 If this run created a worktree (Phase 0b), note that its teardown is deferred: `/session:session-end` removes it after the PR merges, or the user can leave it and exit later with `ExitWorktree`. Do not tear it down here.
 

--- a/plugins-claude/session/skills/session-start/SKILL.md
+++ b/plugins-claude/session/skills/session-start/SKILL.md
@@ -13,7 +13,9 @@ issues instead, use `/session:session-issue`; for a read-only status view, use
 
 > **CRITICAL**: You MUST drive this to a plan. NEVER print "suggested first steps"
 > or ask "ready to start?" — the flow does not end until you have explored the code
-> with research agents and called `EnterPlanMode`.
+> with research agents and called `EnterPlanMode`. And once the approved work is
+> implemented you **STOP and hand back to the user** (spine Phase 5) — never commit,
+> push, open/merge a PR, or finalize on your own. Plan approval ≠ permission to publish.
 
 ### Phase 0 — Take the input and ground it
 

--- a/plugins-claude/statusline/.claude-plugin/plugin.json
+++ b/plugins-claude/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Configurable status line for Claude Code — git status, model, context, API usage, cost segments with ANSI colors",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/statusline/scripts/approve-own-scripts.sh
+++ b/plugins-claude/statusline/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-claude/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-claude/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/stl-game-config/scripts/approve-own-scripts.sh
+++ b/plugins-claude/stl-game-config/scripts/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.

--- a/plugins-copilot/convert-doc/.claude-plugin/plugin.json
+++ b/plugins-copilot/convert-doc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-doc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert documents to/from markdown using pandoc (DOCX, HTML, RST, EPUB, ODT, RTF, LaTeX)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/format-on-save/.claude-plugin/plugin.json
+++ b/plugins-copilot/format-on-save/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "format-on-save",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/image/.claude-plugin/plugin.json
+++ b/plugins-copilot/image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Clipboard paste and screenshot capture for macOS, WSL, and Linux",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-copilot/kb-capture/.claude-plugin/plugin.json
+++ b/plugins-copilot/kb-capture/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-capture",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Research-to-document automation — capture conversation findings as schema-valid markdown with frontmatter, linting, and optional commit",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/markdown/.claude-plugin/plugin.json
+++ b/plugins-copilot/markdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Markdown linting and formatting — check, format, setup",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/notify-on-stop/.claude-plugin/plugin.json
+++ b/plugins-copilot/notify-on-stop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-on-stop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session-history-analyzer/.claude-plugin/plugin.json
+++ b/plugins-copilot/session-history-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-history-analyzer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/tests/approve-own-scripts/test-approve-own-scripts.sh
+++ b/tests/approve-own-scripts/test-approve-own-scripts.sh
@@ -63,6 +63,14 @@ run_test_both() {
   run_test "$expected" "$command" "$label [copilot]" "copilot" "$plugin_root"
 }
 
+# Expects an "ask" decision on Claude Code; on Copilot CLI there is no "ask", so
+# hook_ask degrades to a hard "deny".
+run_test_ask() {
+  local command="$1" label="${2:-$1}" plugin_root="${3:-$FAKE_PLUGIN_ROOT}"
+  run_test ask "$command" "$label" "claude" "$plugin_root"
+  run_test deny "$command" "$label [copilot]" "copilot" "$plugin_root"
+}
+
 # ===== ALLOW: plugin's own scripts =====
 echo "── Direct script execution ──"
 run_test_both allow \
@@ -89,6 +97,52 @@ run_test_both allow \
 run_test_both allow \
   "bash $FAKE_PLUGIN_ROOT/scripts/hook-compat.sh" \
   "bash prefix: hook-compat.sh"
+
+# ===== ASK: outward PR publish guard (create/merge a PR) =====
+# Must fire whether the PR is opened/merged via the plugin's own git-cli wrapper
+# OR a direct gh/tea invocation that would sidestep the wrapper.
+echo "── PR publish guard (must ASK) ──"
+run_test_ask \
+  "bash $FAKE_PLUGIN_ROOT/scripts/git-cli pr create --title x --body y" \
+  "git-cli pr create"
+
+run_test_ask \
+  "bash $FAKE_PLUGIN_ROOT/scripts/git-cli pr merge 5 --squash" \
+  "git-cli pr merge"
+
+run_test_ask \
+  "gh pr create --fill" \
+  "direct gh pr create (sidestep)"
+
+run_test_ask \
+  "tea pr create" \
+  "direct tea pr create (sidestep)"
+
+run_test_ask \
+  "gh pr merge 42 --squash" \
+  "direct gh pr merge (sidestep)"
+
+# Guard must NOT fire on read-only or reversible pr ops.
+echo "── PR guard must NOT fire (read-only / reversible) ──"
+run_test_both allow \
+  "bash $FAKE_PLUGIN_ROOT/scripts/git-cli pr auto-merge-status --branch main" \
+  "git-cli pr auto-merge-status (read-only → own-script allow)"
+
+run_test_both allow \
+  "bash $FAKE_PLUGIN_ROOT/scripts/git-cli pr close 5" \
+  "git-cli pr close (reversible → own-script allow)"
+
+run_test_both allow \
+  "bash $FAKE_PLUGIN_ROOT/scripts/git-cli pr list --state open" \
+  "git-cli pr list (read-only → own-script allow)"
+
+run_test_both none \
+  "gh pr view 3" \
+  "gh pr view (not own script, not publish)"
+
+run_test_both none \
+  "gh pr list" \
+  "gh pr list (not own script, not publish)"
 
 # ===== NONE (fall-through): non-plugin commands =====
 echo "── Non-plugin commands (fall-through) ──"
@@ -169,6 +223,20 @@ if [[ -z "$raw" ]]; then
   ((PASS++)) || true
 else
   printf "  \033[31m✗\033[0m %s  (expected: none, got output)\n" "no COPILOT_PLUGIN_ROOT → fall-through"
+  ((FAIL++)) || true
+fi
+
+# The PR-publish guard runs BEFORE the PLUGIN_ROOT check, so it must still fire
+# even with no plugin root set (guards against a future reorg that moves it).
+payload_claude=$(jq -n --arg t "Bash" --arg c "gh pr create --fill" \
+  '{tool_name:$t,tool_input:{command:$c},hook_event_name:"PreToolUse",permission_mode:"default"}')
+raw=$(echo "$payload_claude" | env -i HOME="$HOME" PATH="$PATH" bash "$HOOK_SCRIPT" 2>/dev/null) || true
+result=$(echo "$raw" | jq -r '.hookSpecificOutput.permissionDecision // "none"' 2>/dev/null || echo "none")
+if [[ "$result" == "ask" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "PR guard fires with no PLUGIN_ROOT → ask"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (expected: ask, got: %s)\n" "PR guard fires with no PLUGIN_ROOT → ask" "$result"
   ((FAIL++)) || true
 fi
 

--- a/utils/approve-own-scripts.sh
+++ b/utils/approve-own-scripts.sh
@@ -38,6 +38,32 @@ source "$(dirname "$0")/hook-compat.sh"
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
+# --- Outward VCS publish guard (applies to ALL Bash, not just own scripts) ---
+# Never SILENTLY approve creating or merging a pull request — whether it goes
+# through this plugin's git-cli wrapper OR a direct `gh`/`tea` invocation that
+# would otherwise sidestep the wrapper (and likely hit a user allowlist).
+# Publishing/merging a PR triggers CI and any auto-merge automation, so it must
+# be confirmed by the user rather than waved through. We require BOTH a known
+# VCS CLI token (gh / tea / git-cli) AND a "pr create" | "pr merge" subcommand,
+# so read-only forms (`pr auto-merge-status`) and reversible ones (`pr close`)
+# still fall through. On Copilot CLI, hook_ask degrades to a hard deny (there is
+# no "ask" there) — meaning the user simply runs the publish step manually.
+#
+# Enabling auto-merge is covered: the real path is `gh pr merge --auto`, which
+# the `pr merge` arm already catches. We deliberately do NOT broaden to a bare
+# "auto-merge" token — that would also trap the read-only `pr auto-merge-status`
+# call the session-end flow relies on. (`pr review --approve`, `release create`
+# etc. are out of scope by design — this guard is narrowly about opening/merging
+# a PR.)
+if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
+  [[ "$HOOK_COMMAND" =~ (^|[[:space:]])pr[[:space:]]+(create|merge)([[:space:]]|$) ]]; then
+  # NOTE: BASH_REMATCH below reflects the SECOND [[ =~ ]] (the pr subcommand
+  # test, evaluated last), so [2] is "create"|"merge". Do not reorder the two
+  # conditions — swapping them would make this message read "pr gh"/"pr tea".
+  hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
+  exit 0
+fi
+
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
 # which scripts belong to this plugin.


### PR DESCRIPTION
## Summary

A session autonomously committed, pushed, and opened a PR without ever stopping for the user. Two root causes: the "do NOT auto-commit" rule was buried as a sub-bullet inside the Phase 4 plan content (shown before implementation, expected to be recalled after), and PR creation via the `git-cli` wrapper was silently auto-approved by `approve-own-scripts.sh`. This PR adds a mechanical backstop on PR publishing and elevates the post-implementation STOP gate to an unmissable, repeated rule.

## Changes

- **`utils/approve-own-scripts.sh`** — new global outward-VCS publish guard: any `gh`/`tea`/`git-cli` `pr create` or `pr merge` returns `ask` (Claude) / `deny` (Copilot) *before* the own-script auto-approve. Catches both the wrapper and direct `gh`/`tea` sidesteps. Read-only (`pr auto-merge-status`, `pr list`) and reversible (`pr close`) ops still pass through; `gh pr merge --auto` is covered by the `pr merge` arm.
- **`spine.md`** — extracted the wrap-up into a standalone **Phase 5 — STOP & hand off (MANDATORY — NO EXCEPTIONS)**, added a top-banner warning, and require being up-front about known/potential problems in caveats.
- **`session-orchestrate`** — Phase 7 hand-off rewritten as a HARD STOP, no exceptions.
- **`session-start` / `session-issue`** — stop gate added to the front-door CRITICAL banners.
- **Version bumps** — all 14 plugins that vendor `approve-own-scripts.sh` (Claude + Copilot), so the guard reaches installed clients regardless of which plugin's hook is active.

## Testing

- `tests/approve-own-scripts/` — 21 new assertions: publish ops ask, read-only/reversible `pr` ops pass through, Copilot `deny` degradation, and the guard fires even with no `PLUGIN_ROOT`.
- Full suite green locally: `test.sh` 1771/0, `validate-plugins.sh` 282/0, `validate-frontmatter.sh` 98/0, `rumdl check .` clean.

## Caveats

- The guard intentionally does **not** gate raw `git commit` / `git push` (not plugin scripts) — those stay on the user's normal permission flow. It hard-gates the PR-publish step.
- Whether a user's own `allow` permission *rule* (e.g. `Bash(gh pr create:*)`) suppresses a hook `ask` is undocumented in Claude Code; if PR-create is explicitly allow-listed in settings, the prompt may be bypassed.
- The "stop and summarize" behavior itself remains prose (not mechanically enforceable); the hook only backstops PR publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)