### PR TITLE
fix(statusline): bump version to 1.1.4 so decimal-strip fix propagates

### DIFF
--- a/plugins-claude/statusline/.claude-plugin/plugin.json
+++ b/plugins-claude/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Configurable status line for Claude Code — git status, model, context, API usage, cost segments with ANSI colors",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary
- PR #151 added `util="${util%%.*}"` to strip `.0` decimals from Session/Week utilization percentages, but didn't bump the plugin version
- Without a version bump, installed plugins see no update and continue displaying `14.0%` / `57.0%`
- Bumps statusline `1.1.3 → 1.1.4` so reinstalling picks up the fix

## Test plan
- [ ] `claude plugin update agent-toolkit/statusline` (or reinstall) after merge
- [ ] Confirm statusline shows `14%` / `57%` instead of `14.0%` / `57.0%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
