### PR TITLE
fix(agentic-ide): align Serena setup for both CLIs

### DIFF
--- a/plugins-claude/agentic-ide/.claude-plugin/plugin.json
+++ b/plugins-claude/agentic-ide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-ide",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/agentic-ide/skills/setup/SKILL.md
+++ b/plugins-claude/agentic-ide/skills/setup/SKILL.md
@@ -67,13 +67,7 @@ Register in `~/.claude.json` (user-level `mcpServers`, or per-project under `.pr
     "serena": {
       "type": "stdio",
       "command": "serena",
-      "args": [
-        "start-mcp-server",
-        "--context", "claude-code",
-        "--project-from-cwd",
-        "--disable-memories",
-        "--disable-onboarding"
-      ],
+      "args": ["start-mcp-server", "--context", "claude-code", "--project-from-cwd"],
       "env": {}
     }
   }
@@ -82,7 +76,7 @@ Register in `~/.claude.json` (user-level `mcpServers`, or per-project under `.pr
 
 - `--context claude-code` tunes prompts and tool descriptions.
 - `--project-from-cwd` auto-detects the project — no per-project config needed.
-- `--disable-memories --disable-onboarding` skips Serena's opaque sidecar notes; project context belongs in source-controlled files.
+- Create `~/.serena/serena_config.yml` with `base_modes: [no-memories]` to disable memories and onboarding tools globally. If you need a one-off invocation instead, pass `--mode interactive --mode editing --mode no-memories` to `serena start-mcp-server` and re-list any other modes you want.
 
 Reconnect Claude Code. `mcp__serena__*` tools should appear; `mcp__serena__get_symbols_overview` on a source file should return structured data. Logs at `~/.serena/logs/`.
 

--- a/plugins-copilot/agentic-ide/.claude-plugin/plugin.json
+++ b/plugins-copilot/agentic-ide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-ide",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "IDE-grade code intelligence for agents — Serena (LSP symbol nav/refactor), ast-grep (AST search/rewrite), and Semgrep (security & dataflow) bundled with usage cheatsheets, setup helpers, and a context-isolated explorer agent",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/agentic-ide/commands/setup.md
+++ b/plugins-copilot/agentic-ide/commands/setup.md
@@ -58,37 +58,22 @@ uv tool install --from git+https://github.com/oraios/serena serena
 
 Verify: `which serena && serena --version`. Upgrade later with `uv tool upgrade serena`.
 
-Register the server with Copilot CLI. Quickest path — the `copilot mcp add` subcommand:
+Create the Serena mode config and register the server with Copilot CLI:
 
 ```bash
-copilot mcp add serena -- serena start-mcp-server \
-  --context=copilot-cli --project-from-cwd --disable-memories --disable-onboarding
-```
+mkdir -p ~/.serena
 
-Or add it to `~/.copilot/mcp-config.json` (user-level; project-level alternative: `.mcp.json` at the repo root):
+cat > ~/.serena/serena_config.yml <<'YAML'
+base_modes:
+  - no-memories
+YAML
 
-```json
-{
-  "mcpServers": {
-    "serena": {
-      "type": "stdio",
-      "command": "serena",
-      "args": [
-        "start-mcp-server",
-        "--context=copilot-cli",
-        "--project-from-cwd",
-        "--disable-memories",
-        "--disable-onboarding"
-      ],
-      "tools": ["*"]
-    }
-  }
-}
+copilot mcp add serena -- serena start-mcp-server --context=copilot-cli --project-from-cwd
 ```
 
 - `--context=copilot-cli` tunes prompts and tool descriptions for Copilot CLI.
 - `--project-from-cwd` auto-detects the project — no per-project config needed.
-- `--disable-memories --disable-onboarding` skips Serena's opaque sidecar notes; project context belongs in source-controlled files.
+- `~/.serena/serena_config.yml` with `base_modes: [no-memories]` disables memories and onboarding tools globally. If you need a one-off invocation instead, pass `--mode interactive --mode editing --mode no-memories` to `serena start-mcp-server` and re-list any other modes you want.
 
 Restart the Copilot CLI session. `serena-*` tools should appear; `serena-get_symbols_overview` on a source file should return structured data. Logs at `~/.serena/logs/`.
 
@@ -121,22 +106,6 @@ Register the server with Copilot CLI — via `copilot mcp add`:
 
 ```bash
 copilot mcp add semgrep -- semgrep-mcp
-```
-
-Or add it to `~/.copilot/mcp-config.json`:
-
-```json
-{
-  "mcpServers": {
-    "semgrep": {
-      "type": "stdio",
-      "command": "semgrep-mcp",
-      "args": [],
-      "tools": ["*"],
-      "env": {}
-    }
-  }
-}
 ```
 
 Optional: add `SEMGREP_APP_TOKEN` to `env` to enable `semgrep_findings` (pulls from Semgrep AppSec Platform). Generate at <https://semgrep.dev/orgs/-/settings/tokens>. All local-scan tools work without it.


### PR DESCRIPTION
## Summary

Update the agentic-ide setup docs to use Serena's supported mode-based configuration instead of removed flags, and make the Copilot CLI setup path explicitly register Copilot rather than implying a Claude-only flow.

## Changes

- remove deprecated `--disable-memories` / `--disable-onboarding` references
- document `~/.serena/serena_config.yml` with `base_modes: [no-memories]`
- simplify the Copilot setup flow to `copilot mcp add`
- bump the `agentic-ide` plugin versions in both manifests

## Testing

- `.github/scripts/validate-plugins.sh`

Closes #147
