### PR TITLE
fix: make git-worktree create one-shot

### DIFF
--- a/copilot-extensions/git-worktree/README.md
+++ b/copilot-extensions/git-worktree/README.md
@@ -15,6 +15,18 @@ Available native tools:
 
 The extension keeps a narrow `onPreToolUse` hook that auto-allows its own `sf_git_worktree_*` tools so Copilot does not stop to prompt on each one individually.
 
+## Intended tool usage
+
+- **Direct create request** (`create a worktree for X`) → call `sf_git_worktree_create` immediately.
+- **Inspection / troubleshooting** → call `sf_git_worktree_status`.
+- **Maybe should this be isolated?** → call `sf_git_worktree_suggest`.
+
+`sf_git_worktree_create` is intended to stand on its own. It derives the target
+path, resolves the base branch when needed, checks whether the branch is
+already checked out in another worktree, and returns either a concise success
+result or a concise blocking error. A status call should not be required before
+an explicit create request.
+
 ## User-level install / update
 
 Install or update the same extension for all repos with:
@@ -42,4 +54,8 @@ copilot-git-worktree-allow /path/to/repo
 
 ## Behavior
 
-The extension keeps `git` as the source of truth. The JS layer provides tool registration, status normalization, suggestion logic, and session context. Create/remove flows reuse the shell scripts in `scripts/`.
+The extension keeps `git` as the source of truth. The JS layer provides tool
+registration, status normalization, suggestion logic, and session context.
+Create/remove flows reuse the shell scripts in `scripts/`. The create path is
+designed to be self-sufficient rather than relying on follow-up inspection
+calls.

--- a/copilot-extensions/git-worktree/extension.mjs
+++ b/copilot-extensions/git-worktree/extension.mjs
@@ -28,18 +28,7 @@ async function handleCreate({ branchName, fromBranch, cwd }) {
         return summarizeCommandFailure("git worktree create", runResult);
     }
 
-    const status = await getWorktreeStatus({ cwd: resolveCwd(cwd) });
-    const created = status.ok
-        ? status.linkedWorktrees.find((worktree) => worktree.branch === branchName)
-        : null;
-
-    return [
-        `Created linked worktree for branch ${branchName}.`,
-        created ? `Path: ${created.path}` : null,
-        runResult.stdout || null,
-    ]
-        .filter(Boolean)
-        .join("\n");
+    return runResult.stdout || `Created linked worktree for branch ${branchName}.`;
 }
 
 async function handleRemove({ target, deleteBranch, force, cwd }) {
@@ -99,7 +88,7 @@ await joinSession({
         {
             name: "sf_git_worktree_create",
             description:
-                "Create a linked git worktree under .github/worktrees/<slug> for parallel work. Supports optional fromBranch. Use for create worktree / parallel checkout requests.",
+                "Create a linked git worktree in one call under .github/worktrees/<slug>. This is the default tool for explicit create-worktree requests: it derives the path, resolves the base branch when needed, checks whether the branch is already checked out elsewhere, and either creates the worktree or returns a concise blocking error. Use status only for inspection, not as a prerequisite to create.",
             parameters: {
                 type: "object",
                 properties: {

--- a/copilot-extensions/git-worktree/scripts/worktree-create.sh
+++ b/copilot-extensions/git-worktree/scripts/worktree-create.sh
@@ -12,7 +12,8 @@
 # Override the base location with WORKTREE_BASE_DIR.
 #
 # If the branch already exists, attaches it. If it doesn't exist, creates it
-# from <base-branch> (defaults to current branch).
+# from <base-branch>. Without --from, new branches default to the current
+# branch; when HEAD is detached they default to the repo's default branch.
 
 set -euo pipefail
 
@@ -72,15 +73,48 @@ BASE_DIR=$(worktree_base_dir)
 SLUG=$(slug_from_branch "$BRANCH")
 WT_PATH="${BASE_DIR}/${SLUG}"
 
-if [[ -d "$WT_PATH" ]]; then
-  echo "Error: worktree directory already exists: $WT_PATH" >&2
+if [[ -z "$SLUG" ]]; then
+  echo "Error: branch name '$BRANCH' does not produce a usable worktree slug." >&2
   exit 1
 fi
 
-# --- Check if branch exists ---
-branch_exists() {
-  git rev-parse --verify "refs/heads/$1" >/dev/null 2>&1
-}
+if [[ -e "$WT_PATH" ]]; then
+  echo "Error: target worktree path already exists: $WT_PATH" >&2
+  exit 1
+fi
+
+if EXISTING_PATH=$(worktree_path_for_branch "$BRANCH" 2>/dev/null); [[ -n "$EXISTING_PATH" ]]; then
+  echo "Error: branch '$BRANCH' is already checked out in another worktree: $EXISTING_PATH" >&2
+  exit 1
+fi
+
+BASE_REF=""
+BASE_REASON=""
+
+if ! branch_exists "$BRANCH"; then
+  if [[ -n "$FROM_BRANCH" ]]; then
+    BASE_REF="$FROM_BRANCH"
+    BASE_REASON="explicit base"
+  else
+    CURRENT_BRANCH=$(current_branch || true)
+    if [[ -n "$CURRENT_BRANCH" ]]; then
+      BASE_REF="$CURRENT_BRANCH"
+      BASE_REASON="current branch"
+    else
+      BASE_REF=$(default_base_ref || true)
+      if [[ -z "$BASE_REF" ]]; then
+        echo "Error: HEAD is detached and no default branch could be resolved. Re-run with --from <base-branch>." >&2
+        exit 1
+      fi
+      BASE_REASON="default branch"
+    fi
+  fi
+
+  if ! ref_exists "$BASE_REF"; then
+    echo "Error: base ref '$BASE_REF' does not exist." >&2
+    exit 1
+  fi
+fi
 
 # --- Ensure the in-repo base dir is gitignored (skip if user overrode the location) ---
 if [[ -z "${WORKTREE_BASE_DIR:-}" ]]; then
@@ -100,25 +134,18 @@ mkdir -p "$BASE_DIR"
 
 # --- Create worktree ---
 if branch_exists "$BRANCH"; then
-  # Branch already exists — check it out in the new worktree
   git worktree add "$WT_PATH" "$BRANCH"
+  HEAD_SHA=$(git -C "$WT_PATH" rev-parse --short HEAD 2>/dev/null || true)
+  echo "Created linked worktree for branch $BRANCH."
+  echo "Path: $WT_PATH"
+  [[ -n "$HEAD_SHA" ]] && echo "HEAD: $HEAD_SHA"
 else
-  # Create new branch
-  if [[ -n "$FROM_BRANCH" ]]; then
-    git worktree add "$WT_PATH" -b "$BRANCH" "$FROM_BRANCH"
-  else
-    git worktree add "$WT_PATH" -b "$BRANCH"
-  fi
+  git worktree add "$WT_PATH" -b "$BRANCH" "$BASE_REF"
+  HEAD_SHA=$(git -C "$WT_PATH" rev-parse --short HEAD 2>/dev/null || true)
+  echo "Created linked worktree for branch $BRANCH."
+  echo "Path: $WT_PATH"
+  echo "Base: $BASE_REASON $BASE_REF"
+  [[ -n "$HEAD_SHA" ]] && echo "HEAD: $HEAD_SHA"
 fi
 
-echo ""
-echo "✓ Worktree created:"
-echo "  Path:   $WT_PATH"
-echo "  Branch: $BRANCH"
-echo ""
-echo "To work in this worktree, run commands with the path prefix, for example:"
-echo "  cd $WT_PATH && git status"
-echo "  cd $WT_PATH && <your commands>"
-echo ""
-echo "To clean up when done:"
-echo "  git worktree remove $WT_PATH"
+echo "Use it with: cd $WT_PATH"

--- a/copilot-extensions/git-worktree/scripts/worktree-lib.sh
+++ b/copilot-extensions/git-worktree/scripts/worktree-lib.sh
@@ -45,23 +45,59 @@ slug_from_branch() {
     sed 's/[^a-zA-Z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//'
 }
 
-# List all linked worktrees (excludes the main worktree).
+# Returns 0 if the local branch exists, 1 otherwise.
+branch_exists() {
+  git rev-parse --verify "refs/heads/$1" >/dev/null 2>&1
+}
+
+# Returns 0 if the ref resolves to a commit, 1 otherwise.
+ref_exists() {
+  git rev-parse --verify "$1^{commit}" >/dev/null 2>&1
+}
+
+# Returns the current branch name, or nothing when HEAD is detached.
+current_branch() {
+  git branch --show-current 2>/dev/null
+}
+
+# Returns the best default base ref for new work:
+# - prefer origin/HEAD (for example origin/main)
+# - then origin/main or origin/master if present
+# - then local main or master
+default_base_ref() {
+  local ref=""
+
+  ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [[ -n "$ref" ]]; then
+    echo "$ref"
+    return 0
+  fi
+
+  for ref in origin/main origin/master main master; do
+    if ref_exists "$ref"; then
+      echo "$ref"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# List all worktrees, including the main worktree.
 # Output format: <path>\t<branch>\t<hash>
 # Branch is "detached" if HEAD is detached.
-list_worktrees() {
-  local path="" branch="" hash="" seen_count=0
+worktree_records() {
+  local path="" branch="" hash=""
 
   while IFS= read -r line; do
     case "$line" in
       "worktree "*)
-        # Flush the previous block, skipping the first (main worktree, seen_count=1 at flush time)
-        if [[ -n "$path" && "$seen_count" -gt 1 ]]; then
+        if [[ -n "$path" ]]; then
           printf '%s\t%s\t%s\n' "$path" "${branch:-unknown}" "${hash:-unknown}"
         fi
         path="${line#worktree }"
         branch=""
         hash=""
-        ((seen_count++)) || true
         ;;
       "HEAD "*)
         hash="${line#HEAD }"
@@ -72,13 +108,31 @@ list_worktrees() {
       "detached")
         branch="detached"
         ;;
+      "")
+        if [[ -n "$path" ]]; then
+          printf '%s\t%s\t%s\n' "$path" "${branch:-unknown}" "${hash:-unknown}"
+        fi
+        path=""
+        branch=""
+        hash=""
+        ;;
     esac
-  done < <(git worktree list --porcelain 2>/dev/null)
+  done < <(git worktree list --porcelain 2>/dev/null; printf '\n')
+}
 
-  # Flush last block if it's a linked worktree (seen_count > 1 means we saw at least 2 blocks)
-  if [[ -n "$path" && "$seen_count" -gt 1 ]]; then
-    printf '%s\t%s\t%s\n' "$path" "${branch:-unknown}" "${hash:-unknown}"
-  fi
+# List all linked worktrees (excludes the main worktree).
+# Output format: <path>\t<branch>\t<hash>
+list_worktrees() {
+  local path="" branch="" hash=""
+  local first=true
+
+  while IFS=$'\t' read -r path branch hash; do
+    if [[ "$first" == true ]]; then
+      first=false
+      continue
+    fi
+    printf '%s\t%s\t%s\n' "$path" "$branch" "$hash"
+  done < <(worktree_records)
 }
 
 # Returns 0 if <target> is within any registered worktree path, 1 otherwise.
@@ -101,17 +155,25 @@ is_worktree_path() {
 # Returns the branch currently checked out in a worktree at <path>.
 branch_for_worktree() {
   local wt_path="$1"
-  local path="" branch=""
-  while IFS= read -r line; do
-    case "$line" in
-      "worktree "*) path="${line#worktree }" ;;
-      "branch "*) branch="${line#branch refs/heads/}" ;;
-      "")
-        if [[ "$path" == "$wt_path" ]]; then
-          echo "$branch"
-          return 0
-        fi
-        ;;
-    esac
-  done < <(git worktree list --porcelain 2>/dev/null)
+  local path="" branch="" hash=""
+
+  while IFS=$'\t' read -r path branch hash; do
+    if [[ "$path" == "$wt_path" ]]; then
+      echo "$branch"
+      return 0
+    fi
+  done < <(worktree_records)
+}
+
+# Returns the worktree path currently using <branch>, if any.
+worktree_path_for_branch() {
+  local target_branch="$1"
+  local path="" branch="" hash=""
+
+  while IFS=$'\t' read -r path branch hash; do
+    if [[ "$branch" == "$target_branch" ]]; then
+      echo "$path"
+      return 0
+    fi
+  done < <(worktree_records)
 }

--- a/tests/git-worktree/test-create-remove.sh
+++ b/tests/git-worktree/test-create-remove.sh
@@ -59,6 +59,17 @@ assert_dir_gone() {
   fi
 }
 
+assert_output_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle" 2>/dev/null; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s (missing: %s)\n" "$label" "$needle"
+    ((FAIL++)) || true
+  fi
+}
+
 rm -rf "$SCRATCH_ROOT"
 mkdir -p "$SCRATCH_ROOT"
 trap 'rm -rf "$SCRATCH_ROOT"' EXIT
@@ -76,10 +87,42 @@ export WORKTREE_BASE_DIR="$SCRATCH_ROOT/my-project-worktrees"
 
 echo "── worktree-create.sh ──"
 WT_PATH="$WORKTREE_BASE_DIR/feature-auth"
-assert_ok "create new worktree" bash "$CREATE_SCRIPT" "feature/auth"
+CREATE_OUTPUT=$(bash "$CREATE_SCRIPT" "feature/auth" 2>&1)
+if [[ $? -eq 0 ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "create new worktree"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s (command failed)\n" "create new worktree"
+  ((FAIL++)) || true
+fi
 assert_dir_exists "worktree directory created" "$WT_PATH"
 assert_ok "branch exists in worktree" git -C "$WT_PATH" rev-parse --verify "refs/heads/feature/auth"
+assert_output_contains "create output reports path" "Path: $WT_PATH" "$CREATE_OUTPUT"
+assert_output_contains "create output reports usage" "Use it with: cd $WT_PATH" "$CREATE_OUTPUT"
 assert_fail "create duplicate fails" bash "$CREATE_SCRIPT" "feature/auth"
+
+echo "── explicit base branch ──"
+git checkout -q -b release/base
+echo "release" >"$MAIN_REPO/release.txt"
+git -C "$MAIN_REPO" add release.txt
+git -C "$MAIN_REPO" commit -q -m "release base"
+git checkout -q -
+EXPLICIT_OUTPUT=$(bash "$CREATE_SCRIPT" "feature/from-base" --from "release/base" 2>&1)
+WT_BASE_PATH="$WORKTREE_BASE_DIR/feature-from-base"
+assert_dir_exists "explicit-base worktree created" "$WT_BASE_PATH"
+assert_output_contains "explicit base reported" "Base: explicit base release/base" "$EXPLICIT_OUTPUT"
+assert_ok "explicit-base worktree contains base file" test -f "$WT_BASE_PATH/release.txt"
+
+echo "── branch already checked out elsewhere ──"
+MANUAL_PATH="$SCRATCH_ROOT/manual-existing"
+git worktree add -q "$MANUAL_PATH" -b "feature/existing"
+EXISTING_OUTPUT=$(bash "$CREATE_SCRIPT" "feature/existing" 2>&1 || true)
+assert_output_contains "existing branch reports occupied worktree" "already checked out in another worktree: $MANUAL_PATH" "$EXISTING_OUTPUT"
+
+echo "── occupied target path ──"
+mkdir -p "$WORKTREE_BASE_DIR/feature-path-conflict"
+PATH_CONFLICT_OUTPUT=$(bash "$CREATE_SCRIPT" "feature/path-conflict" 2>&1 || true)
+assert_output_contains "occupied path reports blocking error" "target worktree path already exists: $WORKTREE_BASE_DIR/feature-path-conflict" "$PATH_CONFLICT_OUTPUT"
 
 echo "── worktree-list.sh ──"
 OUTPUT=$(bash "$LIST_SCRIPT" 2>/dev/null)
@@ -94,6 +137,8 @@ fi
 echo "── worktree-remove.sh ──"
 assert_ok "remove by slug" bash "$REMOVE_SCRIPT" "feature-auth"
 assert_dir_gone "worktree directory removed" "$WT_PATH"
+assert_ok "remove explicit-base worktree by slug" bash "$REMOVE_SCRIPT" "feature-from-base"
+assert_dir_gone "explicit-base worktree removed" "$WT_BASE_PATH"
 assert_fail "remove non-existent worktree fails" bash "$REMOVE_SCRIPT" "nonexistent"
 
 echo "── create → remove --delete-branch ──"

--- a/tests/git-worktree/test-extension.sh
+++ b/tests/git-worktree/test-extension.sh
@@ -45,6 +45,17 @@ assert_ok() {
   fi
 }
 
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! echo "$haystack" | grep -qF "$needle" 2>/dev/null; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s (unexpected: %s)\n" "$label" "$needle"
+    ((FAIL++)) || true
+  fi
+}
+
 EXT_CONTENT=$(cat "$EXT_FILE")
 
 echo "── extension registration ──"
@@ -55,6 +66,10 @@ assert_contains "registers create tool" "sf_git_worktree_create" "$EXT_CONTENT"
 assert_contains "registers remove tool" "sf_git_worktree_remove" "$EXT_CONTENT"
 assert_contains "registers suggest tool" "sf_git_worktree_suggest" "$EXT_CONTENT"
 assert_contains "auto-allows native tools" 'permissionDecision: "allow"' "$EXT_CONTENT"
+assert_contains "create tool advertises one-call path" "Create a linked git worktree in one call" "$EXT_CONTENT"
+assert_contains "create tool says status is not required first" "Use status only for inspection, not as a prerequisite to create" "$EXT_CONTENT"
+assert_not_contains "create handler avoids linked-worktree lookup" "linkedWorktrees.find((worktree) => worktree.branch === branchName)" "$EXT_CONTENT"
+assert_contains "create handler returns script output directly" 'return runResult.stdout || `Created linked worktree for branch ${branchName}.`;' "$EXT_CONTENT"
 
 if echo "$EXT_CONTENT" | grep -q 'console\.log'; then
   printf "  \033[31m✗\033[0m avoids console.log\n"

--- a/tests/git-worktree/test-lib.sh
+++ b/tests/git-worktree/test-lib.sh
@@ -78,14 +78,18 @@ assert_eq "repo_name returns dirname" "my-project" "$(repo_name)"
 echo "── worktree_base_dir ──"
 assert_eq "default base dir is .github/worktrees in main repo" "$MAIN_REPO/.github/worktrees" "$(worktree_base_dir)"
 assert_eq "WORKTREE_BASE_DIR override" "/custom/path" "$(WORKTREE_BASE_DIR=/custom/path worktree_base_dir)"
+assert_true "default_base_ref resolves something usable" test -n "$(default_base_ref)"
 
-echo "── list_worktrees / is_worktree_path ──"
+echo "── worktree helpers ──"
 WT_PATH="$SCRATCH_ROOT/my-project-worktrees/test-branch"
 mkdir -p "$(dirname "$WT_PATH")"
 git worktree add -b test-branch "$WT_PATH" >/dev/null 2>&1
 
 COUNT=$(list_worktrees | wc -l | tr -d ' ')
 assert_eq "list_worktrees returns 1 entry" "1" "$COUNT"
+assert_eq "worktree_path_for_branch finds linked worktree" "$WT_PATH" "$(worktree_path_for_branch "test-branch")"
+assert_true "branch_exists sees created branch" branch_exists "test-branch"
+assert_true "ref_exists sees HEAD" ref_exists "HEAD"
 assert_true "is_worktree_path: exact match" is_worktree_path "$WT_PATH"
 assert_true "is_worktree_path: subpath" is_worktree_path "$WT_PATH/src/file.txt"
 assert_false "is_worktree_path: unrelated path" is_worktree_path "$SCRATCH_ROOT/other"


### PR DESCRIPTION
## Summary

Make the standalone Copilot git-worktree extension handle explicit create requests in one native call.

## Changes

- make `sf_git_worktree_create` the explicit direct-create path and return script output directly
- move branch, base-ref, path, and existing-worktree preflight into the native create script and shared helpers
- add regression coverage for explicit base refs, occupied paths, and branches already checked out in other worktrees

## Testing

- `bash tests/git-worktree/test-lib.sh`
- `bash tests/git-worktree/test-create-remove.sh`
- `bash tests/git-worktree/test-extension.sh`
- `bash tests/git-worktree/test-docs.sh`
- `bash .github/scripts/validate-plugins.sh`
- `bash .github/scripts/validate-frontmatter.sh`