### PR TITLE
fix: load Copilot hook plugins again

### DIFF
--- a/.claude/agents/plugin-validator.md
+++ b/.claude/agents/plugin-validator.md
@@ -52,7 +52,7 @@ You are a plugin validator for the agent-toolkit marketplace repo. Validate the 
 If `plugins-copilot/<name>/` exists:
 
 - Has its own `.claude-plugin/plugin.json` (can be a copy)
-- Has `hooks/hooks.json` in Copilot format (camelCase events, flat array, `version: 1`, `bash` key)
+- Has `hooks/hooks.json` in Copilot format (camelCase event keys, object `hooks` map, `version: 1`, `bash` key)
 - Symlinks point back to `../../plugins-claude/<name>/` for shared dirs (scripts, skills, etc.)
 - Shared content matches (no stale copies)
 

--- a/.github/scripts/validate-plugins.sh
+++ b/.github/scripts/validate-plugins.sh
@@ -6,7 +6,7 @@
 #   2. plugin.json fields      — required fields present in every plugin.json
 #   3. Marketplace coverage    — every plugin dir is listed in the matching marketplace with the expected source path
 #   4. Claude hooks.json       — PascalCase events, "command" key, no top-level "version"
-#   5. Copilot hooks.json      — camelCase events, "bash" key, top-level "version": 1
+#   5. Copilot hooks.json      — camelCase event keys, "bash" key, top-level "version": 1
 #   6. Plugin root variables   — correct ${..._PLUGIN_ROOT} per CLI variant
 #   7. Hook script existence   — referenced scripts resolve to real files
 #   8. Copilot docs paths      — Copilot commands/skills do not reference ${COPILOT_PLUGIN_ROOT}
@@ -158,19 +158,19 @@ validate_copilot_hooks() {
     return
   fi
 
-  # Copilot hooks must use the flat array shape:
-  #   [{"event": "preToolUse", "bash": "..."}]
+  # Copilot hooks must use the object shape:
+  #   {"hooks": {"preToolUse": [{"bash": "..."}]}}
   local shape
   shape=$(jq -r '.hooks | type' "$f" 2>/dev/null)
-  if [[ "$shape" != "array" ]]; then
-    fail "$f — Copilot hooks.json must use flat array .hooks entries"
+  if [[ "$shape" != "object" ]]; then
+    fail "$f — Copilot hooks.json must use object .hooks entries"
     return
   fi
 
   local bad_events has_command missing_bash
-  bad_events=$(jq -r '.hooks[].event | select(test("^[A-Z]"))' "$f" 2>/dev/null)
-  has_command=$(jq -r '[.hooks[] | objects | select(has("command"))] | length' "$f" 2>/dev/null)
-  missing_bash=$(jq -r '[.hooks[] | objects | select(((.bash // "") | length) == 0)] | length' "$f" 2>/dev/null)
+  bad_events=$(jq -r '.hooks | keys[] | select(test("^[A-Z]"))' "$f" 2>/dev/null)
+  has_command=$(jq -r '[.hooks[]?[]? | objects | select(has("command"))] | length' "$f" 2>/dev/null)
+  missing_bash=$(jq -r '[.hooks[]?[]? | objects | select(((.bash // "") | length) == 0)] | length' "$f" 2>/dev/null)
 
   if [[ -n "$bad_events" ]]; then
     fail "$f — non-camelCase events: $bad_events"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ Both Claude Code and Copilot CLI recognize the same plugin format (`.claude-plug
 |---|---|---|
 | Marketplace | `.claude-plugin/marketplace.json` | `.github/plugin/marketplace.json` |
 | Hook events | PascalCase (`PreToolUse`) | camelCase (`preToolUse`) |
-| Hook format | Nested `hooks` array, `command` key | Flat array, `bash` key, `version: 1` |
+| Hook format | Nested `hooks` array, `command` key | Object `hooks` map, `bash` key, `version: 1` |
 | Plugin root var | `${CLAUDE_PLUGIN_ROOT}` | `${COPILOT_PLUGIN_ROOT}` |
 
 **Dual-marketplace approach** — Both marketplaces list nearly all plugins. Copilot CLI uses `plugins-copilot/` variants so hook-enabled plugins can provide a Copilot-format `hooks.json`. Shared directories (scripts, skills, etc.) are symlinked back to the canonical `plugins-claude/` source. The `commands/` directory only exists in `plugins-copilot/` (Claude side has been migrated to skills only) and is always a real directory there — never a symlink:
@@ -284,7 +284,7 @@ plugins-copilot/<name>/
 ├── .claude-plugin/
 │   └── plugin.json          # copy of canonical plugin.json (version kept in sync)
 ├── hooks/
-│   └── hooks.json           # Copilot CLI format (camelCase, flat, version:1)
+│   └── hooks.json                # Copilot CLI format (camelCase, object map, version:1)
 ├── commands/                # real directory — Copilot's user-invocable slash commands
 ├── scripts -> ../../plugins-claude/<name>/scripts
 ├── skills -> ../../plugins-claude/<name>/skills

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ plugins-copilot/<name>/
 ├── .claude-plugin/
 │   └── plugin.json               # copy of canonical plugin.json
 ├── hooks/
-│   └── hooks.json                # Copilot CLI format (camelCase events, flat array, version: 1)
+│   └── hooks.json                # Copilot CLI format (camelCase event keys, object map, version: 1)
 └── scripts -> ../../plugins-claude/<name>/scripts
 ```
 
@@ -174,7 +174,7 @@ source "$(dirname "$0")/hook-compat.sh"
 |-----------|-------------|-------------|
 | Plugin root var | `${CLAUDE_PLUGIN_ROOT}` | `${COPILOT_PLUGIN_ROOT}` |
 | Hook event names | PascalCase (`PreToolUse`) | camelCase (`preToolUse`) |
-| Hook format | Nested `hooks` array, `command` key | Flat array, `bash` key, `version: 1` |
+| Hook format | Nested `hooks` array, `command` key | Object `hooks` map, `bash` key, `version: 1` |
 | Payload keys | `tool_name` / `tool_input` | `toolName` / `toolArgs` |
 
 ## License

--- a/plugins-claude/convert-doc/.claude-plugin/plugin.json
+++ b/plugins-claude/convert-doc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-doc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Convert documents to/from markdown using pandoc (DOCX, HTML, RST, EPUB, ODT, RTF, LaTeX)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-claude/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/format-on-save/.claude-plugin/plugin.json
+++ b/plugins-claude/format-on-save/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "format-on-save",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/image/.claude-plugin/plugin.json
+++ b/plugins-claude/image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Clipboard paste and screenshot capture for macOS, WSL, and Linux",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-claude/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-claude/kb-capture/.claude-plugin/plugin.json
+++ b/plugins-claude/kb-capture/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-capture",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Research-to-document automation — capture conversation findings as schema-valid markdown with frontmatter, linting, and optional commit",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/markdown/.claude-plugin/plugin.json
+++ b/plugins-claude/markdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Markdown linting and formatting — check, format, setup",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/notify-on-stop/.claude-plugin/plugin.json
+++ b/plugins-claude/notify-on-stop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-on-stop",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-claude/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session-history-analyzer/.claude-plugin/plugin.json
+++ b/plugins-claude/session-history-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-history-analyzer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-claude/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/convert-doc/.claude-plugin/plugin.json
+++ b/plugins-copilot/convert-doc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-doc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Convert documents to/from markdown using pandoc (DOCX, HTML, RST, EPUB, ODT, RTF, LaTeX)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/convert-doc/hooks/hooks.json
+++ b/plugins-copilot/convert-doc/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
+++ b/plugins-copilot/elevated-edit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elevated-edit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Pull/edit/push workflow for remote or privileged files — bridges SSH and sudo boundaries using rsync",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/elevated-edit/hooks/hooks.json
+++ b/plugins-copilot/elevated-edit/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/format-on-save/.claude-plugin/plugin.json
+++ b/plugins-copilot/format-on-save/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "format-on-save",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "PostToolUse hook that auto-formats files after Edit/Write using language-appropriate formatters (shfmt, prettier, markdownlint, google-java-format, ktlint, cargo fmt, taplo, ruff)",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/format-on-save/hooks/hooks.json
+++ b/plugins-copilot/format-on-save/hooks/hooks.json
@@ -1,15 +1,17 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    },
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/format-on-save.sh",
-      "event": "postToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/format-on-save.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/git-tools/hooks/hooks.json
+++ b/plugins-copilot/git-tools/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/image/.claude-plugin/plugin.json
+++ b/plugins-copilot/image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Clipboard paste and screenshot capture for macOS, WSL, and Linux",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/image/hooks/hooks.json
+++ b/plugins-copilot/image/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
+++ b/plugins-copilot/java-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java-toolkit",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Java/JVM tooling — Maven Central intelligence and class search/decompilation (MCP via Docker), plus a jar-explore script for raw JAR content inspection",
   "mcpServers": "./mcp.json",
   "author": {

--- a/plugins-copilot/java-toolkit/hooks/hooks.json
+++ b/plugins-copilot/java-toolkit/hooks/hooks.json
@@ -1,9 +1,10 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "event": "preToolUse",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/kb-capture/.claude-plugin/plugin.json
+++ b/plugins-copilot/kb-capture/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kb-capture",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Research-to-document automation — capture conversation findings as schema-valid markdown with frontmatter, linting, and optional commit",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/kb-capture/hooks/hooks.json
+++ b/plugins-copilot/kb-capture/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/markdown/.claude-plugin/plugin.json
+++ b/plugins-copilot/markdown/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Markdown linting and formatting — check, format, setup",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/markdown/hooks/hooks.json
+++ b/plugins-copilot/markdown/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/notify-on-stop/.claude-plugin/plugin.json
+++ b/plugins-copilot/notify-on-stop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-on-stop",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Desktop notification when Claude finishes a long-running task. Configurable threshold via CLAUDE_NOTIFY_MIN_SECONDS (default: 30s). Works on macOS, WSL, and Linux.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/notify-on-stop/hooks/hooks.json
+++ b/plugins-copilot/notify-on-stop/hooks/hooks.json
@@ -1,20 +1,23 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    },
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh",
-      "event": "userPromptSubmit"
-    },
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh",
-      "event": "stop"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ],
+    "userPromptSubmit": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh"
+      }
+    ],
+    "stop": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/notify-on-stop.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/permission-manager/.claude-plugin/plugin.json
+++ b/plugins-copilot/permission-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-manager",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Bash command safety classifier with shfmt-based compound parsing, extensible custom patterns, and WebFetch domain management",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/permission-manager/hooks/hooks.json
+++ b/plugins-copilot/permission-manager/hooks/hooks.json
@@ -1,20 +1,19 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    },
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/cmd-gate.sh",
-      "event": "preToolUse"
-    },
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/web-gate.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      },
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/cmd-gate.sh"
+      },
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/web-gate.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/session-history-analyzer/.claude-plugin/plugin.json
+++ b/plugins-copilot/session-history-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-history-analyzer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Analyze Claude Code session history for workflow patterns, friction hotspots, and automation candidates",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session-history-analyzer/hooks/hooks.json
+++ b/plugins-copilot/session-history-analyzer/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/hooks/hooks.json
+++ b/plugins-copilot/session/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }

--- a/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
+++ b/plugins-copilot/stl-game-config/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stl-game-config",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Configure Steam games via SteamTinkerLaunch with automated system detection and template-based configuration",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/stl-game-config/hooks/hooks.json
+++ b/plugins-copilot/stl-game-config/hooks/hooks.json
@@ -1,10 +1,11 @@
 {
   "version": 1,
-  "hooks": [
-    {
-      "type": "command",
-      "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh",
-      "event": "preToolUse"
-    }
-  ]
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "bash ${COPILOT_PLUGIN_ROOT}/scripts/approve-own-scripts.sh"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
Copilot was rejecting hook-enabled plugins because the repo still wrote `hooks.json` in the old flat-array shape. This prevented `git-tools` from loading its `/ship` command and left installed Copilot plugin metadata stale.

## Test plan
- `bash .github/scripts/validate-plugins.sh`
- `copilot plugin update git-tools@agent-toolkit