### PR TITLE
feat(session): auto-rename session after issue/work selection

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: session-issue
 description: "Browse open issues, pick one, and start work on it"
-allowed-tools: Agent, Bash, AskUserQuestion, EnterPlanMode, EnterWorktree, Read
+allowed-tools: Agent, Bash, AskUserQuestion, EnterPlanMode, EnterWorktree, Read, Skill
 ---
 
 The **discovery** door: rank the open issues, pick one, then run the shared
@@ -87,9 +87,14 @@ begin-work spine (explore → plan). To start from your own description instead,
    number — the linkage lives in the PR's `Closes #N`, which is what auto-closes
    the issue on merge.
 
+6. **Rename this session** — invoke the built-in rename via the `Skill` tool
+   (`skill: "rename"`, no args) so the session title reflects the issue being
+   worked on. The rename auto-generates a short descriptive name from the current
+   conversation context — call it now, while the issue title and summary are fresh.
+
 ### Phase 3 — Run the spine
 
-6. **Read the shared begin-work spine and execute it** (use the Read tool):
+7. **Read the shared begin-work spine and execute it** (use the Read tool):
 
    ```text
    ${CLAUDE_PLUGIN_ROOT}/reference/spine.md

--- a/plugins-claude/session/skills/session-start/SKILL.md
+++ b/plugins-claude/session/skills/session-start/SKILL.md
@@ -2,7 +2,7 @@
 disable-model-invocation: true
 name: session-start
 description: "Start work from your description — explore the codebase and plan"
-allowed-tools: Bash, Agent, EnterPlanMode, AskUserQuestion, EnterWorktree, Read
+allowed-tools: Bash, Agent, EnterPlanMode, AskUserQuestion, EnterWorktree, Read, Skill
 ---
 
 Start work from whatever you describe. This is the **input-driven** door: you say
@@ -53,9 +53,14 @@ issues instead, use `/session:session-issue`; for a read-only status view, use
    - **Freeform** → base name `wip-<kebab-slug>` (3-5 word slug from the description).
      No issue linked; the description is the context.
 
+4. **Rename this session** — invoke the built-in rename via the `Skill` tool
+   (`skill: "rename"`, no args). Call it regardless of whether this is new work
+   or a continuation — the description from Phase 0 is in context and the rename
+   auto-generates a short descriptive name from it.
+
 ### Phase 2 — Run the spine
 
-4. **Read the shared begin-work spine and execute it** (use the Read tool):
+5. **Read the shared begin-work spine and execute it** (use the Read tool):
 
    ```text
    ${CLAUDE_PLUGIN_ROOT}/reference/spine.md
@@ -64,6 +69,6 @@ issues instead, use `/session:session-issue`; for a read-only status view, use
    Hand it the context you gathered (the freeform description and/or the issue
    body + labels) and the base branch name from Phase 1. The spine drives Isolate
    (worktree) → Escalate-to-orchestrate? → Explore (parallel research agents) →
-   Plan (`EnterPlanMode`) → Hand-off. If Phase 0 determined you are continuing an
-   existing branch, tell the spine to skip its Isolate phase. Complete every
+   Plan (`EnterPlanMode`) → Hand-off. If Phase 0 determined you are continuing
+   an existing branch, tell the spine to skip its Isolate phase. Complete every
    MANDATORY phase — the flow ends only once you have presented a plan.

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary
- Invoke `/rename` (via Skill tool) automatically in `session-issue` and `session-start` right after the work context is known — issue title or freeform description — so sessions get a descriptive short name instead of `<project>:master`
- Added `Skill` to `allowed-tools` in both skills
- Rename step placed in `session-issue` after Phase 2 (branch slug derived) and in `session-start` after Phase 1 (branch name set), covering both new work and continuations
- Version bump 4.3.3 → 4.4.0

## Test plan
- [ ] Run `/session:session-issue`, pick an issue — verify session renames before spine starts
- [ ] Run `/session:session-start` with a freeform description — verify session renames
- [ ] Run `/session:session-start` while already on a feature branch (continuation) — verify rename still fires
