### PR TITLE
feat(statusline): add git_show_behind config option

### DIFF
--- a/plugins-claude/statusline/.claude-plugin/plugin.json
+++ b/plugins-claude/statusline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Configurable status line for Claude Code — git status, model, context, API usage, cost segments with ANSI colors",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/statusline/scripts/statusline.sh
+++ b/plugins-claude/statusline/scripts/statusline.sh
@@ -21,6 +21,7 @@ DEFAULT_COST_THRESHOLDS=(5 20)
 DEFAULT_EXTRA_HIDE_ZERO=true
 DEFAULT_EXTRA_ONLY_BURNING=false
 DEFAULT_CURRENCY="$"
+DEFAULT_GIT_SHOW_BEHIND=true
 
 # Default colors (256-color codes or keywords)
 declare -A DEFAULT_COLORS=(
@@ -54,6 +55,7 @@ COST_THRESHOLDS=()
 EXTRA_HIDE_ZERO=true
 EXTRA_ONLY_BURNING=false
 CURRENCY=""
+GIT_SHOW_BEHIND=true
 declare -A COLORS=()
 
 MODEL="" CTX_PCT="" COST="" CWD="" PROJECT_DIR=""
@@ -151,6 +153,7 @@ load_config() {
     v=$(echo "$cfg" | jq -r '.extra_hide_zero // empty' 2>/dev/null) && [[ -n "$v" ]] && EXTRA_HIDE_ZERO="$v"
     v=$(echo "$cfg" | jq -r '.extra_only_burning // empty' 2>/dev/null) && [[ -n "$v" ]] && EXTRA_ONLY_BURNING="$v"
     v=$(echo "$cfg" | jq -r '.currency // empty' 2>/dev/null) && [[ -n "$v" ]] && CURRENCY="$v"
+    v=$(echo "$cfg" | jq -r '.git_show_behind // empty' 2>/dev/null) && [[ -n "$v" ]] && GIT_SHOW_BEHIND="$v"
     local ct
     ct=$(echo "$cfg" | jq -r '.cost_thresholds // empty | .[]' 2>/dev/null) || true
     if [[ -n "$ct" ]]; then
@@ -627,7 +630,7 @@ seg_git() {
   ((unstaged > 0)) && out+=" $(c "${COLORS[git_unstaged]}")!${unstaged}$(c reset)"
   ((untracked > 0)) && out+=" $(c "${COLORS[git_untracked]}")?${untracked}$(c reset)"
   ((ahead > 0)) && out+=" $(c "${COLORS[git_ahead]}")⇡${ahead}$(c reset)"
-  ((behind > 0)) && out+=" $(c "${COLORS[git_behind]}")⇣${behind}$(c reset)"
+  [[ "$GIT_SHOW_BEHIND" == "true" ]] && ((behind > 0)) && out+=" $(c "${COLORS[git_behind]}")⇣${behind}$(c reset)"
 
   printf '%s' "$out"
 }


### PR DESCRIPTION
## Summary

- Adds `git_show_behind` boolean config option (default: `true`) to suppress the ⇣N behind indicator in the git segment
- Ahead/behind are both computed from local tracking refs — no remote query involved — but behind reflects remote state ("what's on origin you haven't pulled") rather than session work ("what have you committed locally")
- Sets `git_show_behind: false` in the user config by default for the maintainer

## Test plan

- [ ] Verify `⇡N` still appears when commits are ahead of tracking ref
- [ ] Verify `⇣N` is hidden when `git_show_behind: false` in config
- [ ] Verify `⇣N` still appears when `git_show_behind: true` (default)
- [ ] Verify statusline renders correctly with no config file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
