### PR TITLE
feat(statusline): strip decimals from percentile fields

### DIFF
--- a/plugins-claude/statusline/scripts/statusline.sh
+++ b/plugins-claude/statusline/scripts/statusline.sh
@@ -650,6 +650,7 @@ seg_session() {
 
   local util resets_at
   util=$(echo "$usage" | jq -r '.five_hour.utilization // empty' 2>/dev/null) || return
+  util="${util%%.*}"
   resets_at=$(echo "$usage" | jq -r '.five_hour.resets_at // empty' 2>/dev/null) || true
   [[ -z "$util" ]] && return
 
@@ -675,6 +676,7 @@ seg_weekly() {
 
   local util resets_at
   util=$(echo "$usage" | jq -r '.seven_day.utilization // empty' 2>/dev/null) || return
+  util="${util%%.*}"
   resets_at=$(echo "$usage" | jq -r '.seven_day.resets_at // empty' 2>/dev/null) || true
   [[ -z "$util" ]] && return
 


### PR DESCRIPTION
Remove decimal places from session and weekly segment utilization percentages.

The utilization values from the usage API are always full numbers (e.g., `45.0`), so the decimal places are unnecessary and clutter the display. This change strips decimals before displaying the percentage.

**Changes:**
- `seg_session`: add `util=\"${util%%.*}\"` to strip `.five_hour.utilization`
- `seg_weekly`: add `util=\"${util%%.*}\"` to strip `.seven_day.utilization`
- `seg_extra` already had this stripping in place

**Before:** `Ctx 45%`, `Ses 60.0%`, `Wk 75.0%`
**After:** `Ctx 45%`, `Ses 60%`, `Wk 75%`

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>