### PR TITLE
feat(session): auto-approve reads of a plugin's own bundled files

### DIFF
--- a/plugins-claude/convert-doc/scripts/approve-own-scripts.sh
+++ b/plugins-claude/convert-doc/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/convert-doc/scripts/approve-own-scripts.sh
+++ b/plugins-claude/convert-doc/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/elevated-edit/scripts/approve-own-scripts.sh
+++ b/plugins-claude/elevated-edit/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/elevated-edit/scripts/approve-own-scripts.sh
+++ b/plugins-claude/elevated-edit/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/format-on-save/scripts/approve-own-scripts.sh
+++ b/plugins-claude/format-on-save/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/format-on-save/scripts/approve-own-scripts.sh
+++ b/plugins-claude/format-on-save/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/git-tools/scripts/approve-own-scripts.sh
+++ b/plugins-claude/git-tools/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/git-tools/scripts/approve-own-scripts.sh
+++ b/plugins-claude/git-tools/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/image/scripts/approve-own-scripts.sh
+++ b/plugins-claude/image/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/image/scripts/approve-own-scripts.sh
+++ b/plugins-claude/image/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/java-toolkit/scripts/approve-own-scripts.sh
+++ b/plugins-claude/java-toolkit/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/java-toolkit/scripts/approve-own-scripts.sh
+++ b/plugins-claude/java-toolkit/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/kb-capture/scripts/approve-own-scripts.sh
+++ b/plugins-claude/kb-capture/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/kb-capture/scripts/approve-own-scripts.sh
+++ b/plugins-claude/kb-capture/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/markdown/scripts/approve-own-scripts.sh
+++ b/plugins-claude/markdown/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/markdown/scripts/approve-own-scripts.sh
+++ b/plugins-claude/markdown/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/notify-on-stop/scripts/approve-own-scripts.sh
+++ b/plugins-claude/notify-on-stop/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/notify-on-stop/scripts/approve-own-scripts.sh
+++ b/plugins-claude/notify-on-stop/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/permission-manager/scripts/approve-own-scripts.sh
+++ b/plugins-claude/permission-manager/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/permission-manager/scripts/approve-own-scripts.sh
+++ b/plugins-claude/permission-manager/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/session-history-analyzer/scripts/approve-own-scripts.sh
+++ b/plugins-claude/session-history-analyzer/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/session-history-analyzer/scripts/approve-own-scripts.sh
+++ b/plugins-claude/session-history-analyzer/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/hooks/hooks.json
+++ b/plugins-claude/session/hooks/hooks.json
@@ -1,9 +1,18 @@
 {
-  "description": "Auto-approve this plugin's own scripts",
+  "description": "Auto-approve this plugin's own scripts and reads of its own bundled files",
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob|Grep",
         "hooks": [
           {
             "type": "command",

--- a/plugins-claude/session/scripts/approve-own-scripts.sh
+++ b/plugins-claude/session/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/session/scripts/approve-own-scripts.sh
+++ b/plugins-claude/session/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/statusline/scripts/approve-own-scripts.sh
+++ b/plugins-claude/statusline/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/statusline/scripts/approve-own-scripts.sh
+++ b/plugins-claude/statusline/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/stl-game-config/scripts/approve-own-scripts.sh
+++ b/plugins-claude/stl-game-config/scripts/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-claude/stl-game-config/scripts/approve-own-scripts.sh
+++ b/plugins-claude/stl-game-config/scripts/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/tests/approve-own-scripts/test-approve-own-scripts.sh
+++ b/tests/approve-own-scripts/test-approve-own-scripts.sh
@@ -252,6 +252,70 @@ else
   ((FAIL++)) || true
 fi
 
+# ===== Read/Glob/Grep: auto-approve reads of the plugin's own bundled files =====
+# Read carries the target in file_path; Glob/Grep use path. The hook allows any
+# target under the plugin root and falls through otherwise.
+#
+# run_read_test EXPECTED TOOL FIELD VALUE [FORMAT] [PLUGIN_ROOT]
+run_read_test() {
+  # Note: ${6-default} (no colon) so an explicit empty arg stays empty — that's
+  # how the "no plugin root → defer" case is exercised.
+  local expected="$1" tool="$2" field="$3" value="$4" format="${5:-claude}" plugin_root="${6-$FAKE_PLUGIN_ROOT}"
+  local label="$tool $field=$value"
+  label="$label${format:+ [$format]}"
+  [[ "$format" == "claude" ]] && label="$tool $field=$value"
+
+  local payload raw result env_var="CLAUDE_PLUGIN_ROOT"
+  if [[ "$format" == "copilot" ]]; then
+    env_var="COPILOT_PLUGIN_ROOT"
+    local args_json
+    args_json=$(jq -n --arg f "$field" --arg v "$value" '{($f):$v}' | jq -c '.')
+    payload=$(jq -n --arg t "${tool,,}" --arg a "$args_json" '{"toolName":$t,"toolArgs":$a}')
+  else
+    payload=$(jq -n --arg t "$tool" --arg f "$field" --arg v "$value" \
+      '{tool_name:$t,tool_input:{($f):$v},hook_event_name:"PreToolUse",permission_mode:"default"}')
+  fi
+
+  local cmd_env=(env -i HOME="$HOME" PATH="$PATH")
+  [[ -n "$plugin_root" ]] && cmd_env+=("$env_var=$plugin_root")
+  raw=$(echo "$payload" | "${cmd_env[@]}" bash "$HOOK_SCRIPT" 2>/dev/null) || true
+
+  if [[ -z "$raw" ]]; then
+    result="none"
+  elif [[ "$format" == "copilot" ]]; then
+    result=$(echo "$raw" | jq -r '.permissionDecision // "none"')
+  else
+    result=$(echo "$raw" | jq -r '.hookSpecificOutput.permissionDecision // "none"')
+  fi
+
+  if [[ "$result" == "$expected" ]]; then
+    printf "  \033[32m✓\033[0m %s\n" "$label"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s  (expected: %s, got: %s)\n" "$label" "$expected" "$result"
+    ((FAIL++)) || true
+  fi
+}
+
+echo "── Read/Glob/Grep own files (must ALLOW) ──"
+run_read_test allow Read file_path "$FAKE_PLUGIN_ROOT/reference/spine.md"
+run_read_test allow Read file_path "$FAKE_PLUGIN_ROOT/reference/spine.md" copilot
+run_read_test allow Read file_path "$FAKE_PLUGIN_ROOT/skills/foo/SKILL.md"
+run_read_test allow Glob path "$FAKE_PLUGIN_ROOT/reference"
+run_read_test allow Grep path "$FAKE_PLUGIN_ROOT/scripts"
+run_read_test allow Grep path "$FAKE_PLUGIN_ROOT/scripts" copilot
+
+echo "── Read/Glob/Grep other paths (fall-through) ──"
+run_read_test none Read file_path "/data/workspace/project/CLAUDE.md"
+run_read_test none Read file_path "/data/workspace/project/CLAUDE.md" copilot
+run_read_test none Read file_path "${FAKE_PLUGIN_ROOT}-evil/secret"
+run_read_test none Read file_path "$FAKE_PLUGIN_ROOT/../../../etc/passwd"
+run_read_test none Grep path "/etc"
+# A pathless Grep (project-wide search) must defer, not blanket-allow.
+run_read_test none Grep pattern "TODO"
+# No plugin root → can't classify ownership → defer.
+run_read_test none Read file_path "$FAKE_PLUGIN_ROOT/reference/spine.md" claude ""
+
 # ===== Summary =====
 echo ""
 echo "Total: $((PASS + FAIL + SKIP))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"

--- a/utils/approve-own-scripts.sh
+++ b/utils/approve-own-scripts.sh
@@ -54,21 +54,22 @@ source "$(dirname "$0")/hook-compat.sh"
 
 # CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
 # to the installed plugin directory. If neither is set, we can't determine
-# which files belong to this plugin — fall through for every tool.
+# which files belong to this plugin. We resolve it here but DON'T exit yet:
+# the Bash PR-publish guard below must fire even when the root is unknown.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 # --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
-# Read carries the target in file_path; Glob/Grep use path. hook-compat already
-# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+# Read carries the target in file_path; Glob/Grep use path. Pull whichever is
+# present directly from the payload — `// empty` collapses both "missing key"
+# and JSON null so a pathless Grep yields an empty string (we don't lean on
+# HOOK_FILE_PATH here: its copilot path renders a missing key as "null").
 if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
-  read_target="$HOOK_FILE_PATH"
-  if [[ -z "$read_target" ]]; then
-    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
-      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
-    else
-      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
-    fi
+  # Without a plugin root we can't tell which files are "ours" — defer.
+  [[ -n "$PLUGIN_ROOT" ]] || exit 0
+  if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+    read_target=$(echo "$HOOK_INPUT" | jq -r 'try ((.toolArgs | fromjson) | (.file_path // .path // empty)) catch empty' 2>/dev/null || echo "")
+  else
+    read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
   fi
   # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
   [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
@@ -105,6 +106,10 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
+
+# The scripts-dir match below needs a known plugin root; the VCS guard above
+# did not. Defer now if we still don't have one.
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 

--- a/utils/approve-own-scripts.sh
+++ b/utils/approve-own-scripts.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
-# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own scripts.
+# approve-own-scripts.sh — PreToolUse hook to auto-approve a plugin's own files.
 #
-# Place in a plugin's hooks.json as a PreToolUse hook for Bash.
-# Auto-allows any Bash command whose executable path starts with the
-# plugin's scripts/ directory. Falls through (exit 0, no output) for
-# commands that don't match, letting other hooks or the user decide.
+# Two jobs, by tool:
+#   Bash             — auto-allow any command whose executable lives under the
+#                      plugin's scripts/ directory (and guard outward PR publish).
+#   Read|Glob|Grep   — auto-allow reading any file under the plugin's own root.
+#                      Plugins live in an out-of-workspace install cache, so a
+#                      skill that Reads its own ${CLAUDE_PLUGIN_ROOT}/reference/*
+#                      otherwise prompts the user on every invocation.
 #
-# Claude Code hooks.json:
+# Falls through (exit 0, no output) for anything that doesn't match, letting
+# other hooks or the user decide.
+#
+# Claude Code hooks.json — register for both tool groups:
 #   {
 #     "hooks": {
-#       "PreToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-#         }]
-#       }]
+#       "PreToolUse": [
+#         {
+#           "matcher": "Bash",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         },
+#         {
+#           "matcher": "Read|Glob|Grep",
+#           "hooks": [{
+#             "type": "command",
+#             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+#           }]
+#         }
+#       ]
 #     }
 #   }
 #
-# Copilot CLI hooks.json:
+# Copilot CLI hooks.json (preToolUse has no matcher — the script self-filters
+# by tool name, so a single entry covers both groups):
 #   {
 #     "version": 1,
 #     "hooks": {
@@ -35,6 +51,32 @@ set -euo pipefail
 HOOK_INPUT=$(cat)
 # shellcheck source=hook-compat.sh
 source "$(dirname "$0")/hook-compat.sh"
+
+# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
+# to the installed plugin directory. If neither is set, we can't determine
+# which files belong to this plugin — fall through for every tool.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
+[[ -n "$PLUGIN_ROOT" ]] || exit 0
+
+# --- Read/Glob/Grep: auto-approve reads of this plugin's own bundled files ---
+# Read carries the target in file_path; Glob/Grep use path. hook-compat already
+# normalized file_path into HOOK_FILE_PATH; pull path only if that's empty.
+if [[ "$HOOK_TOOL_NAME" == "Read" || "$HOOK_TOOL_NAME" == "Glob" || "$HOOK_TOOL_NAME" == "Grep" ]]; then
+  read_target="$HOOK_FILE_PATH"
+  if [[ -z "$read_target" ]]; then
+    if [[ "$HOOK_FORMAT" == "copilot" ]]; then
+      read_target=$(echo "$HOOK_INPUT" | jq -r 'try (.toolArgs | fromjson | .path) catch ""' 2>/dev/null || echo "")
+    else
+      read_target=$(echo "$HOOK_INPUT" | jq -r '.tool_input.path // empty')
+    fi
+  fi
+  # Empty target (e.g. a project-wide Grep with no path) or traversal: defer.
+  [[ -n "$read_target" && "$read_target" != *".."* ]] || exit 0
+  if [[ "$read_target" == "${PLUGIN_ROOT}/"* ]]; then
+    hook_allow "plugin file: ${read_target#"${PLUGIN_ROOT}/"}"
+  fi
+  exit 0
+fi
 
 [[ "$HOOK_TOOL_NAME" == "Bash" ]] || exit 0
 
@@ -63,12 +105,6 @@ if [[ "$HOOK_COMMAND" =~ (^|[[:space:]/])(gh|tea|git-cli)[[:space:]] ]] &&
   hook_ask "Confirm before publishing: this opens/merges a PR (\`pr ${BASH_REMATCH[2]}\`), which triggers CI and auto-merge. Session flows must stop for your review first — approve only if you intend to publish right now."
   exit 0
 fi
-
-# CLAUDE_PLUGIN_ROOT (Claude Code) or COPILOT_PLUGIN_ROOT (Copilot CLI) is set
-# to the installed plugin directory. If neither is set, we can't determine
-# which scripts belong to this plugin.
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${COPILOT_PLUGIN_ROOT:-}}"
-[[ -n "$PLUGIN_ROOT" ]] || exit 0
 
 SCRIPTS_DIR="${PLUGIN_ROOT}/scripts"
 


### PR DESCRIPTION
## Summary

The `session` skills Read `${CLAUDE_PLUGIN_ROOT}/reference/spine.md` as a required step of the begin-work spine. That path resolves to the out-of-workspace plugin install cache, so Claude Code's file-permission gate prompted the user **on every session**. The plugin's existing auto-approve hook only matched `Bash`, so it never saw the Read.

This generalizes the shared `approve-own-scripts.sh` hook from "approve own **scripts**" → "approve own **files**":

- New `Read`/`Glob`/`Grep` branch auto-allows any path under the plugin's own root (`${CLAUDE_PLUGIN_ROOT}/...`), with traversal rejection and empty-path fall-through. Bash handling and the outward PR-publish guard are untouched.
- `Read|Glob|Grep` matcher added to session's Claude `hooks.json`. Copilot side needs nothing — its `preToolUse` entry is matcher-less and the script self-filters by tool name.
- Re-vendored to all 14 consumers (drift-clean); `session` bumped 4.2.4 → 4.2.5 both sides.

Genuine decisions still stop and ask (orchestrate-escalation question, PR-publish confirmation) — only the "can I read my own file" prompt is removed.

## Test plan

- [x] 7 unit cases on the hook: own-file Read/Grep → allow; project file, traversal, pathless Grep → defer; own Bash script → allow; `pr create` → ask.
- [x] `utils/sync.sh --check` → no drift.
- [x] `.github/scripts/validate-plugins.sh` → 439 checks, 0 failures.
