### PR TITLE
fix(git-tools): JSON output for write commands + comment CRUD + api passthrough

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -9,6 +9,7 @@
 #   git-tools issue show   <N>
 #   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
 #   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+#   git-tools issue comment list <N> | delete <id> | edit <id> [--body ...]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
@@ -32,7 +33,11 @@
 #   git-tools repo info
 #   git-tools user whoami
 #
-# Output: normalized JSON (arrays or objects) regardless of platform.
+#   git-tools api <path> [-X METHOD] [-f key=val ...]  (raw passthrough; path first)
+#
+# Output: normalized JSON (arrays or objects) regardless of platform. Write
+# commands return JSON too: create -> {number, url}; comment -> the comment
+# object {id, author, body, html_url, created_at}. `api` returns RAW backend JSON.
 # Exit codes: 0 success, 1 usage error, 2 platform detection failure,
 #             3 CLI not found, 4 command failed
 
@@ -124,6 +129,27 @@ parse_body_args() {
   if [[ "$read_stdin" == "1" ]]; then
     read_body_from_stdin
   fi
+}
+
+# jq filter normalizing a single comment object. GitHub and Gitea both return
+# REST-shaped comments with the same field names (id, body, html_url, user,
+# created_at), so one filter serves both backends for add/list/edit.
+COMMENT_JQ='{id, author: (.user.login // .user // ""), body, html_url: (.html_url // ""), created_at}'
+
+# Emit {number, url} JSON from a create command's human output by scraping the
+# first issue/PR URL it printed. Used by issue/pr create so write commands return
+# parseable JSON instead of gh/tea's human-rendered text. Dies with the raw
+# output if no URL is found (so a silent format change surfaces loudly).
+emit_created_json() {
+  local raw="$1" url num
+  url=$(printf '%s\n' "$raw" \
+    | grep -oiE 'https?://[^[:space:]]+/(issues?|pulls?)/[0-9]+' \
+    | head -n1 || true)
+  [[ -n "$url" ]] || die "could not parse created object URL from output: $raw"
+  num="${url##*/}"
+  # The regex guarantees a trailing [0-9]+, so number is always a true integer.
+  jq -n --arg number "$num" --arg url "$url" \
+    '{number: ($number | tonumber), url: $url}'
 }
 
 # ---------------------------------------------------------------------------
@@ -389,26 +415,73 @@ case "$cmd:$sub" in
         [[ -n "$BODY"     ]] && args+=(--body "$BODY")
         [[ -n "$label"    ]] && args+=(--label "$label")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        GH_NO_COLOR=1 gh issue create "${args[@]}"
+        # Keep the CLI call (preserves --label by name; the Gitea REST create
+        # endpoint requires numeric label IDs) and normalize its URL to JSON.
+        out=$(GH_NO_COLOR=1 gh issue create "${args[@]}") || die "gh issue create failed"
+        emit_created_json "$out"
         ;;
       gitea)
         args=(--title "$title")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
         [[ -n "$label"    ]] && args+=(--labels "$label")
         [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
-        NO_COLOR=1 tea issues create "${args[@]}"
+        out=$(NO_COLOR=1 tea issues create "${args[@]}") || die "tea issues create failed"
+        emit_created_json "$out"
         ;;
     esac
     ;;
 
   issue:comment)
-    [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment <N> [--body TEXT | --body-file FILE]"
-    num="$1"; shift
-    parse_body_args "$@"
-    [[ -n "$BODY" ]] || die_usage "issue comment requires --body or --body-file"
-    case "$PLATFORM" in
-      github) GH_NO_COLOR=1 gh issue comment "$num" --body "$BODY" ;;
-      gitea)  NO_COLOR=1 tea comment "$num" "$BODY" ;;
+    [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment <N> [--body ...] | comment list <N> | comment delete <id> | comment edit <id> [--body ...]"
+    action="$1"
+    case "$action" in
+      list)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment list <N>"
+        num="$1"; shift
+        # gh --paginate merges all comment pages into one JSON array; tea api
+        # returns only the server's default page (Gitea default 20; see SKILL.md).
+        case "$PLATFORM" in
+          github) cli_json "[.[] | $COMMENT_JQ]" env GH_NO_COLOR=1 gh api --paginate "repos/{owner}/{repo}/issues/$num/comments" ;;
+          gitea)  cli_json "[.[] | $COMMENT_JQ]" env NO_COLOR=1 tea api "repos/{owner}/{repo}/issues/$num/comments" ;;
+        esac
+        ;;
+      delete)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment delete <id>"
+        cid="$1"
+        # DELETE returns HTTP 204 with an empty body — never pipe through jq.
+        case "$PLATFORM" in
+          github) GH_NO_COLOR=1 gh api -X DELETE "repos/{owner}/{repo}/issues/comments/$cid" >/dev/null \
+                    || die "gh api DELETE issues/comments/$cid failed" ;;
+          gitea)  NO_COLOR=1 tea api -X DELETE "repos/{owner}/{repo}/issues/comments/$cid" >/dev/null \
+                    || die "tea api DELETE issues/comments/$cid failed" ;;
+        esac
+        jq -n --arg id "$cid" '{deleted: true, id: ($id | tonumber? // $id)}'
+        ;;
+      edit)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment edit <id> [--body TEXT | --body-file FILE]"
+        cid="$1"; shift
+        parse_body_args "$@"
+        [[ -n "$BODY" ]] || die_usage "issue comment edit requires --body or --body-file"
+        case "$PLATFORM" in
+          github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$cid" -f "body=$BODY" ;;
+          gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X PATCH "repos/{owner}/{repo}/issues/comments/$cid" -f "body=$BODY" ;;
+        esac
+        ;;
+      *)
+        # Add a comment to issue <N>. Post via REST so the response carries the
+        # new comment's id/url — a definitive success signal that prevents the
+        # silent double-posts the old human-text path caused (#142).
+        num="$action"; shift
+        parse_body_args "$@"
+        [[ -n "$BODY" ]] || die_usage "issue comment requires --body or --body-file"
+        case "$PLATFORM" in
+          github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+          gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+        esac
+        ;;
     esac
     ;;
 
@@ -522,13 +595,15 @@ case "$cmd:$sub" in
         args=(--title "$title" --head "$head" --base "$base")
         [[ -n "$BODY"     ]] && args+=(--body "$BODY")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        GH_NO_COLOR=1 gh pr create "${args[@]}"
+        out=$(GH_NO_COLOR=1 gh pr create "${args[@]}") || die "gh pr create failed"
+        emit_created_json "$out"
         ;;
       gitea)
         args=(--title "$title" --head "$head" --base "$base")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
         [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
-        NO_COLOR=1 tea pr create "${args[@]}"
+        out=$(NO_COLOR=1 tea pr create "${args[@]}") || die "tea pr create failed"
+        emit_created_json "$out"
         ;;
     esac
     ;;
@@ -538,11 +613,12 @@ case "$cmd:$sub" in
     num="$1"; shift
     parse_body_args "$@"
     [[ -n "$BODY" ]] || die_usage "pr comment requires --body or --body-file"
+    # A PR is an "issue" for commenting on both platforms — the comment lives at
+    # the issues/{n}/comments endpoint. Post via REST so the response carries the
+    # new comment's id/url (mirrors issue comment; kills the double-post foot-gun).
     case "$PLATFORM" in
-      # gh uses the same comment command for both issues and PRs
-      github) GH_NO_COLOR=1 gh pr comment "$num" --body "$BODY" ;;
-      # tea uses a unified comment command for both issues and PRs
-      gitea)  NO_COLOR=1 tea comment "$num" "$BODY" ;;
+      github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+      gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
     esac
     ;;
 
@@ -1291,6 +1367,28 @@ case "$cmd:$sub" in
     ;;
 
   # -------------------------------------------------------------------------
+  # API PASSTHROUGH
+  # -------------------------------------------------------------------------
+
+  api:*)
+    # Raw authenticated REST passthrough — the escape hatch for capabilities the
+    # wrapper doesn't expose, so a missing operation never forces a bypass to
+    # gh/tea directly. Output is the backend's RAW JSON (not normalized); supply
+    # your own --jq or pipe. {owner}/{repo} are substituted by gh/tea from the
+    # current remote. The <path> must come first; flags follow it:
+    #   git-tools api repos/{owner}/{repo}/issues/5/comments
+    #   git-tools api repos/{owner}/{repo}/issues/comments/123 -X DELETE
+    #   git-tools api repos/{owner}/{repo}/issues -X POST -f title=hi
+    endpoint="$sub"
+    [[ -n "$endpoint" && "$endpoint" != -* ]] \
+      || die_usage "usage: git-tools api <path> [-X METHOD] [-f key=val ...]  (path must come first)"
+    case "$PLATFORM" in
+      github) GH_NO_COLOR=1 gh api "$endpoint" "$@" ;;
+      gitea)  NO_COLOR=1 tea api "$endpoint" "$@" ;;
+    esac
+    ;;
+
+  # -------------------------------------------------------------------------
   # Help / unknown
   # -------------------------------------------------------------------------
 
@@ -1309,6 +1407,9 @@ ISSUE COMMANDS
   git-tools issue show   <N>
   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+  git-tools issue comment list   <N>
+  git-tools issue comment delete <id>
+  git-tools issue comment edit   <id> [--body TEXT | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
@@ -1332,6 +1433,14 @@ REPO / USER
   git-tools repo default-branch
   git-tools repo info
   git-tools user whoami
+
+API PASSTHROUGH
+  git-tools api <path> [-X METHOD] [-f key=val ...]   raw gh/tea api call
+                                                      (path first; output NOT normalized)
+
+Write commands (issue/pr create, issue/pr comment, comment edit) return JSON:
+  create  -> {number, url}
+  comment -> {id, author, body, html_url, created_at}
 EOF
     exit 0
     ;;

--- a/plugins-claude/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-tools/skills/git-cli/SKILL.md
@@ -21,6 +21,8 @@ Run `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli --help` for the full subcommand list 
 - `pr wait --branch NAME` — poll until merged/closed/blocked (default 300s). **Use this instead of writing your own poll loop.**
 - `run watch --branch NAME` — poll CI to pass/fail/timeout with proper terminal-state detection. **Use this instead of writing your own poll loop.**
 - `run show <id>` — aggregates per-job status on Gitea so failed jobs don't get masked by a run-level success (#87).
+- `issue comment list <N>` / `delete <id>` / `edit <id> [--body ...]` — read, remove, and update comments. Use `list` to verify a comment posted (the add command returns the new comment's `id`, so you never need to blind-retry and risk a double-post).
+- `api <path> [-X METHOD] [-f key=val ...]` — raw authenticated `gh`/`tea api` passthrough; the escape hatch when the wrapper lacks a capability. The `<path>` must come first. Output is the backend's **raw** JSON (not normalized) — supply your own `--jq` or pipe.
 
 ## Body input
 
@@ -48,7 +50,7 @@ after `GIT_CLI_STDIN_TIMEOUT` seconds (default 10) instead of blocking.
 
 ## Normalized JSON output
 
-All commands return JSON with a consistent schema across platforms. Issue/PR objects use:
+All commands return JSON with a consistent schema across platforms — **including the write commands** (`issue`/`pr create`, `issue`/`pr comment`, `comment edit`), so every result is parseable and carries a definitive success object. Read commands (`issue`/`pr list`/`show`) return the full issue/PR object:
 
 ```json
 {
@@ -65,5 +67,15 @@ All commands return JSON with a consistent schema across platforms. Issue/PR obj
   "url": "https://..."
 }
 ```
+
+Write commands return a compact object:
+
+- **`issue`/`pr create`** → `{number, url}` (follow with `issue show <N>` for the full object).
+- **`issue`/`pr comment`, `comment edit`** → the comment `{id, author, body, html_url, created_at}`. The `id` is the success signal — confirm a post without blind-retrying.
+- **`comment delete`** → `{deleted: true, id}`.
+
+The only un-normalized command is `api`, which is a deliberate raw passthrough.
+
+> **Pagination:** `issue comment list` fetches all pages on GitHub (`gh api --paginate`); on Gitea it returns the server's default page size, so a very long thread may be truncated. For verify-after-write this is sufficient.
 
 Downstream skills (e.g. `session/*`) depend on this shape — don't bypass the wrapper just to get raw `gh`/`tea` output.

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -9,6 +9,7 @@
 #   git-tools issue show   <N>
 #   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
 #   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+#   git-tools issue comment list <N> | delete <id> | edit <id> [--body ...]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
@@ -32,7 +33,11 @@
 #   git-tools repo info
 #   git-tools user whoami
 #
-# Output: normalized JSON (arrays or objects) regardless of platform.
+#   git-tools api <path> [-X METHOD] [-f key=val ...]  (raw passthrough; path first)
+#
+# Output: normalized JSON (arrays or objects) regardless of platform. Write
+# commands return JSON too: create -> {number, url}; comment -> the comment
+# object {id, author, body, html_url, created_at}. `api` returns RAW backend JSON.
 # Exit codes: 0 success, 1 usage error, 2 platform detection failure,
 #             3 CLI not found, 4 command failed
 
@@ -124,6 +129,27 @@ parse_body_args() {
   if [[ "$read_stdin" == "1" ]]; then
     read_body_from_stdin
   fi
+}
+
+# jq filter normalizing a single comment object. GitHub and Gitea both return
+# REST-shaped comments with the same field names (id, body, html_url, user,
+# created_at), so one filter serves both backends for add/list/edit.
+COMMENT_JQ='{id, author: (.user.login // .user // ""), body, html_url: (.html_url // ""), created_at}'
+
+# Emit {number, url} JSON from a create command's human output by scraping the
+# first issue/PR URL it printed. Used by issue/pr create so write commands return
+# parseable JSON instead of gh/tea's human-rendered text. Dies with the raw
+# output if no URL is found (so a silent format change surfaces loudly).
+emit_created_json() {
+  local raw="$1" url num
+  url=$(printf '%s\n' "$raw" \
+    | grep -oiE 'https?://[^[:space:]]+/(issues?|pulls?)/[0-9]+' \
+    | head -n1 || true)
+  [[ -n "$url" ]] || die "could not parse created object URL from output: $raw"
+  num="${url##*/}"
+  # The regex guarantees a trailing [0-9]+, so number is always a true integer.
+  jq -n --arg number "$num" --arg url "$url" \
+    '{number: ($number | tonumber), url: $url}'
 }
 
 # ---------------------------------------------------------------------------
@@ -389,26 +415,73 @@ case "$cmd:$sub" in
         [[ -n "$BODY"     ]] && args+=(--body "$BODY")
         [[ -n "$label"    ]] && args+=(--label "$label")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        GH_NO_COLOR=1 gh issue create "${args[@]}"
+        # Keep the CLI call (preserves --label by name; the Gitea REST create
+        # endpoint requires numeric label IDs) and normalize its URL to JSON.
+        out=$(GH_NO_COLOR=1 gh issue create "${args[@]}") || die "gh issue create failed"
+        emit_created_json "$out"
         ;;
       gitea)
         args=(--title "$title")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
         [[ -n "$label"    ]] && args+=(--labels "$label")
         [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
-        NO_COLOR=1 tea issues create "${args[@]}"
+        out=$(NO_COLOR=1 tea issues create "${args[@]}") || die "tea issues create failed"
+        emit_created_json "$out"
         ;;
     esac
     ;;
 
   issue:comment)
-    [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment <N> [--body TEXT | --body-file FILE]"
-    num="$1"; shift
-    parse_body_args "$@"
-    [[ -n "$BODY" ]] || die_usage "issue comment requires --body or --body-file"
-    case "$PLATFORM" in
-      github) GH_NO_COLOR=1 gh issue comment "$num" --body "$BODY" ;;
-      gitea)  NO_COLOR=1 tea comment "$num" "$BODY" ;;
+    [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment <N> [--body ...] | comment list <N> | comment delete <id> | comment edit <id> [--body ...]"
+    action="$1"
+    case "$action" in
+      list)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment list <N>"
+        num="$1"; shift
+        # gh --paginate merges all comment pages into one JSON array; tea api
+        # returns only the server's default page (Gitea default 20; see SKILL.md).
+        case "$PLATFORM" in
+          github) cli_json "[.[] | $COMMENT_JQ]" env GH_NO_COLOR=1 gh api --paginate "repos/{owner}/{repo}/issues/$num/comments" ;;
+          gitea)  cli_json "[.[] | $COMMENT_JQ]" env NO_COLOR=1 tea api "repos/{owner}/{repo}/issues/$num/comments" ;;
+        esac
+        ;;
+      delete)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment delete <id>"
+        cid="$1"
+        # DELETE returns HTTP 204 with an empty body — never pipe through jq.
+        case "$PLATFORM" in
+          github) GH_NO_COLOR=1 gh api -X DELETE "repos/{owner}/{repo}/issues/comments/$cid" >/dev/null \
+                    || die "gh api DELETE issues/comments/$cid failed" ;;
+          gitea)  NO_COLOR=1 tea api -X DELETE "repos/{owner}/{repo}/issues/comments/$cid" >/dev/null \
+                    || die "tea api DELETE issues/comments/$cid failed" ;;
+        esac
+        jq -n --arg id "$cid" '{deleted: true, id: ($id | tonumber? // $id)}'
+        ;;
+      edit)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment edit <id> [--body TEXT | --body-file FILE]"
+        cid="$1"; shift
+        parse_body_args "$@"
+        [[ -n "$BODY" ]] || die_usage "issue comment edit requires --body or --body-file"
+        case "$PLATFORM" in
+          github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$cid" -f "body=$BODY" ;;
+          gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X PATCH "repos/{owner}/{repo}/issues/comments/$cid" -f "body=$BODY" ;;
+        esac
+        ;;
+      *)
+        # Add a comment to issue <N>. Post via REST so the response carries the
+        # new comment's id/url — a definitive success signal that prevents the
+        # silent double-posts the old human-text path caused (#142).
+        num="$action"; shift
+        parse_body_args "$@"
+        [[ -n "$BODY" ]] || die_usage "issue comment requires --body or --body-file"
+        case "$PLATFORM" in
+          github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+          gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+        esac
+        ;;
     esac
     ;;
 
@@ -522,13 +595,15 @@ case "$cmd:$sub" in
         args=(--title "$title" --head "$head" --base "$base")
         [[ -n "$BODY"     ]] && args+=(--body "$BODY")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        GH_NO_COLOR=1 gh pr create "${args[@]}"
+        out=$(GH_NO_COLOR=1 gh pr create "${args[@]}") || die "gh pr create failed"
+        emit_created_json "$out"
         ;;
       gitea)
         args=(--title "$title" --head "$head" --base "$base")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
         [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
-        NO_COLOR=1 tea pr create "${args[@]}"
+        out=$(NO_COLOR=1 tea pr create "${args[@]}") || die "tea pr create failed"
+        emit_created_json "$out"
         ;;
     esac
     ;;
@@ -538,11 +613,12 @@ case "$cmd:$sub" in
     num="$1"; shift
     parse_body_args "$@"
     [[ -n "$BODY" ]] || die_usage "pr comment requires --body or --body-file"
+    # A PR is an "issue" for commenting on both platforms — the comment lives at
+    # the issues/{n}/comments endpoint. Post via REST so the response carries the
+    # new comment's id/url (mirrors issue comment; kills the double-post foot-gun).
     case "$PLATFORM" in
-      # gh uses the same comment command for both issues and PRs
-      github) GH_NO_COLOR=1 gh pr comment "$num" --body "$BODY" ;;
-      # tea uses a unified comment command for both issues and PRs
-      gitea)  NO_COLOR=1 tea comment "$num" "$BODY" ;;
+      github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+      gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
     esac
     ;;
 
@@ -1291,6 +1367,28 @@ case "$cmd:$sub" in
     ;;
 
   # -------------------------------------------------------------------------
+  # API PASSTHROUGH
+  # -------------------------------------------------------------------------
+
+  api:*)
+    # Raw authenticated REST passthrough — the escape hatch for capabilities the
+    # wrapper doesn't expose, so a missing operation never forces a bypass to
+    # gh/tea directly. Output is the backend's RAW JSON (not normalized); supply
+    # your own --jq or pipe. {owner}/{repo} are substituted by gh/tea from the
+    # current remote. The <path> must come first; flags follow it:
+    #   git-tools api repos/{owner}/{repo}/issues/5/comments
+    #   git-tools api repos/{owner}/{repo}/issues/comments/123 -X DELETE
+    #   git-tools api repos/{owner}/{repo}/issues -X POST -f title=hi
+    endpoint="$sub"
+    [[ -n "$endpoint" && "$endpoint" != -* ]] \
+      || die_usage "usage: git-tools api <path> [-X METHOD] [-f key=val ...]  (path must come first)"
+    case "$PLATFORM" in
+      github) GH_NO_COLOR=1 gh api "$endpoint" "$@" ;;
+      gitea)  NO_COLOR=1 tea api "$endpoint" "$@" ;;
+    esac
+    ;;
+
+  # -------------------------------------------------------------------------
   # Help / unknown
   # -------------------------------------------------------------------------
 
@@ -1309,6 +1407,9 @@ ISSUE COMMANDS
   git-tools issue show   <N>
   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+  git-tools issue comment list   <N>
+  git-tools issue comment delete <id>
+  git-tools issue comment edit   <id> [--body TEXT | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
@@ -1332,6 +1433,14 @@ REPO / USER
   git-tools repo default-branch
   git-tools repo info
   git-tools user whoami
+
+API PASSTHROUGH
+  git-tools api <path> [-X METHOD] [-f key=val ...]   raw gh/tea api call
+                                                      (path first; output NOT normalized)
+
+Write commands (issue/pr create, issue/pr comment, comment edit) return JSON:
+  create  -> {number, url}
+  comment -> {id, author, body, html_url, created_at}
 EOF
     exit 0
     ;;

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-copilot/git-tools/skills/git-cli/SKILL.md
@@ -45,10 +45,19 @@ Progress update...
 EOF
 gh issue comment <number> --body 'LGTM'
 
+# Read / edit / delete comments — verify a post by its id instead of blind-retrying
+gh api repos/{owner}/{repo}/issues/<number>/comments
+gh api -X PATCH  repos/{owner}/{repo}/issues/comments/<id> -f body='Updated'
+gh api -X DELETE repos/{owner}/{repo}/issues/comments/<id>
+
 # Close or reopen
 gh issue close <number>
 gh issue reopen <number>
 ```
+
+> Raw `gh api` / `tea api` is the escape hatch when a higher-level command is
+> missing a capability — it returns the backend's JSON, which you can shape with
+> `--jq` or pipe through `jq`.
 
 ### Pull Requests
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/tests/git-cli/test-body-args.sh
+++ b/tests/git-cli/test-body-args.sh
@@ -53,13 +53,24 @@ esac
 EOF
 chmod +x "$MOCK_DIR/git"
 
-# Mock gh: capture the value passed to --body into BODY_FILE for any subcommand.
+# Mock gh: capture the inline body into BODY_FILE. issue/pr create still pass it
+# via --body; issue/pr comment now post via `gh api ... -f body=VALUE`, so capture
+# both forms. `gh api user` (detect_current_user) returns a login.
 cat >"$MOCK_DIR/gh" <<MOCK_EOF
 #!/usr/bin/env bash
 args=("\$@")
 case "\$1:\$2" in
   repo:view) echo "main" ;;
-  api:*)     echo '{"login":"testuser"}' ;;
+  api:user)  echo "testuser" ;;
+  api:*)
+    # Raw api passthrough (comment add/edit): capture -f body=VALUE.
+    for ((i=0; i<\${#args[@]}; i++)); do
+      if [[ "\${args[\$i]}" == "-f" && "\${args[\$((i+1))]}" == body=* ]]; then
+        printf '%s' "\${args[\$((i+1))]#body=}" > "$BODY_FILE"
+      fi
+    done
+    echo '{"id":1,"body":"x","html_url":"https://github.com/owner/repo/issues/42#issuecomment-1","user":{"login":"testuser"},"created_at":"t"}'
+    ;;
   *)
     for ((i=0; i<\${#args[@]}; i++)); do
       if [[ "\${args[\$i]}" == "--body" ]]; then
@@ -113,7 +124,7 @@ if ! skip_filtered "$label"; then
   fi
 else ((SKIP++)) || true; fi
 
-label="--body TEXT → inline value reaches gh (pr comment)"
+label="--body TEXT → inline value reaches gh api (pr comment)"
 if ! skip_filtered "$label"; then
   run_gh none -- pr comment 42 --body "looks good"
   if [[ "$EXIT" == "0" ]] && [[ -f "$BODY_FILE" ]] && grep -qx "looks good" "$BODY_FILE"; then

--- a/tests/git-cli/test-issue-write-json.sh
+++ b/tests/git-cli/test-issue-write-json.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# test-issue-write-json.sh — git-cli write-command JSON output (#142).
+#
+# Verifies that write commands emit parseable JSON instead of gh/tea human text:
+#   - issue/pr create        -> {number, url}
+#   - issue/pr comment (add) -> {id, author, body, html_url, created_at}
+#   - issue comment list     -> [ {id, ...}, ... ]
+#   - issue comment delete   -> {deleted: true, id}
+#   - issue comment edit     -> {id, body, ...}
+#   - api <path>             -> raw backend JSON passthrough
+# Covers both the github (gh) and gitea (tea) platform paths via PATH-injected
+# mock CLIs, mirroring tests/git-cli/test-run-show.sh.
+#
+# Usage: bash tests/git-cli/test-issue-write-json.sh [filter]
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GIT_CLI="$SCRIPT_DIR/../../utils/git-cli"
+
+PASS=0
+FAIL=0
+SKIP=0
+FILTER="${1:-}"
+
+MOCK_DIR=""
+cleanup() { [[ -n "$MOCK_DIR" ]] && rm -rf "$MOCK_DIR"; }
+trap cleanup EXIT
+MOCK_DIR=$(mktemp -d)
+
+pass() {
+  printf "  \033[32m✓\033[0m %s\n" "$1"
+  ((PASS++)) || true
+}
+fail() {
+  printf "  \033[31m✗\033[0m %s  (%s)\n" "$1" "$2"
+  ((FAIL++)) || true
+}
+# Returns 0 (skip) when a filter is set and does not match; counts the skip.
+skip_filter() {
+  if [[ -n "$FILTER" ]] && ! echo "$1" | grep -qi "$FILTER"; then
+    ((SKIP++)) || true
+    return 0
+  fi
+  return 1
+}
+
+run_cli() { PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" "$@" 2>"$MOCK_DIR/stderr"; }
+
+# ---------------------------------------------------------------------------
+# Shared mock backends. The gh/tea mocks answer the REST/CLI shapes the wrapper
+# now uses. The git mock selects the platform via the remote hostname.
+# ---------------------------------------------------------------------------
+
+write_gh_mock() {
+  cat >"$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+case "$1 $2" in
+  "issue create") echo "https://github.com/owner/repo/issues/42"; exit 0 ;;
+  "pr create")    echo "https://github.com/owner/repo/pull/7";    exit 0 ;;
+esac
+if [[ "$1" == "api" ]]; then
+  case "$args" in
+    *"api user"*) echo "alice"; exit 0 ;;
+    *"-X DELETE"*) exit 0 ;;
+    *"-X PATCH"*)  echo '{"id":101,"body":"edited","html_url":"https://github.com/owner/repo/issues/5#issuecomment-101","user":{"login":"alice"},"created_at":"2026-06-02T00:00:00Z"}'; exit 0 ;;
+    *"-X POST"*comments*) echo '{"id":101,"body":"hello","html_url":"https://github.com/owner/repo/issues/5#issuecomment-101","user":{"login":"alice"},"created_at":"2026-06-02T00:00:00Z"}'; exit 0 ;;
+    *comments*) echo '[{"id":101,"body":"first","html_url":"u1","user":{"login":"alice"},"created_at":"t1"},{"id":102,"body":"second","html_url":"u2","user":{"login":"bob"},"created_at":"t2"}]'; exit 0 ;;
+    *__ping__*) echo '{"pong":true}'; exit 0 ;;
+  esac
+fi
+echo "unexpected gh call: $args" >&2; exit 1
+EOF
+  chmod +x "$MOCK_DIR/gh"
+}
+
+write_tea_mock() {
+  cat >"$MOCK_DIR/tea" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+case "$1 $2 $3" in
+  "login list --output") echo '[{"url":"https://git.stonefish.tech","user":"alice"}]'; exit 0 ;;
+esac
+case "$1 $2" in
+  "issues create") echo "Created issue https://git.stonefish.tech/owner/repo/issues/42"; exit 0 ;;
+  "pr create")     echo "Created pull  https://git.stonefish.tech/owner/repo/pulls/7";   exit 0 ;;
+esac
+if [[ "$1" == "api" ]]; then
+  case "$args" in
+    *"-X DELETE"*) exit 0 ;;
+    *"-X PATCH"*)  echo '{"id":101,"body":"edited","html_url":"https://git.stonefish.tech/owner/repo/issues/5#issuecomment-101","user":{"login":"alice"},"created_at":"t"}'; exit 0 ;;
+    *"-X POST"*comments*) echo '{"id":101,"body":"hello","html_url":"https://git.stonefish.tech/owner/repo/issues/5#issuecomment-101","user":{"login":"alice"},"created_at":"t"}'; exit 0 ;;
+    *comments*) echo '[{"id":101,"body":"first","html_url":"u1","user":{"login":"alice"},"created_at":"t1"},{"id":102,"body":"second","html_url":"u2","user":{"login":"bob"},"created_at":"t2"}]'; exit 0 ;;
+    *__ping__*) echo '{"pong":true}'; exit 0 ;;
+  esac
+fi
+echo "unexpected tea call: $args" >&2; exit 1
+EOF
+  chmod +x "$MOCK_DIR/tea"
+}
+
+# Platform selectors: choose the remote host so detect_platform resolves
+# github (github.com fallback) vs gitea (matches the tea login host).
+set_platform_github() {
+  cat >"$MOCK_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") echo "https://github.com/owner/repo.git" ;;
+  *) command git "$@" ;;
+esac
+EOF
+  chmod +x "$MOCK_DIR/git"
+  # tea present but with a non-github login → no match → github.com fallback.
+  cat >"$MOCK_DIR/tea" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1 $2 $3" == "login list --output" ]] && { echo '[]'; exit 0; }
+echo "unexpected tea call on github path: $*" >&2; exit 1
+EOF
+  chmod +x "$MOCK_DIR/tea"
+  write_gh_mock
+}
+
+set_platform_gitea() {
+  cat >"$MOCK_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") echo "https://git.stonefish.tech/owner/repo.git" ;;
+  *) command git "$@" ;;
+esac
+EOF
+  chmod +x "$MOCK_DIR/git"
+  write_tea_mock
+}
+
+# assert_json <label> <jq-test-expr> <output>
+assert_json() {
+  local label="$1" expr="$2" out="$3"
+  if ! echo "$out" | jq -e . >/dev/null 2>&1; then
+    fail "$label" "not valid JSON: out=$out stderr=$(cat "$MOCK_DIR/stderr")"
+  elif [[ "$(
+    echo "$out" | jq -e "$expr" >/dev/null 2>&1
+    echo $?
+  )" == "0" ]]; then
+    pass "$label"
+  else
+    fail "$label" "assertion '$expr' failed: out=$out"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Per-platform test battery
+# ---------------------------------------------------------------------------
+
+run_battery() {
+  local plat="$1"
+  echo "── write-command JSON: $plat ──"
+
+  local label out rc
+
+  label="[$plat] issue create -> {number,url}"
+  if ! skip_filter "$label"; then
+    out=$(run_cli issue create --title "x" --body "b") || true
+    assert_json "$label" '.number == 42 and (.url | test("/issues/42$"))' "$out"
+  fi
+
+  label="[$plat] issue comment add -> {id,author,body}"
+  if ! skip_filter "$label"; then
+    out=$(run_cli issue comment 5 --body "hello") || true
+    assert_json "$label" '.id == 101 and .author == "alice" and .body == "hello"' "$out"
+  fi
+
+  label="[$plat] issue comment list -> [{id},...]"
+  if ! skip_filter "$label"; then
+    out=$(run_cli issue comment list 5) || true
+    assert_json "$label" '(type == "array") and (length == 2) and (.[0].id == 101)' "$out"
+  fi
+
+  label="[$plat] issue comment delete -> {deleted,id}"
+  if ! skip_filter "$label"; then
+    out=$(run_cli issue comment delete 99) || true
+    assert_json "$label" '.deleted == true and .id == 99' "$out"
+  fi
+
+  label="[$plat] issue comment edit -> {id,body}"
+  if ! skip_filter "$label"; then
+    out=$(run_cli issue comment edit 101 --body "edited") || true
+    assert_json "$label" '.id == 101 and .body == "edited"' "$out"
+  fi
+
+  label="[$plat] pr create -> {number,url}"
+  if ! skip_filter "$label"; then
+    out=$(run_cli pr create --title "x" --head feat --base main --body "b") || true
+    assert_json "$label" '.number == 7 and (.url | test("/(pull|pulls)/7$"))' "$out"
+  fi
+
+  label="[$plat] pr comment add -> {id,body}"
+  if ! skip_filter "$label"; then
+    out=$(run_cli pr comment 5 --body "hello") || true
+    assert_json "$label" '.id == 101 and .body == "hello"' "$out"
+  fi
+
+  label="[$plat] api passthrough -> raw backend JSON"
+  if ! skip_filter "$label"; then
+    out=$(run_cli api "repos/{owner}/{repo}/__ping__") || true
+    assert_json "$label" '.pong == true' "$out"
+  fi
+
+  label="[$plat] api rejects leading flag (path must come first)"
+  if ! skip_filter "$label"; then
+    rc=0
+    run_cli api -X GET >/dev/null || rc=$?
+    if [[ "$rc" == "1" ]]; then pass "$label"; else fail "$label" "exit=$rc"; fi
+  fi
+}
+
+set_platform_github
+run_battery "github"
+set_platform_gitea
+run_battery "gitea"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Total: $((PASS + FAIL))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -9,6 +9,7 @@
 #   git-tools issue show   <N>
 #   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
 #   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+#   git-tools issue comment list <N> | delete <id> | edit <id> [--body ...]
 #   git-tools issue close  <N>
 #   git-tools issue reopen <N>
 #
@@ -32,7 +33,11 @@
 #   git-tools repo info
 #   git-tools user whoami
 #
-# Output: normalized JSON (arrays or objects) regardless of platform.
+#   git-tools api <path> [-X METHOD] [-f key=val ...]  (raw passthrough; path first)
+#
+# Output: normalized JSON (arrays or objects) regardless of platform. Write
+# commands return JSON too: create -> {number, url}; comment -> the comment
+# object {id, author, body, html_url, created_at}. `api` returns RAW backend JSON.
 # Exit codes: 0 success, 1 usage error, 2 platform detection failure,
 #             3 CLI not found, 4 command failed
 
@@ -124,6 +129,27 @@ parse_body_args() {
   if [[ "$read_stdin" == "1" ]]; then
     read_body_from_stdin
   fi
+}
+
+# jq filter normalizing a single comment object. GitHub and Gitea both return
+# REST-shaped comments with the same field names (id, body, html_url, user,
+# created_at), so one filter serves both backends for add/list/edit.
+COMMENT_JQ='{id, author: (.user.login // .user // ""), body, html_url: (.html_url // ""), created_at}'
+
+# Emit {number, url} JSON from a create command's human output by scraping the
+# first issue/PR URL it printed. Used by issue/pr create so write commands return
+# parseable JSON instead of gh/tea's human-rendered text. Dies with the raw
+# output if no URL is found (so a silent format change surfaces loudly).
+emit_created_json() {
+  local raw="$1" url num
+  url=$(printf '%s\n' "$raw" \
+    | grep -oiE 'https?://[^[:space:]]+/(issues?|pulls?)/[0-9]+' \
+    | head -n1 || true)
+  [[ -n "$url" ]] || die "could not parse created object URL from output: $raw"
+  num="${url##*/}"
+  # The regex guarantees a trailing [0-9]+, so number is always a true integer.
+  jq -n --arg number "$num" --arg url "$url" \
+    '{number: ($number | tonumber), url: $url}'
 }
 
 # ---------------------------------------------------------------------------
@@ -389,26 +415,73 @@ case "$cmd:$sub" in
         [[ -n "$BODY"     ]] && args+=(--body "$BODY")
         [[ -n "$label"    ]] && args+=(--label "$label")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        GH_NO_COLOR=1 gh issue create "${args[@]}"
+        # Keep the CLI call (preserves --label by name; the Gitea REST create
+        # endpoint requires numeric label IDs) and normalize its URL to JSON.
+        out=$(GH_NO_COLOR=1 gh issue create "${args[@]}") || die "gh issue create failed"
+        emit_created_json "$out"
         ;;
       gitea)
         args=(--title "$title")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
         [[ -n "$label"    ]] && args+=(--labels "$label")
         [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
-        NO_COLOR=1 tea issues create "${args[@]}"
+        out=$(NO_COLOR=1 tea issues create "${args[@]}") || die "tea issues create failed"
+        emit_created_json "$out"
         ;;
     esac
     ;;
 
   issue:comment)
-    [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment <N> [--body TEXT | --body-file FILE]"
-    num="$1"; shift
-    parse_body_args "$@"
-    [[ -n "$BODY" ]] || die_usage "issue comment requires --body or --body-file"
-    case "$PLATFORM" in
-      github) GH_NO_COLOR=1 gh issue comment "$num" --body "$BODY" ;;
-      gitea)  NO_COLOR=1 tea comment "$num" "$BODY" ;;
+    [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment <N> [--body ...] | comment list <N> | comment delete <id> | comment edit <id> [--body ...]"
+    action="$1"
+    case "$action" in
+      list)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment list <N>"
+        num="$1"; shift
+        # gh --paginate merges all comment pages into one JSON array; tea api
+        # returns only the server's default page (Gitea default 20; see SKILL.md).
+        case "$PLATFORM" in
+          github) cli_json "[.[] | $COMMENT_JQ]" env GH_NO_COLOR=1 gh api --paginate "repos/{owner}/{repo}/issues/$num/comments" ;;
+          gitea)  cli_json "[.[] | $COMMENT_JQ]" env NO_COLOR=1 tea api "repos/{owner}/{repo}/issues/$num/comments" ;;
+        esac
+        ;;
+      delete)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment delete <id>"
+        cid="$1"
+        # DELETE returns HTTP 204 with an empty body — never pipe through jq.
+        case "$PLATFORM" in
+          github) GH_NO_COLOR=1 gh api -X DELETE "repos/{owner}/{repo}/issues/comments/$cid" >/dev/null \
+                    || die "gh api DELETE issues/comments/$cid failed" ;;
+          gitea)  NO_COLOR=1 tea api -X DELETE "repos/{owner}/{repo}/issues/comments/$cid" >/dev/null \
+                    || die "tea api DELETE issues/comments/$cid failed" ;;
+        esac
+        jq -n --arg id "$cid" '{deleted: true, id: ($id | tonumber? // $id)}'
+        ;;
+      edit)
+        shift
+        [[ $# -ge 1 ]] || die_usage "usage: git-tools issue comment edit <id> [--body TEXT | --body-file FILE]"
+        cid="$1"; shift
+        parse_body_args "$@"
+        [[ -n "$BODY" ]] || die_usage "issue comment edit requires --body or --body-file"
+        case "$PLATFORM" in
+          github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X PATCH "repos/{owner}/{repo}/issues/comments/$cid" -f "body=$BODY" ;;
+          gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X PATCH "repos/{owner}/{repo}/issues/comments/$cid" -f "body=$BODY" ;;
+        esac
+        ;;
+      *)
+        # Add a comment to issue <N>. Post via REST so the response carries the
+        # new comment's id/url — a definitive success signal that prevents the
+        # silent double-posts the old human-text path caused (#142).
+        num="$action"; shift
+        parse_body_args "$@"
+        [[ -n "$BODY" ]] || die_usage "issue comment requires --body or --body-file"
+        case "$PLATFORM" in
+          github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+          gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+        esac
+        ;;
     esac
     ;;
 
@@ -522,13 +595,15 @@ case "$cmd:$sub" in
         args=(--title "$title" --head "$head" --base "$base")
         [[ -n "$BODY"     ]] && args+=(--body "$BODY")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
-        GH_NO_COLOR=1 gh pr create "${args[@]}"
+        out=$(GH_NO_COLOR=1 gh pr create "${args[@]}") || die "gh pr create failed"
+        emit_created_json "$out"
         ;;
       gitea)
         args=(--title "$title" --head "$head" --base "$base")
         [[ -n "$BODY"     ]] && args+=(--description "$BODY")
         [[ -n "$assignee" ]] && args+=(--assignees "$assignee")
-        NO_COLOR=1 tea pr create "${args[@]}"
+        out=$(NO_COLOR=1 tea pr create "${args[@]}") || die "tea pr create failed"
+        emit_created_json "$out"
         ;;
     esac
     ;;
@@ -538,11 +613,12 @@ case "$cmd:$sub" in
     num="$1"; shift
     parse_body_args "$@"
     [[ -n "$BODY" ]] || die_usage "pr comment requires --body or --body-file"
+    # A PR is an "issue" for commenting on both platforms — the comment lives at
+    # the issues/{n}/comments endpoint. Post via REST so the response carries the
+    # new comment's id/url (mirrors issue comment; kills the double-post foot-gun).
     case "$PLATFORM" in
-      # gh uses the same comment command for both issues and PRs
-      github) GH_NO_COLOR=1 gh pr comment "$num" --body "$BODY" ;;
-      # tea uses a unified comment command for both issues and PRs
-      gitea)  NO_COLOR=1 tea comment "$num" "$BODY" ;;
+      github) cli_json "$COMMENT_JQ" env GH_NO_COLOR=1 gh api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
+      gitea)  cli_json "$COMMENT_JQ" env NO_COLOR=1 tea api -X POST "repos/{owner}/{repo}/issues/$num/comments" -f "body=$BODY" ;;
     esac
     ;;
 
@@ -1291,6 +1367,28 @@ case "$cmd:$sub" in
     ;;
 
   # -------------------------------------------------------------------------
+  # API PASSTHROUGH
+  # -------------------------------------------------------------------------
+
+  api:*)
+    # Raw authenticated REST passthrough — the escape hatch for capabilities the
+    # wrapper doesn't expose, so a missing operation never forces a bypass to
+    # gh/tea directly. Output is the backend's RAW JSON (not normalized); supply
+    # your own --jq or pipe. {owner}/{repo} are substituted by gh/tea from the
+    # current remote. The <path> must come first; flags follow it:
+    #   git-tools api repos/{owner}/{repo}/issues/5/comments
+    #   git-tools api repos/{owner}/{repo}/issues/comments/123 -X DELETE
+    #   git-tools api repos/{owner}/{repo}/issues -X POST -f title=hi
+    endpoint="$sub"
+    [[ -n "$endpoint" && "$endpoint" != -* ]] \
+      || die_usage "usage: git-tools api <path> [-X METHOD] [-f key=val ...]  (path must come first)"
+    case "$PLATFORM" in
+      github) GH_NO_COLOR=1 gh api "$endpoint" "$@" ;;
+      gitea)  NO_COLOR=1 tea api "$endpoint" "$@" ;;
+    esac
+    ;;
+
+  # -------------------------------------------------------------------------
   # Help / unknown
   # -------------------------------------------------------------------------
 
@@ -1309,6 +1407,9 @@ ISSUE COMMANDS
   git-tools issue show   <N>
   git-tools issue create --title T [--body TEXT | --body-file FILE] [--label L] [--assignee U]
   git-tools issue comment <N> [--body TEXT | --body-file FILE]
+  git-tools issue comment list   <N>
+  git-tools issue comment delete <id>
+  git-tools issue comment edit   <id> [--body TEXT | --body-file FILE]
   git-tools issue close  <N>
   git-tools issue reopen <N>
 
@@ -1332,6 +1433,14 @@ REPO / USER
   git-tools repo default-branch
   git-tools repo info
   git-tools user whoami
+
+API PASSTHROUGH
+  git-tools api <path> [-X METHOD] [-f key=val ...]   raw gh/tea api call
+                                                      (path first; output NOT normalized)
+
+Write commands (issue/pr create, issue/pr comment, comment edit) return JSON:
+  create  -> {number, url}
+  comment -> {id, author, body, html_url, created_at}
 EOF
     exit 0
     ;;


### PR DESCRIPTION
## Summary

`git-cli`'s write commands (`issue`/`pr create`, `issue`/`pr comment`) printed human-rendered text instead of the normalized JSON the wrapper promises, so callers had no machine-readable success signal — which caused **silent duplicate comment posts** during a real issue migration. The wrapper also had no way to read/edit/delete comments and no generic `api` escape hatch. This adds JSON output to every write command, full comment CRUD, and a raw `api` passthrough. Resolves #142.

## Changes

- **`issue`/`pr create`** → emit `{number, url}` by capturing the CLI's URL output (keeps the CLI call so `--label` by name still works; Gitea's REST create needs label IDs).
- **`issue`/`pr comment` (add)** → POST via `gh`/`tea api` to `repos/{owner}/{repo}/issues/{n}/comments` and normalize to `{id, author, body, html_url, created_at}`. The `id` is the definitive success signal that prevents blind-retry double-posts.
- **New** `issue comment list <N>` (GET), `delete <id>` (204 → `{deleted:true,id}`), `edit <id>` (PATCH).
- **New** generic `api <path> [-X METHOD] [-f k=v …]` raw passthrough (path-first), the escape hatch when the wrapper lacks a capability.
- Updated `--help`, file header, and SKILL.md (Claude + Copilot).
- Bumped `git-tools` 2.0.13 → 2.1.0 and `session` 4.2.3 → 4.2.4 (vendors the updated util); re-synced vendored copies.

## Testing

- New `tests/git-cli/test-issue-write-json.sh` — 18 assertions across GitHub (`gh`) and Gitea (`tea`) mocks covering create, comment add/list/delete/edit, `api` passthrough, and the path-first guard.
- Updated `tests/git-cli/test-body-args.sh` for the `api`-based `pr comment` path.
- All four CI checks pass locally: `test.sh` (1789 passed), `validate-plugins.sh` (281), `validate-frontmatter.sh` (98), `rumdl` (clean).
- Read-only live verification against the real remote confirmed `api` passthrough, `comment list`, and the comment normalizer against a real comment. Mutating paths were validated via mocks only (not posted live).