### PR TITLE
feat(git-tools): progress-aware timeouts for pr wait & run watch

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/README.md
+++ b/plugins-claude/git-tools/README.md
@@ -28,7 +28,7 @@ claude plugin install St0nefish/agent-toolkit/git-tools
 | Repository | `default-branch`, `info` |
 | User | `whoami` |
 
-`pr wait` polls until a PR is merged/closed/blocked (default timeout: 300s). `run watch` waits for CI completion with a 60s initial delay for CI startup (default timeout: 600s).
+`pr wait` polls until a PR is merged/closed/blocked, staying alive while CI or auto-merge is still progressing (idle timeout 5 min, hard ceiling 60 min). `run watch` waits for CI completion with a 60s initial delay for CI startup (hard ceiling 60 min).
 
 ## What `ship` does
 

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -22,12 +22,12 @@
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
-#   git-tools pr wait      --branch NAME [--timeout 300] [--interval 15]
+#   git-tools pr wait      --branch NAME [--timeout 3600] [--idle-timeout 300] [--interval 15]
 #
 #   git-tools run list     [--limit N] [--status STATUS] [--branch BRANCH]
 #   git-tools run show     <run-id>
 #   git-tools run logs     <run-id> [--failed-only]
-#   git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--interval S]
+#   git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--idle-timeout S] [--interval S]
 #
 #   git-tools repo default-branch
 #   git-tools repo info
@@ -331,6 +331,56 @@ _run_failed_jobs() {
   local run_id="$1" show_json
   show_json=$("$0" run show "$run_id" 2>/dev/null) || return 0
   echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")'
+}
+
+# Progress-aware timeout decision shared by `pr wait` and `run watch`.
+# Echoes "ceiling" if the absolute deadline is hit, "idle" if the no-progress
+# window is hit, or nothing (return 1) if neither. A bound of 0 disables it.
+# A flat wall-clock timeout is the wrong primitive for CI that can run 15+
+# minutes: this lets callers keep waiting while CI is actively progressing and
+# give up only after a stretch of no progress, with a hard ceiling backstop.
+_wait_timed_out() {
+  local elapsed="$1" idle="$2" max_timeout="$3" idle_timeout="$4"
+  if [[ "$max_timeout" -gt 0 && "$elapsed" -ge "$max_timeout" ]]; then
+    echo "ceiling"; return 0
+  fi
+  if [[ "$idle_timeout" -gt 0 && "$idle" -ge "$idle_timeout" ]]; then
+    echo "idle"; return 0
+  fi
+  return 1
+}
+
+# Coarse CI status — pending|success|failure|none — for a PR/branch, used by
+# `pr wait` to tell whether CI is actively progressing. GitHub aggregates the
+# PR's statusCheckRollup; Gitea maps the latest run's status. Every API call is
+# guarded so a probe failure degrades to "none" and never aborts the wait loop.
+_ci_status() {
+  local pr_number="$1" branch="$2" view_json run_status
+  case "$PLATFORM" in
+    github)
+      view_json=$(GH_NO_COLOR=1 gh pr view "$pr_number" --json statusCheckRollup 2>/dev/null) || { echo "none"; return 0; }
+      echo "$view_json" | jq -r '
+        [.statusCheckRollup // [] | .[] |
+          if .__typename == "CheckRun" then
+            if .conclusion then (.conclusion | ascii_downcase) else "pending" end
+          else (.state // "pending" | ascii_downcase) end
+        ] |
+        if length == 0 then "none"
+        elif any(. == "failure" or . == "error" or . == "timed_out" or . == "action_required") then "failure"
+        elif all(. == "success" or . == "neutral" or . == "skipped") then "success"
+        else "pending" end' 2>/dev/null || echo "none"
+      ;;
+    gitea)
+      run_status=$("$0" run list --branch "$branch" --limit 1 2>/dev/null | jq -r '.[0].status // "none"' 2>/dev/null) || run_status="none"
+      case "$run_status" in
+        queued|in_progress|waiting|running|pending|requested) echo "pending" ;;
+        failure|timed_out|cancelled|canceled|skipped) echo "failure" ;;
+        ""|none|null) echo "none" ;;
+        *) echo "success" ;;
+      esac
+      ;;
+    *) echo "none" ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -686,12 +736,14 @@ case "$cmd:$sub" in
     ;;
 
   pr:wait)
-    branch=""; timeout=300; interval=15
+    # timeout is the hard ceiling; idle_timeout is the no-progress window.
+    branch=""; timeout=3600; idle_timeout=300; interval=15
     while [[ $# -gt 0 ]]; do
       case "$1" in
-        --branch)   [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
-        --timeout)  [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
-        --interval) [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
+        --branch)       [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
+        --timeout)      [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
+        --idle-timeout) [[ $# -gt 1 ]] || die_usage "--idle-timeout requires a value"; shift; idle_timeout="$1" ;;
+        --interval)     [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
         *) die_usage "unknown flag: $1" ;;
       esac
       shift
@@ -714,6 +766,8 @@ case "$cmd:$sub" in
     pr_number=$(echo "$pr" | jq -r '.number')
     pr_url=$(echo "$pr" | jq -r '.url // ""')
     elapsed=0
+    idle=0
+    last_signal=""
     unknown_streak=0
 
     # Poll loop
@@ -724,7 +778,22 @@ case "$cmd:$sub" in
       pr_mergeable=$(echo "$show_json" | jq -r '.mergeable // ""')
       [[ -z "$pr_url" || "$pr_url" == "null" ]] && pr_url=$(echo "$show_json" | jq -r '.url // ""')
 
-      echo "PR #$pr_number: state=$pr_state merged=$pr_merged (${elapsed}s elapsed)" >&2
+      # Progress signals: CI still running or auto-merge pending means the PR is
+      # actively advancing toward merge, so the idle clock must not count down.
+      checks=$(_ci_status "$pr_number" "$branch")
+      if [[ "$PLATFORM" == "github" ]]; then
+        auto_merge=$("$0" pr auto-merge-status --number "$pr_number" 2>/dev/null | sed -n 's/^auto_merge: //p' | head -1) || auto_merge=""
+        [[ "$auto_merge" == "true" ]] || auto_merge="false"
+      else
+        auto_merge="false"
+      fi
+      signal="$pr_state|$pr_mergeable|$checks|$auto_merge"
+      if [[ "$checks" == "pending" || "$auto_merge" == "true" || "$signal" != "$last_signal" ]]; then
+        idle=0
+      fi
+      last_signal="$signal"
+
+      echo "PR #$pr_number: state=$pr_state merged=$pr_merged checks=$checks auto_merge=$auto_merge (idle ${idle}s, ${elapsed}s elapsed)" >&2
 
       case "$pr_state" in
         merged)
@@ -778,18 +847,27 @@ case "$cmd:$sub" in
       # Reset unknown streak on any recognized state
       [[ "$pr_state" == "merged" || "$pr_state" == "closed" || "$pr_state" == "open" ]] && unknown_streak=0
 
-      # Check timeout
-      if [[ "$elapsed" -ge "$timeout" ]]; then
+      # Check timeout — only give up after a stretch of no progress (idle) or
+      # the absolute ceiling, never while CI/auto-merge is still working.
+      timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+      if [[ -n "$timeout_kind" ]]; then
+        if [[ "$timeout_kind" == "ceiling" ]]; then
+          reason="exceeded max wait ${timeout}s"
+        else
+          reason="no progress for ${idle}s"
+        fi
         echo "status: timeout"
         echo "pr_number: $pr_number"
         [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
         echo "duration: ${elapsed}s"
-        echo "Timed out after ${elapsed}s waiting for PR #$pr_number to merge" >&2
+        echo "reason: $reason"
+        echo "Timed out waiting for PR #$pr_number to merge ($reason)" >&2
         exit 2
       fi
 
       sleep "$interval"
       elapsed=$(( elapsed + interval ))
+      idle=$(( idle + interval ))
     done
     ;;
 
@@ -953,12 +1031,17 @@ case "$cmd:$sub" in
     ;;
 
   run:watch)
-    branch=""; initial_delay=60; timeout=600; interval=15
+    # timeout is the hard ceiling; idle_timeout is the no-progress backstop.
+    # While CI is actively pending the idle clock is reset each poll, so a long
+    # (15+ min) suite runs to completion up to the ceiling rather than being cut
+    # off by a flat wall-clock timeout.
+    branch=""; initial_delay=60; timeout=3600; idle_timeout=300; interval=15
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --branch)        [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
         --initial-delay) [[ $# -gt 1 ]] || die_usage "--initial-delay requires a value"; shift; initial_delay="$1" ;;
         --timeout)       [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
+        --idle-timeout)  [[ $# -gt 1 ]] || die_usage "--idle-timeout requires a value"; shift; idle_timeout="$1" ;;
         --interval)      [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
         *) die_usage "unknown flag: $1" ;;
       esac
@@ -967,6 +1050,7 @@ case "$cmd:$sub" in
     [[ -n "$branch" ]] || die_usage "run watch requires --branch"
 
     elapsed=0
+    idle=0
 
     # On GitHub, prefer PR-based status checking — one API call gives us both
     # merge state and all CI check results via statusCheckRollup, avoiding the
@@ -1188,21 +1272,30 @@ case "$cmd:$sub" in
             exit 0
             ;;
           pending)
-            # Still running — keep polling
+            # Still running — keep polling. Active CI is progress, so reset idle.
+            idle=0
             ;;
         esac
 
-        # Check timeout
-        if [[ "$elapsed" -ge "$timeout" ]]; then
+        # Check timeout — idle window or absolute ceiling (see _wait_timed_out).
+        timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+        if [[ -n "$timeout_kind" ]]; then
+          if [[ "$timeout_kind" == "ceiling" ]]; then
+            reason="exceeded max wait ${timeout}s"
+          else
+            reason="no progress for ${idle}s"
+          fi
           echo "status: timeout"
           [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
           echo "duration: ${elapsed}s"
-          echo "Timed out after ${elapsed}s waiting for CI on PR #$pr_number" >&2
+          echo "reason: $reason"
+          echo "Timed out waiting for CI on PR #$pr_number ($reason)" >&2
           exit 2
         fi
 
         sleep "$interval"
         elapsed=$(( elapsed + interval ))
+        idle=$(( idle + interval ))
       done
     fi
 
@@ -1263,7 +1356,8 @@ case "$cmd:$sub" in
       # explicitly; everything else exits.  Do NOT add a `*) keep polling`.
       case "$run_status" in
         queued|in_progress|waiting|running|pending|requested)
-          # Non-terminal — keep polling
+          # Non-terminal — keep polling. Active CI is progress, so reset idle.
+          idle=0
           ;;
         failure|timed_out)
           failed_jobs=$(_run_failed_jobs "$run_id")
@@ -1310,16 +1404,24 @@ case "$cmd:$sub" in
           ;;
       esac
 
-      if [[ "$elapsed" -ge "$timeout" ]]; then
+      timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+      if [[ -n "$timeout_kind" ]]; then
+        if [[ "$timeout_kind" == "ceiling" ]]; then
+          reason="exceeded max wait ${timeout}s"
+        else
+          reason="no progress for ${idle}s"
+        fi
         echo "status: timeout"
         [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
         echo "duration: ${elapsed}s"
-        echo "Timed out after ${elapsed}s waiting for CI on branch '$branch'" >&2
+        echo "reason: $reason"
+        echo "Timed out waiting for CI on branch '$branch' ($reason)" >&2
         exit 2
       fi
 
       sleep "$interval"
       elapsed=$(( elapsed + interval ))
+      idle=$(( idle + interval ))
     done
     ;;
 
@@ -1421,13 +1523,13 @@ PR COMMANDS
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]
-  git-tools pr wait      --branch NAME [--timeout 300] [--interval 15]
+  git-tools pr wait      --branch NAME [--timeout 3600] [--idle-timeout 300] [--interval 15]
 
 CI RUN COMMANDS
   git-tools run list     [--limit N] [--status STATUS] [--branch BRANCH]
   git-tools run show     <run-id>
   git-tools run logs     <run-id> [--failed-only]
-  git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--interval S]
+  git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--idle-timeout S] [--interval S]
 
 REPO / USER
   git-tools repo default-branch

--- a/plugins-claude/git-tools/skills/git-cli/SKILL.md
+++ b/plugins-claude/git-tools/skills/git-cli/SKILL.md
@@ -18,8 +18,8 @@ allowed-tools: Bash
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/git-cli --help` for the full subcommand list (`issue`, `pr`, `run`, `repo`, `user`) and per-command flags. A few non-obvious ones worth knowing:
 
 - `pr show --branch NAME` — resolve the most-recent PR for a branch.
-- `pr wait --branch NAME` — poll until merged/closed/blocked (default 300s). **Use this instead of writing your own poll loop.**
-- `run watch --branch NAME` — poll CI to pass/fail/timeout with proper terminal-state detection. **Use this instead of writing your own poll loop.**
+- `pr wait --branch NAME` — poll until merged/closed/blocked. Progress-aware: won't time out while CI or auto-merge is still active (idle timeout 5 min, hard ceiling 60 min; tune with `--idle-timeout`/`--timeout`). **Use this instead of writing your own poll loop.**
+- `run watch --branch NAME` — poll CI to pass/fail/timeout with proper terminal-state detection. Waits through long runs up to a 60 min ceiling (tune with `--timeout`). **Use this instead of writing your own poll loop.**
 - `run show <id>` — aggregates per-job status on Gitea so failed jobs don't get masked by a run-level success (#87).
 - `issue comment list <N>` / `delete <id>` / `edit <id> [--body ...]` — read, remove, and update comments. Use `list` to verify a comment posted (the add command returns the new comment's `id`, so you never need to blind-retry and risk a double-post).
 - `api <path> [-X METHOD] [-f key=val ...]` — raw authenticated `gh`/`tea api` passthrough; the escape hatch when the wrapper lacks a capability. The `<path>` must come first. Output is the backend's **raw** JSON (not normalized) — supply your own `--jq` or pipe.

--- a/plugins-claude/git-tools/skills/ship/SKILL.md
+++ b/plugins-claude/git-tools/skills/ship/SKILL.md
@@ -117,7 +117,7 @@ Pull a concise title from the most recent commit message; pull the body from the
 ### 5. Watch CI
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run watch --branch "$(git rev-parse --abbrev-ref HEAD)" --timeout 600 --interval 30
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli run watch --branch "$(git rev-parse --abbrev-ref HEAD)" --interval 30
 ```
 
 This polls until CI passes, fails, or merges. Output includes `status` (`pass|fail|closed|timeout|no-workflow`), `url`, `duration`, and on fail `failed_jobs` with logs piped to stderr.
@@ -129,7 +129,7 @@ This polls until CI passes, fails, or merges. Output includes `status` (`pass|fa
 If the repo has an auto-merge bot (some repos enable auto-merge on PR open), wait for the merge to complete:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr wait --branch "$(git rev-parse --abbrev-ref HEAD)" --timeout 300 --interval 15
+${CLAUDE_PLUGIN_ROOT}/scripts/git-cli pr wait --branch "$(git rev-parse --abbrev-ref HEAD)" --interval 15
 ```
 
 Skip this step if the repo does not auto-merge. **Never call `git-cli pr merge` to merge manually unless the user explicitly asks** — that bypasses CI gating and the auto-merge workflow.

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -22,12 +22,12 @@
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
-#   git-tools pr wait      --branch NAME [--timeout 300] [--interval 15]
+#   git-tools pr wait      --branch NAME [--timeout 3600] [--idle-timeout 300] [--interval 15]
 #
 #   git-tools run list     [--limit N] [--status STATUS] [--branch BRANCH]
 #   git-tools run show     <run-id>
 #   git-tools run logs     <run-id> [--failed-only]
-#   git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--interval S]
+#   git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--idle-timeout S] [--interval S]
 #
 #   git-tools repo default-branch
 #   git-tools repo info
@@ -331,6 +331,56 @@ _run_failed_jobs() {
   local run_id="$1" show_json
   show_json=$("$0" run show "$run_id" 2>/dev/null) || return 0
   echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")'
+}
+
+# Progress-aware timeout decision shared by `pr wait` and `run watch`.
+# Echoes "ceiling" if the absolute deadline is hit, "idle" if the no-progress
+# window is hit, or nothing (return 1) if neither. A bound of 0 disables it.
+# A flat wall-clock timeout is the wrong primitive for CI that can run 15+
+# minutes: this lets callers keep waiting while CI is actively progressing and
+# give up only after a stretch of no progress, with a hard ceiling backstop.
+_wait_timed_out() {
+  local elapsed="$1" idle="$2" max_timeout="$3" idle_timeout="$4"
+  if [[ "$max_timeout" -gt 0 && "$elapsed" -ge "$max_timeout" ]]; then
+    echo "ceiling"; return 0
+  fi
+  if [[ "$idle_timeout" -gt 0 && "$idle" -ge "$idle_timeout" ]]; then
+    echo "idle"; return 0
+  fi
+  return 1
+}
+
+# Coarse CI status — pending|success|failure|none — for a PR/branch, used by
+# `pr wait` to tell whether CI is actively progressing. GitHub aggregates the
+# PR's statusCheckRollup; Gitea maps the latest run's status. Every API call is
+# guarded so a probe failure degrades to "none" and never aborts the wait loop.
+_ci_status() {
+  local pr_number="$1" branch="$2" view_json run_status
+  case "$PLATFORM" in
+    github)
+      view_json=$(GH_NO_COLOR=1 gh pr view "$pr_number" --json statusCheckRollup 2>/dev/null) || { echo "none"; return 0; }
+      echo "$view_json" | jq -r '
+        [.statusCheckRollup // [] | .[] |
+          if .__typename == "CheckRun" then
+            if .conclusion then (.conclusion | ascii_downcase) else "pending" end
+          else (.state // "pending" | ascii_downcase) end
+        ] |
+        if length == 0 then "none"
+        elif any(. == "failure" or . == "error" or . == "timed_out" or . == "action_required") then "failure"
+        elif all(. == "success" or . == "neutral" or . == "skipped") then "success"
+        else "pending" end' 2>/dev/null || echo "none"
+      ;;
+    gitea)
+      run_status=$("$0" run list --branch "$branch" --limit 1 2>/dev/null | jq -r '.[0].status // "none"' 2>/dev/null) || run_status="none"
+      case "$run_status" in
+        queued|in_progress|waiting|running|pending|requested) echo "pending" ;;
+        failure|timed_out|cancelled|canceled|skipped) echo "failure" ;;
+        ""|none|null) echo "none" ;;
+        *) echo "success" ;;
+      esac
+      ;;
+    *) echo "none" ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -686,12 +736,14 @@ case "$cmd:$sub" in
     ;;
 
   pr:wait)
-    branch=""; timeout=300; interval=15
+    # timeout is the hard ceiling; idle_timeout is the no-progress window.
+    branch=""; timeout=3600; idle_timeout=300; interval=15
     while [[ $# -gt 0 ]]; do
       case "$1" in
-        --branch)   [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
-        --timeout)  [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
-        --interval) [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
+        --branch)       [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
+        --timeout)      [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
+        --idle-timeout) [[ $# -gt 1 ]] || die_usage "--idle-timeout requires a value"; shift; idle_timeout="$1" ;;
+        --interval)     [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
         *) die_usage "unknown flag: $1" ;;
       esac
       shift
@@ -714,6 +766,8 @@ case "$cmd:$sub" in
     pr_number=$(echo "$pr" | jq -r '.number')
     pr_url=$(echo "$pr" | jq -r '.url // ""')
     elapsed=0
+    idle=0
+    last_signal=""
     unknown_streak=0
 
     # Poll loop
@@ -724,7 +778,22 @@ case "$cmd:$sub" in
       pr_mergeable=$(echo "$show_json" | jq -r '.mergeable // ""')
       [[ -z "$pr_url" || "$pr_url" == "null" ]] && pr_url=$(echo "$show_json" | jq -r '.url // ""')
 
-      echo "PR #$pr_number: state=$pr_state merged=$pr_merged (${elapsed}s elapsed)" >&2
+      # Progress signals: CI still running or auto-merge pending means the PR is
+      # actively advancing toward merge, so the idle clock must not count down.
+      checks=$(_ci_status "$pr_number" "$branch")
+      if [[ "$PLATFORM" == "github" ]]; then
+        auto_merge=$("$0" pr auto-merge-status --number "$pr_number" 2>/dev/null | sed -n 's/^auto_merge: //p' | head -1) || auto_merge=""
+        [[ "$auto_merge" == "true" ]] || auto_merge="false"
+      else
+        auto_merge="false"
+      fi
+      signal="$pr_state|$pr_mergeable|$checks|$auto_merge"
+      if [[ "$checks" == "pending" || "$auto_merge" == "true" || "$signal" != "$last_signal" ]]; then
+        idle=0
+      fi
+      last_signal="$signal"
+
+      echo "PR #$pr_number: state=$pr_state merged=$pr_merged checks=$checks auto_merge=$auto_merge (idle ${idle}s, ${elapsed}s elapsed)" >&2
 
       case "$pr_state" in
         merged)
@@ -778,18 +847,27 @@ case "$cmd:$sub" in
       # Reset unknown streak on any recognized state
       [[ "$pr_state" == "merged" || "$pr_state" == "closed" || "$pr_state" == "open" ]] && unknown_streak=0
 
-      # Check timeout
-      if [[ "$elapsed" -ge "$timeout" ]]; then
+      # Check timeout — only give up after a stretch of no progress (idle) or
+      # the absolute ceiling, never while CI/auto-merge is still working.
+      timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+      if [[ -n "$timeout_kind" ]]; then
+        if [[ "$timeout_kind" == "ceiling" ]]; then
+          reason="exceeded max wait ${timeout}s"
+        else
+          reason="no progress for ${idle}s"
+        fi
         echo "status: timeout"
         echo "pr_number: $pr_number"
         [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
         echo "duration: ${elapsed}s"
-        echo "Timed out after ${elapsed}s waiting for PR #$pr_number to merge" >&2
+        echo "reason: $reason"
+        echo "Timed out waiting for PR #$pr_number to merge ($reason)" >&2
         exit 2
       fi
 
       sleep "$interval"
       elapsed=$(( elapsed + interval ))
+      idle=$(( idle + interval ))
     done
     ;;
 
@@ -953,12 +1031,17 @@ case "$cmd:$sub" in
     ;;
 
   run:watch)
-    branch=""; initial_delay=60; timeout=600; interval=15
+    # timeout is the hard ceiling; idle_timeout is the no-progress backstop.
+    # While CI is actively pending the idle clock is reset each poll, so a long
+    # (15+ min) suite runs to completion up to the ceiling rather than being cut
+    # off by a flat wall-clock timeout.
+    branch=""; initial_delay=60; timeout=3600; idle_timeout=300; interval=15
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --branch)        [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
         --initial-delay) [[ $# -gt 1 ]] || die_usage "--initial-delay requires a value"; shift; initial_delay="$1" ;;
         --timeout)       [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
+        --idle-timeout)  [[ $# -gt 1 ]] || die_usage "--idle-timeout requires a value"; shift; idle_timeout="$1" ;;
         --interval)      [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
         *) die_usage "unknown flag: $1" ;;
       esac
@@ -967,6 +1050,7 @@ case "$cmd:$sub" in
     [[ -n "$branch" ]] || die_usage "run watch requires --branch"
 
     elapsed=0
+    idle=0
 
     # On GitHub, prefer PR-based status checking — one API call gives us both
     # merge state and all CI check results via statusCheckRollup, avoiding the
@@ -1188,21 +1272,30 @@ case "$cmd:$sub" in
             exit 0
             ;;
           pending)
-            # Still running — keep polling
+            # Still running — keep polling. Active CI is progress, so reset idle.
+            idle=0
             ;;
         esac
 
-        # Check timeout
-        if [[ "$elapsed" -ge "$timeout" ]]; then
+        # Check timeout — idle window or absolute ceiling (see _wait_timed_out).
+        timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+        if [[ -n "$timeout_kind" ]]; then
+          if [[ "$timeout_kind" == "ceiling" ]]; then
+            reason="exceeded max wait ${timeout}s"
+          else
+            reason="no progress for ${idle}s"
+          fi
           echo "status: timeout"
           [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
           echo "duration: ${elapsed}s"
-          echo "Timed out after ${elapsed}s waiting for CI on PR #$pr_number" >&2
+          echo "reason: $reason"
+          echo "Timed out waiting for CI on PR #$pr_number ($reason)" >&2
           exit 2
         fi
 
         sleep "$interval"
         elapsed=$(( elapsed + interval ))
+        idle=$(( idle + interval ))
       done
     fi
 
@@ -1263,7 +1356,8 @@ case "$cmd:$sub" in
       # explicitly; everything else exits.  Do NOT add a `*) keep polling`.
       case "$run_status" in
         queued|in_progress|waiting|running|pending|requested)
-          # Non-terminal — keep polling
+          # Non-terminal — keep polling. Active CI is progress, so reset idle.
+          idle=0
           ;;
         failure|timed_out)
           failed_jobs=$(_run_failed_jobs "$run_id")
@@ -1310,16 +1404,24 @@ case "$cmd:$sub" in
           ;;
       esac
 
-      if [[ "$elapsed" -ge "$timeout" ]]; then
+      timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+      if [[ -n "$timeout_kind" ]]; then
+        if [[ "$timeout_kind" == "ceiling" ]]; then
+          reason="exceeded max wait ${timeout}s"
+        else
+          reason="no progress for ${idle}s"
+        fi
         echo "status: timeout"
         [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
         echo "duration: ${elapsed}s"
-        echo "Timed out after ${elapsed}s waiting for CI on branch '$branch'" >&2
+        echo "reason: $reason"
+        echo "Timed out waiting for CI on branch '$branch' ($reason)" >&2
         exit 2
       fi
 
       sleep "$interval"
       elapsed=$(( elapsed + interval ))
+      idle=$(( idle + interval ))
     done
     ;;
 
@@ -1421,13 +1523,13 @@ PR COMMANDS
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]
-  git-tools pr wait      --branch NAME [--timeout 300] [--interval 15]
+  git-tools pr wait      --branch NAME [--timeout 3600] [--idle-timeout 300] [--interval 15]
 
 CI RUN COMMANDS
   git-tools run list     [--limit N] [--status STATUS] [--branch BRANCH]
   git-tools run show     <run-id>
   git-tools run logs     <run-id> [--failed-only]
-  git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--interval S]
+  git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--idle-timeout S] [--interval S]
 
 REPO / USER
   git-tools repo default-branch

--- a/plugins-claude/session/skills/session-end/SKILL.md
+++ b/plugins-claude/session/skills/session-end/SKILL.md
@@ -184,8 +184,8 @@ fails from inside a worktree.)
     user to resolve conflicts and re-invoke
   - **Skip wait** — continue to step 9
 - **`timeout`** — if auto-merge was detected in
-  step 8a, automatically re-run `pr wait` with
-  `--timeout 600` (up to 2 retries, no prompt).
+  step 8a, automatically re-run `pr wait`
+  (up to 2 retries, no prompt).
   If auto-merge was NOT detected, ask via
   AskUserQuestion:
   - **Wait longer** — re-run `pr wait` with a

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/tests/session/test-pr-wait.sh
+++ b/tests/session/test-pr-wait.sh
@@ -332,6 +332,123 @@ chmod +x "$MOCK_DIR/gh"
 run_test "merged" "0" "transient unknown then recovery → status: merged, exit 0"
 
 # ---------------------------------------------------------------------------
+# Test: progress-aware timeout (issue #149)
+# pr wait must not time out while CI/auto-merge is progressing; it gives up
+# after an idle window of no progress, with a larger absolute ceiling.
+# ---------------------------------------------------------------------------
+
+echo "── pr wait: progress-aware timeout ──"
+
+# Idle window fires when there is no progress. Mock has no statusCheckRollup
+# (_ci_status → none) and no autoMergeRequest (→ false), so an open PR makes no
+# progress and must hit the small idle window well before the large ceiling.
+write_mock_gh <<'EOF'
+case "$1:$2" in
+  pr:list)
+    echo '[{"number":20,"title":"Test PR","body":"","state":"OPEN","author":{"login":"u"},"headRefName":"test-branch","baseRefName":"main","labels":[],"assignees":[],"mergeable":"MERGEABLE","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/20"}]'
+    ;;
+  pr:view)
+    echo '{"number":20,"title":"Test PR","body":"","state":"OPEN","author":{"login":"u"},"headRefName":"test-branch","baseRefName":"main","labels":[],"assignees":[],"mergeable":"MERGEABLE","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/20","comments":[]}'
+    ;;
+esac
+EOF
+
+start=$SECONDS
+exit_code=0
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr wait \
+  --branch "test-branch" --idle-timeout 2 --timeout 100 --interval 1 2>/dev/null) || exit_code=$?
+duration=$((SECONDS - start))
+got_status=$(echo "$output" | grep '^status:' | head -1 | sed 's/^status: *//')
+got_reason=$(echo "$output" | grep '^reason:' | head -1 | sed 's/^reason: *//')
+
+if [[ "$got_status" == "timeout" && "$exit_code" == "2" && "$got_reason" == *"no progress"* && "$duration" -lt 20 ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "idle timeout fires on no progress (reason='$got_reason', ${duration}s, not the 100s ceiling)"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (status=%s exit=%s reason='%s' dur=%ss)\n" \
+    "idle timeout fires on no progress" "$got_status" "$exit_code" "$got_reason" "$duration"
+  ((FAIL++)) || true
+fi
+
+# Pending CI counts as progress and resets the idle clock, so with a tiny idle
+# window but a small ceiling the wait runs to the ceiling, not the idle window.
+write_mock_gh <<'EOF'
+case "$1:$2" in
+  pr:list)
+    echo '[{"number":21,"title":"Test PR","body":"","state":"OPEN","author":{"login":"u"},"headRefName":"test-branch","baseRefName":"main","labels":[],"assignees":[],"mergeable":"MERGEABLE","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/21"}]'
+    ;;
+  pr:view)
+    echo '{"number":21,"title":"Test PR","body":"","state":"OPEN","author":{"login":"u"},"headRefName":"test-branch","baseRefName":"main","labels":[],"assignees":[],"mergeable":"MERGEABLE","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/21","statusCheckRollup":[{"__typename":"CheckRun","conclusion":null}],"comments":[]}'
+    ;;
+esac
+EOF
+
+start=$SECONDS
+exit_code=0
+output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" pr wait \
+  --branch "test-branch" --idle-timeout 1 --timeout 4 --interval 1 2>/dev/null) || exit_code=$?
+duration=$((SECONDS - start))
+got_status=$(echo "$output" | grep '^status:' | head -1 | sed 's/^status: *//')
+got_reason=$(echo "$output" | grep '^reason:' | head -1 | sed 's/^reason: *//')
+
+if [[ "$got_status" == "timeout" && "$exit_code" == "2" && "$got_reason" == *"max wait"* && "$duration" -ge 3 ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "pending CI defeats idle → ceiling (reason='$got_reason', ${duration}s)"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (status=%s exit=%s reason='%s' dur=%ss)\n" \
+    "pending CI defeats idle → ceiling" "$got_status" "$exit_code" "$got_reason" "$duration"
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
+# Test: default timeout invariants (issue #149)
+# Parsed directly from the canonical git-cli source — no wall-clock wait.
+# ---------------------------------------------------------------------------
+
+echo "── pr wait / run watch: default timeout invariants ──"
+
+pr_wait_line=$(grep -A4 '^  pr:wait)' "$GIT_CLI" | grep 'branch=""' | head -1)
+run_watch_line=$(grep -A7 '^  run:watch)' "$GIT_CLI" | grep 'branch=""' | head -1)
+
+pr_wait_timeout=$(echo "$pr_wait_line" | sed -nE 's/.*[;[:space:]]timeout=([0-9]+).*/\1/p')
+pr_wait_idle=$(echo "$pr_wait_line" | sed -nE 's/.*idle_timeout=([0-9]+).*/\1/p')
+run_watch_timeout=$(echo "$run_watch_line" | sed -nE 's/.*[;[:space:]]timeout=([0-9]+).*/\1/p')
+run_watch_idle=$(echo "$run_watch_line" | sed -nE 's/.*idle_timeout=([0-9]+).*/\1/p')
+
+assert_eq() { # <label> <expected> <got>
+  if [[ "$2" == "$3" ]]; then
+    printf "  \033[32m✓\033[0m %s (=%s)\n" "$1" "$3"
+    ((PASS++)) || true
+  else
+    printf "  \033[31m✗\033[0m %s  (expected %s, got '%s')\n" "$1" "$2" "$3"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_eq "pr wait default timeout is 3600" "3600" "$pr_wait_timeout"
+assert_eq "pr wait default idle-timeout is 300" "300" "$pr_wait_idle"
+assert_eq "run watch default timeout is 3600" "3600" "$run_watch_timeout"
+assert_eq "run watch default idle-timeout is 300" "300" "$run_watch_idle"
+
+if [[ -n "$pr_wait_timeout" && -n "$run_watch_timeout" && "$pr_wait_timeout" -ge "$run_watch_timeout" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "pr wait ceiling ($pr_wait_timeout) >= run watch ceiling ($run_watch_timeout)"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (pr wait='%s' run watch='%s')\n" \
+    "pr wait ceiling >= run watch ceiling" "$pr_wait_timeout" "$run_watch_timeout"
+  ((FAIL++)) || true
+fi
+
+if [[ -n "$pr_wait_idle" && -n "$pr_wait_timeout" && "$pr_wait_idle" -le "$pr_wait_timeout" ]]; then
+  printf "  \033[32m✓\033[0m %s\n" "pr wait idle ($pr_wait_idle) <= ceiling ($pr_wait_timeout)"
+  ((PASS++)) || true
+else
+  printf "  \033[31m✗\033[0m %s  (idle='%s' ceiling='%s')\n" \
+    "pr wait idle <= ceiling" "$pr_wait_idle" "$pr_wait_timeout"
+  ((FAIL++)) || true
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -22,12 +22,12 @@
 #   git-tools pr merge     <N> [--squash | --rebase]
 #   git-tools pr close     <N>
 #   git-tools pr auto-merge-status --branch NAME [--number N]
-#   git-tools pr wait      --branch NAME [--timeout 300] [--interval 15]
+#   git-tools pr wait      --branch NAME [--timeout 3600] [--idle-timeout 300] [--interval 15]
 #
 #   git-tools run list     [--limit N] [--status STATUS] [--branch BRANCH]
 #   git-tools run show     <run-id>
 #   git-tools run logs     <run-id> [--failed-only]
-#   git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--interval S]
+#   git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--idle-timeout S] [--interval S]
 #
 #   git-tools repo default-branch
 #   git-tools repo info
@@ -331,6 +331,56 @@ _run_failed_jobs() {
   local run_id="$1" show_json
   show_json=$("$0" run show "$run_id" 2>/dev/null) || return 0
   echo "$show_json" | jq -r '[.jobs[]? | select(.status == "failure") | .name] | join(",")'
+}
+
+# Progress-aware timeout decision shared by `pr wait` and `run watch`.
+# Echoes "ceiling" if the absolute deadline is hit, "idle" if the no-progress
+# window is hit, or nothing (return 1) if neither. A bound of 0 disables it.
+# A flat wall-clock timeout is the wrong primitive for CI that can run 15+
+# minutes: this lets callers keep waiting while CI is actively progressing and
+# give up only after a stretch of no progress, with a hard ceiling backstop.
+_wait_timed_out() {
+  local elapsed="$1" idle="$2" max_timeout="$3" idle_timeout="$4"
+  if [[ "$max_timeout" -gt 0 && "$elapsed" -ge "$max_timeout" ]]; then
+    echo "ceiling"; return 0
+  fi
+  if [[ "$idle_timeout" -gt 0 && "$idle" -ge "$idle_timeout" ]]; then
+    echo "idle"; return 0
+  fi
+  return 1
+}
+
+# Coarse CI status — pending|success|failure|none — for a PR/branch, used by
+# `pr wait` to tell whether CI is actively progressing. GitHub aggregates the
+# PR's statusCheckRollup; Gitea maps the latest run's status. Every API call is
+# guarded so a probe failure degrades to "none" and never aborts the wait loop.
+_ci_status() {
+  local pr_number="$1" branch="$2" view_json run_status
+  case "$PLATFORM" in
+    github)
+      view_json=$(GH_NO_COLOR=1 gh pr view "$pr_number" --json statusCheckRollup 2>/dev/null) || { echo "none"; return 0; }
+      echo "$view_json" | jq -r '
+        [.statusCheckRollup // [] | .[] |
+          if .__typename == "CheckRun" then
+            if .conclusion then (.conclusion | ascii_downcase) else "pending" end
+          else (.state // "pending" | ascii_downcase) end
+        ] |
+        if length == 0 then "none"
+        elif any(. == "failure" or . == "error" or . == "timed_out" or . == "action_required") then "failure"
+        elif all(. == "success" or . == "neutral" or . == "skipped") then "success"
+        else "pending" end' 2>/dev/null || echo "none"
+      ;;
+    gitea)
+      run_status=$("$0" run list --branch "$branch" --limit 1 2>/dev/null | jq -r '.[0].status // "none"' 2>/dev/null) || run_status="none"
+      case "$run_status" in
+        queued|in_progress|waiting|running|pending|requested) echo "pending" ;;
+        failure|timed_out|cancelled|canceled|skipped) echo "failure" ;;
+        ""|none|null) echo "none" ;;
+        *) echo "success" ;;
+      esac
+      ;;
+    *) echo "none" ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -686,12 +736,14 @@ case "$cmd:$sub" in
     ;;
 
   pr:wait)
-    branch=""; timeout=300; interval=15
+    # timeout is the hard ceiling; idle_timeout is the no-progress window.
+    branch=""; timeout=3600; idle_timeout=300; interval=15
     while [[ $# -gt 0 ]]; do
       case "$1" in
-        --branch)   [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
-        --timeout)  [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
-        --interval) [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
+        --branch)       [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
+        --timeout)      [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
+        --idle-timeout) [[ $# -gt 1 ]] || die_usage "--idle-timeout requires a value"; shift; idle_timeout="$1" ;;
+        --interval)     [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
         *) die_usage "unknown flag: $1" ;;
       esac
       shift
@@ -714,6 +766,8 @@ case "$cmd:$sub" in
     pr_number=$(echo "$pr" | jq -r '.number')
     pr_url=$(echo "$pr" | jq -r '.url // ""')
     elapsed=0
+    idle=0
+    last_signal=""
     unknown_streak=0
 
     # Poll loop
@@ -724,7 +778,22 @@ case "$cmd:$sub" in
       pr_mergeable=$(echo "$show_json" | jq -r '.mergeable // ""')
       [[ -z "$pr_url" || "$pr_url" == "null" ]] && pr_url=$(echo "$show_json" | jq -r '.url // ""')
 
-      echo "PR #$pr_number: state=$pr_state merged=$pr_merged (${elapsed}s elapsed)" >&2
+      # Progress signals: CI still running or auto-merge pending means the PR is
+      # actively advancing toward merge, so the idle clock must not count down.
+      checks=$(_ci_status "$pr_number" "$branch")
+      if [[ "$PLATFORM" == "github" ]]; then
+        auto_merge=$("$0" pr auto-merge-status --number "$pr_number" 2>/dev/null | sed -n 's/^auto_merge: //p' | head -1) || auto_merge=""
+        [[ "$auto_merge" == "true" ]] || auto_merge="false"
+      else
+        auto_merge="false"
+      fi
+      signal="$pr_state|$pr_mergeable|$checks|$auto_merge"
+      if [[ "$checks" == "pending" || "$auto_merge" == "true" || "$signal" != "$last_signal" ]]; then
+        idle=0
+      fi
+      last_signal="$signal"
+
+      echo "PR #$pr_number: state=$pr_state merged=$pr_merged checks=$checks auto_merge=$auto_merge (idle ${idle}s, ${elapsed}s elapsed)" >&2
 
       case "$pr_state" in
         merged)
@@ -778,18 +847,27 @@ case "$cmd:$sub" in
       # Reset unknown streak on any recognized state
       [[ "$pr_state" == "merged" || "$pr_state" == "closed" || "$pr_state" == "open" ]] && unknown_streak=0
 
-      # Check timeout
-      if [[ "$elapsed" -ge "$timeout" ]]; then
+      # Check timeout — only give up after a stretch of no progress (idle) or
+      # the absolute ceiling, never while CI/auto-merge is still working.
+      timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+      if [[ -n "$timeout_kind" ]]; then
+        if [[ "$timeout_kind" == "ceiling" ]]; then
+          reason="exceeded max wait ${timeout}s"
+        else
+          reason="no progress for ${idle}s"
+        fi
         echo "status: timeout"
         echo "pr_number: $pr_number"
         [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
         echo "duration: ${elapsed}s"
-        echo "Timed out after ${elapsed}s waiting for PR #$pr_number to merge" >&2
+        echo "reason: $reason"
+        echo "Timed out waiting for PR #$pr_number to merge ($reason)" >&2
         exit 2
       fi
 
       sleep "$interval"
       elapsed=$(( elapsed + interval ))
+      idle=$(( idle + interval ))
     done
     ;;
 
@@ -953,12 +1031,17 @@ case "$cmd:$sub" in
     ;;
 
   run:watch)
-    branch=""; initial_delay=60; timeout=600; interval=15
+    # timeout is the hard ceiling; idle_timeout is the no-progress backstop.
+    # While CI is actively pending the idle clock is reset each poll, so a long
+    # (15+ min) suite runs to completion up to the ceiling rather than being cut
+    # off by a flat wall-clock timeout.
+    branch=""; initial_delay=60; timeout=3600; idle_timeout=300; interval=15
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --branch)        [[ $# -gt 1 ]] || die_usage "--branch requires a value"; shift; branch="$1" ;;
         --initial-delay) [[ $# -gt 1 ]] || die_usage "--initial-delay requires a value"; shift; initial_delay="$1" ;;
         --timeout)       [[ $# -gt 1 ]] || die_usage "--timeout requires a value"; shift; timeout="$1" ;;
+        --idle-timeout)  [[ $# -gt 1 ]] || die_usage "--idle-timeout requires a value"; shift; idle_timeout="$1" ;;
         --interval)      [[ $# -gt 1 ]] || die_usage "--interval requires a value"; shift; interval="$1" ;;
         *) die_usage "unknown flag: $1" ;;
       esac
@@ -967,6 +1050,7 @@ case "$cmd:$sub" in
     [[ -n "$branch" ]] || die_usage "run watch requires --branch"
 
     elapsed=0
+    idle=0
 
     # On GitHub, prefer PR-based status checking — one API call gives us both
     # merge state and all CI check results via statusCheckRollup, avoiding the
@@ -1188,21 +1272,30 @@ case "$cmd:$sub" in
             exit 0
             ;;
           pending)
-            # Still running — keep polling
+            # Still running — keep polling. Active CI is progress, so reset idle.
+            idle=0
             ;;
         esac
 
-        # Check timeout
-        if [[ "$elapsed" -ge "$timeout" ]]; then
+        # Check timeout — idle window or absolute ceiling (see _wait_timed_out).
+        timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+        if [[ -n "$timeout_kind" ]]; then
+          if [[ "$timeout_kind" == "ceiling" ]]; then
+            reason="exceeded max wait ${timeout}s"
+          else
+            reason="no progress for ${idle}s"
+          fi
           echo "status: timeout"
           [[ -n "$pr_url" && "$pr_url" != "null" ]] && echo "url: $pr_url"
           echo "duration: ${elapsed}s"
-          echo "Timed out after ${elapsed}s waiting for CI on PR #$pr_number" >&2
+          echo "reason: $reason"
+          echo "Timed out waiting for CI on PR #$pr_number ($reason)" >&2
           exit 2
         fi
 
         sleep "$interval"
         elapsed=$(( elapsed + interval ))
+        idle=$(( idle + interval ))
       done
     fi
 
@@ -1263,7 +1356,8 @@ case "$cmd:$sub" in
       # explicitly; everything else exits.  Do NOT add a `*) keep polling`.
       case "$run_status" in
         queued|in_progress|waiting|running|pending|requested)
-          # Non-terminal — keep polling
+          # Non-terminal — keep polling. Active CI is progress, so reset idle.
+          idle=0
           ;;
         failure|timed_out)
           failed_jobs=$(_run_failed_jobs "$run_id")
@@ -1310,16 +1404,24 @@ case "$cmd:$sub" in
           ;;
       esac
 
-      if [[ "$elapsed" -ge "$timeout" ]]; then
+      timeout_kind=$(_wait_timed_out "$elapsed" "$idle" "$timeout" "$idle_timeout" || true)
+      if [[ -n "$timeout_kind" ]]; then
+        if [[ "$timeout_kind" == "ceiling" ]]; then
+          reason="exceeded max wait ${timeout}s"
+        else
+          reason="no progress for ${idle}s"
+        fi
         echo "status: timeout"
         [[ -n "$run_url" && "$run_url" != "null" ]] && echo "url: $run_url"
         echo "duration: ${elapsed}s"
-        echo "Timed out after ${elapsed}s waiting for CI on branch '$branch'" >&2
+        echo "reason: $reason"
+        echo "Timed out waiting for CI on branch '$branch' ($reason)" >&2
         exit 2
       fi
 
       sleep "$interval"
       elapsed=$(( elapsed + interval ))
+      idle=$(( idle + interval ))
     done
     ;;
 
@@ -1421,13 +1523,13 @@ PR COMMANDS
   git-tools pr merge     <N> [--squash | --rebase]
   git-tools pr close     <N>
   git-tools pr auto-merge-status --branch NAME [--number N]
-  git-tools pr wait      --branch NAME [--timeout 300] [--interval 15]
+  git-tools pr wait      --branch NAME [--timeout 3600] [--idle-timeout 300] [--interval 15]
 
 CI RUN COMMANDS
   git-tools run list     [--limit N] [--status STATUS] [--branch BRANCH]
   git-tools run show     <run-id>
   git-tools run logs     <run-id> [--failed-only]
-  git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--interval S]
+  git-tools run watch    --branch NAME [--initial-delay S] [--timeout S] [--idle-timeout S] [--interval S]
 
 REPO / USER
   git-tools repo default-branch


### PR DESCRIPTION
## Summary

Closes #149.

A flat wall-clock timeout is the wrong primitive for CI that can run 15+ minutes: it either kills a legitimately-long run or must be set so high it waits forever on a genuinely stuck PR. `pr wait` (300s) and `run watch` (600s) both reported false `status: timeout` (exit 2) on PRs that merged moments later.

Both commands are now **progress-aware**: they never time out while CI is actively pending/running or auto-merge is pending, and give up only after an idle window of no progress, with a large absolute ceiling as the backstop.

### Changes
- New shared helpers in `utils/git-cli`: `_wait_timed_out` (idle/ceiling decision) and `_ci_status` (coarse `pending|success|failure|none` — GitHub `statusCheckRollup` / Gitea `run list`, fully guarded).
- `pr wait`: default `--timeout 3600` (hard ceiling) + new `--idle-timeout 300`; probes CI status + auto-merge each poll, resets the idle clock on progress, and emits a `reason:` line on timeout. Exit codes unchanged.
- `run watch`: default `--timeout` 600→3600, new `--idle-timeout 300`; resets idle in the keep-polling branches. The #53–60-sensitive terminal-state logic is untouched.
- Updated usage/`--help` strings and docs (`git-cli`/`ship`/`session-end` SKILLs, README).
- Minor version bumps: `git-tools` 2.1.0 → 2.2.0, `session` 4.2.5 → 4.3.0 (claude + copilot); re-vendored `git-cli` into both plugin `scripts/`.

### Trade-off
"Pending = progress" (required so a single legitimately-long check isn't false-timed-out) means a genuinely stuck/queued runner waits up to the 60-min ceiling rather than being caught by the idle clock. Documented in help/docs.

## Test plan
- `bash tests/session/test-pr-wait.sh` → 21/21, including new behavioral tests: idle fires on no-progress (~2s, not the 100s ceiling), pending CI defeats idle → ceiling, plus default-value invariants.
- `bash test.sh` → 1829 passed, 0 failed.
- `bash .github/scripts/validate-plugins.sh` → 279/0 (vendored-drift + claude↔copilot version parity).
- `bash .github/scripts/validate-frontmatter.sh` → 91/0.
- `rumdl check` on changed markdown → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
