### PR TITLE
fix(session): replace Skill(rename) with direct JSONL rename script

### DIFF
--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/rename-session
+++ b/plugins-claude/session/scripts/rename-session
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Rename the active Claude Code session for the current CWD.
+# Usage: rename-session <new-name>
+set -euo pipefail
+
+NEW_NAME="${1:-}"
+if [[ -z "$NEW_NAME" ]]; then
+    echo "Usage: rename-session <new-name>" >&2
+    exit 1
+fi
+
+CWD="$(pwd)"
+SESSIONS_DIR="$HOME/.claude/sessions"
+
+# Find the session file for this CWD
+SESSION_FILE=""
+for f in "$SESSIONS_DIR"/*.json; do
+    [[ -f "$f" ]] || continue
+    if jq -e --arg cwd "$CWD" '.cwd == $cwd' "$f" >/dev/null 2>&1; then
+        SESSION_FILE="$f"
+        break
+    fi
+done
+
+if [[ -z "$SESSION_FILE" ]]; then
+    echo "rename-session: no active session found for cwd=$CWD" >&2
+    exit 1
+fi
+
+SESSION_ID=$(jq -r '.sessionId' "$SESSION_FILE")
+if [[ -z "$SESSION_ID" || "$SESSION_ID" == "null" ]]; then
+    echo "rename-session: could not read sessionId from $SESSION_FILE" >&2
+    exit 1
+fi
+
+# Encode CWD: replace every / with - (leading / becomes leading -)
+ENCODED_CWD=$(echo "$CWD" | sed 's|/|-|g')
+JSONL_PATH="$HOME/.claude/projects/${ENCODED_CWD}/${SESSION_ID}.jsonl"
+
+if [[ ! -f "$JSONL_PATH" ]]; then
+    echo "rename-session: session JSONL not found: $JSONL_PATH" >&2
+    exit 1
+fi
+
+# Append custom-title record — this is what /rename writes
+jq -nc --arg n "$NEW_NAME" --arg s "$SESSION_ID" \
+    '{"type":"custom-title","customTitle":$n,"sessionId":$s}' >> "$JSONL_PATH"
+
+# Patch the live PID file so the UI updates immediately
+TEMP=$(mktemp)
+jq --arg n "$NEW_NAME" '.name = $n' "$SESSION_FILE" > "$TEMP"
+rm -f "$SESSION_FILE" && mv "$TEMP" "$SESSION_FILE"
+
+echo "Session renamed to: $NEW_NAME"

--- a/plugins-claude/session/skills/session-issue/SKILL.md
+++ b/plugins-claude/session/skills/session-issue/SKILL.md
@@ -87,10 +87,14 @@ begin-work spine (explore → plan). To start from your own description instead,
    number — the linkage lives in the PR's `Closes #N`, which is what auto-closes
    the issue on merge.
 
-6. **Rename this session** — invoke the built-in rename via the `Skill` tool
-   (`skill: "rename"`, no args) so the session title reflects the issue being
-   worked on. The rename auto-generates a short descriptive name from the current
-   conversation context — call it now, while the issue title and summary are fresh.
+6. **Rename this session** — call the rename script using the base name from
+   step 5 (the `<type>-<slug>` you just built):
+
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/rename-session "<base-name>"
+   ```
+
+   Call this now, while the issue title and summary are fresh.
 
 ### Phase 3 — Run the spine
 

--- a/plugins-claude/session/skills/session-start/SKILL.md
+++ b/plugins-claude/session/skills/session-start/SKILL.md
@@ -53,10 +53,14 @@ issues instead, use `/session:session-issue`; for a read-only status view, use
    - **Freeform** → base name `wip-<kebab-slug>` (3-5 word slug from the description).
      No issue linked; the description is the context.
 
-4. **Rename this session** — invoke the built-in rename via the `Skill` tool
-   (`skill: "rename"`, no args). Call it regardless of whether this is new work
-   or a continuation — the description from Phase 0 is in context and the rename
-   auto-generates a short descriptive name from it.
+4. **Rename this session** — call the rename script using the base name from
+   step 3 (the `<type>-<slug>` or `wip-<kebab-slug>` you just built):
+
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/rename-session "<base-name>"
+   ```
+
+   Call this regardless of whether it is new work or a continuation.
 
 ### Phase 2 — Run the spine
 

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
## Summary

- `Skill(rename)` is a UI-only command — the harness rejects programmatic calls with *"rename is a UI command, not a skill"*
- Investigated Claude Code session storage: session titles live as `custom-title` records in `~/.claude/projects/<cwd>/<uuid>.jsonl`, and the live display name is cached in `~/.claude/sessions/<pid>.json`
- Added `scripts/rename-session` which finds the active session by CWD, appends the custom-title record, and patches the PID file for immediate UI update — all without user interaction
- Updated `session-start` (step 4) and `session-issue` (step 6) to call the script with the base name already built in the prior step

## Test plan

- [ ] Run `/session:start` with a freeform description — session title updates automatically to `wip-<slug>` without `/rename` prompt
- [ ] Run `/session:issue` with an issue number — session title updates to `<type>-<slug>` without `/rename` prompt
- [ ] Verify `rename-session` handles no active session gracefully (exits non-zero with message)
- [ ] Verify session title persists after session close (check JSONL for `custom-title` record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
