### PR TITLE
feat(freecad): agent-scripted CAD plugin — live GUI loop, angled joinery, cut-list optimizer

### DIFF
--- a/plugins-claude/freecad/README.md
+++ b/plugins-claude/freecad/README.md
@@ -223,8 +223,9 @@ Each of these cost a real debugging session.
 
 ## Trackpad navigation
 
-FreeCAD defaults to three-button-mouse bindings that are unusable on a laptop.
-Set the navigation style to **Gesture** in the status-bar dropdown (bottom
-right, shows `CAD` by default): left-drag rotates, two-finger drag pans, scroll
-zooms. Spacebar toggles visibility of the tree selection — that is how you
-isolate a part.
+`fclive` sets trackpad-friendly defaults on first build: **Gesture** navigation
+(left-drag rotates, two-finger drag pans, scroll zooms), **Turntable** orbit
+(keeps "up" instead of tumbling like Trackball), and rotate-about-cursor. To
+change it, use the navigation-style dropdown in the status bar (bottom right).
+Spacebar toggles visibility of the tree selection — that is how you isolate a
+part.

--- a/plugins-claude/freecad/lib/live-reload.py
+++ b/plugins-claude/freecad/lib/live-reload.py
@@ -37,6 +37,7 @@ POLL_MS = int(os.environ.get("WW_POLL_MS", "1000"))
 LOG = os.environ.get("WW_LOG")
 STOP = os.environ.get("WW_STOP")
 SNAP = os.environ.get("WW_SNAP")
+OPEN = os.environ.get("WW_OPEN")
 
 _state = {"mtime": 0.0, "camera": None, "builds": 0}
 
@@ -56,6 +57,25 @@ def _say(msg):
 def _view():
     doc = Gui.activeDocument()
     return doc.activeView() if doc else None
+
+
+def _apply_view_prefs(view):
+    """One-time: make orbiting sane for furniture/woodworking. FreeCAD ships with
+    Trackball orbit, which tumbles the model and loses 'up' -- disorienting for a
+    model that has an obvious floor and top. Gesture navigation + Turntable orbit
+    (spin about vertical, tilt) + rotate-at-cursor is far better here."""
+    try:
+        p = App.ParamGet("User parameter:BaseApp/Preferences/View")
+        p.SetString("NavigationStyle", "Gui::GestureNavigationStyle")
+        p.SetInt("OrbitStyle", 0)     # 0 = Turntable (keeps the up vector)
+        p.SetInt("RotationMode", 1)   # 1 = rotate about the cursor
+    except Exception:
+        pass
+    try:
+        view.setNavigationType("Gui::GestureNavigationStyle")
+    except Exception:
+        pass
+    _say("LIVE      view: Gesture nav + Turntable orbit + rotate-at-cursor")
 
 
 def _rebuild():
@@ -88,6 +108,8 @@ def _rebuild():
             except Exception:
                 Gui.SendMsgToActiveView("ViewFit")
         else:
+            if _state["builds"] == 0:
+                _apply_view_prefs(view)
             view.viewAxonometric()
             Gui.SendMsgToActiveView("ViewFit")
     _state["builds"] += 1
@@ -126,7 +148,24 @@ def _quit():
     QtCore.QCoreApplication.quit()
 
 
-def _snapshot(out_dir):
+_SNAP_VIEWS = {
+    "iso": "viewAxonometric", "axo": "viewAxonometric",
+    "front": "viewFront", "rear": "viewRear",
+    "top": "viewTop", "bottom": "viewBottom",
+    "left": "viewLeft", "right": "viewRight",
+}
+
+
+def _settle(ms):
+    """Pump the event loop so a camera animation finishes before we grab a frame
+    -- otherwise a canned view is photographed mid-flight."""
+    t = QtCore.QElapsedTimer()
+    t.start()
+    while t.elapsed() < ms:
+        QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.AllEvents, 50)
+
+
+def _snapshot(out_dir, view_name=""):
     """Report the live session back to the agent: view, selection, drags.
 
     Without this the loop only runs one way — the agent pushes geometry and the
@@ -149,10 +188,29 @@ def _snapshot(out_dir):
         doc = App.activeDocument()
         result["doc"] = doc.Name
 
-        view = gdoc.activeView()
+        v = gdoc.activeView()
+        # Optional canned view: remember the user's camera, swing to iso/top/...,
+        # grab the frame, then snap their camera right back so their view is
+        # undisturbed. No new window, no focus steal.
+        cam = None
+        setter = _SNAP_VIEWS.get(view_name.strip().lower()) if view_name else None
+        if setter:
+            try:
+                cam = v.getCamera()
+                getattr(v, setter)()
+                Gui.SendMsgToActiveView("ViewFit")
+                _settle(600)
+                result["view"] = view_name
+            except Exception:
+                cam = None
         png = os.path.join(out_dir, "%s.snap.png" % doc.Name)
-        view.saveImage(png, 1400, 1000, "Current")
+        v.saveImage(png, 1400, 1000, "Current")
         result["png"] = png
+        if cam is not None:
+            try:
+                v.setCamera(cam)
+            except Exception:
+                pass
 
         try:
             result["selected"] = [o.Name for o in Gui.Selection.getSelection()]
@@ -189,15 +247,18 @@ def _snapshot(out_dir):
 
 
 def _handle_snap():
+    view_name = ""
     try:
         with open(SNAP) as fh:
-            out_dir = fh.read().strip()
+            lines = fh.read().splitlines()
+        out_dir = lines[0].strip() if lines else ""
+        view_name = lines[1].strip() if len(lines) > 1 else ""
     except OSError:
         out_dir = os.path.dirname(SCRIPT)
     if not out_dir:
         out_dir = os.path.dirname(SCRIPT)
 
-    result = _snapshot(out_dir)
+    result = _snapshot(out_dir, view_name)
     try:
         with open(os.path.join(out_dir, "snapshot.json"), "w") as fh:
             json.dump(result, fh, indent=2)
@@ -211,10 +272,42 @@ def _handle_snap():
          % (len(result["moved"]), len(result["selected"]), result.get("png")))
 
 
+def _handle_open():
+    """Open a second document as a TAB in this running instance -- a .py model
+    (built fresh) or a .FCStd. Lets the agent inspect one part/joint in isolation
+    without a new window. ww.Model only closes its own doc name on rebuild, so
+    the extra tab survives the watched script's rebuilds."""
+    try:
+        with open(OPEN) as fh:
+            path = fh.read().strip()
+    except OSError:
+        path = ""
+    try:
+        os.remove(OPEN)
+    except OSError:
+        pass
+    if not path or not os.path.exists(path):
+        _say("OPEN      no such file: %r" % path)
+        return
+    try:
+        if path.endswith(".py"):
+            sys.modules.pop("wwkit", None)  # pick up library edits too
+            g = {"__name__": "__main__", "__file__": path}
+            exec(compile(open(path).read(), path, "exec"), g)
+        else:
+            App.openDocument(path)
+        _say("OPEN      %s -> new tab" % os.path.basename(path))
+    except Exception:
+        _say("OPEN      FAILED\n" + traceback.format_exc())
+
+
 def _tick():
     if STOP and os.path.exists(STOP):
         _quit()
         return
+
+    if OPEN and os.path.exists(OPEN):
+        _handle_open()
 
     if SNAP and os.path.exists(SNAP):
         _handle_snap()

--- a/plugins-claude/freecad/lib/wwcut.py
+++ b/plugins-claude/freecad/lib/wwcut.py
@@ -4,9 +4,9 @@ A cut list says "I need a 610mm shelf". A *cut plan* says "buy three 8ft 1x10s,
 and out of board #1 cut 610, 610, 610, 430, with 118 left over". The second one
 is the thing you take to the lumberyard and the saw. This module does that.
 
-Two packing problems, both solved greedily (first-fit-decreasing). Optimal bin
-packing is NP-hard and pointless here: with a dozen parts, FFD lands within a
-board or two of optimal, and the saw is not that precise anyway.
+Two packing problems, both solved greedily (first-fit-decreasing, multi-start).
+Optimal bin packing is NP-hard and pointless here: with a dozen parts, FFD lands
+within a board or two of optimal, and the saw is not that precise anyway.
 
   * linear   - boards. Parts have one meaningful dimension (length); they get
                packed into stock lengths (6ft, 8ft, ...).
@@ -14,49 +14,90 @@ board or two of optimal, and the saw is not that precise anyway.
                shelf/guillotine layout because that is how you actually cut a
                sheet: rip it into strips, then crosscut each strip.
 
-Grain runs the length of a sheet. Rotating a part 90 degrees to squeeze it in
-turns the grain the wrong way, so rotation is OFF by default for sheet goods —
-a plan that saves half a sheet by cross-graining your cabinet sides is not a
-saving. Pass allow_rotate=True if the material has no grain (MDF) or you do not
-care.
+Three things a raw bin-packer does not know but a woodworker cares about:
+
+  * Grain runs the length of a sheet. Rotating a part 90 degrees to squeeze it in
+    turns the grain the wrong way, so rotation is OFF by default for sheet goods
+    - a plan that saves half a sheet by cross-graining your cabinet sides is not
+    a saving. Pass allow_rotate=True if the material has no grain (MDF).
+  * Kerf. Every cut eats a saw-blade's width; the plan accounts for it.
+  * Trim. Stock does not arrive dead square. `end_trim`/`edge_trim` knock a
+    margin off each end/edge before anything is packed into the usable region.
+
+Nothing here is hard-coded policy. The catalog - board lengths, sheet sizes and
+their grain axis - is configurable, and the transport limit and preferred cut are
+*preferences*: the planner honours them when it can, quietly upgrades a part to a
+bigger piece when the preferred one is too small (with a note), and **flags** any
+part that simply cannot meet the limits (bigger than any stocked sheet, or longer
+than the truck) instead of failing or - worse - lying about an impossible cut.
+
+An optional stronger sheet packer (`rectpack`, Apache-2.0) is used when it is
+importable; otherwise the built-in shelf packer runs. Either way the result is a
+set of rip strips you can actually cut, and a rectpack layout that does not
+reduce to clean rips is rejected in favour of the shelf plan.
 """
 
 IN = 25.4
 FT = 304.8
 
-# What the yard actually sells. Override per project.
-STOCK_LENGTHS = [6 * FT, 8 * FT, 10 * FT, 12 * FT, 16 * FT]
-KERF = 3.2  # a thin-kerf blade, ~1/8"
+# --- the catalog: what the yard actually sells. Override per project. --------
 
-# Sheet goods come home in one of three shapes. You always *buy* a full 4x8;
-# the store's panel saw is what turns it into something that fits in a truck.
+# Board stock lengths.
+BOARD_LENGTHS = [6 * FT, 8 * FT, 10 * FT, 12 * FT, 16 * FT]
+STOCK_LENGTHS = BOARD_LENGTHS  # backwards-compatible alias
+
+# Sheet stock sizes, as (grain, cross, name). The first dimension is the grain
+# direction. 4x8 is the everything sheet; 5x5 is Baltic-birch ply; add project
+# panels or precut sizes here.
+SHEET_SIZES = [
+    (8 * FT, 4 * FT, "4x8"),
+    (5 * FT, 5 * FT, "5x5"),
+]
+SHEET = SHEET_SIZES[0][:2]  # (8ft, 4ft) — backwards-compatible default
+
+KERF = 3.2       # a thin-kerf blade, ~1/8"
+END_TRIM = 1 * IN     # squared off each board END before use (snipe / square-up)
+EDGE_TRIM = 0.5 * IN  # trimmed off each sheet EDGE before use (factory edge)
+
+# Parts are cut oversize and trimmed to final, to align edges and clean tearout.
+# This grows each part's footprint in each dimension (independent of KERF, which
+# is the blade width *between* parts, and of the trims, which square the stock).
+OVERSIZE = IN / 8.0   # 1/8" bigger per dimension, then trimmed to final
+
+# How a bought sheet gets cut down for the truck, as fractions of the sheet it
+# came from. You always *buy* the full sheet; the store's panel saw turns it into
+# something that fits in the bed.
 #
-# The first dimension is the grain direction. This is why a crosscut half and a
-# ripped half are not interchangeable: crosscutting a 4x8 gives two 4x4s whose
-# grain runs along a 4ft axis, while ripping gives two 2x8s whose grain still
-# runs the full 8ft. Same area, different material.
+# A crosscut half and a ripped half are not interchangeable: crosscutting a 4x8
+# gives two 4x4s whose grain runs along a 4ft axis, while ripping gives two 2x8s
+# whose grain still runs the full 8ft. Same area, different material.
 #
-#   name          piece (grain, cross)   per full sheet
+#   name          (grain_frac, cross_frac, pieces_per_full)
 SHEET_PIECES = {
-    "full": ((8 * FT, 4 * FT), 1),
-    "half": ((4 * FT, 4 * FT), 2),       # crosscut in half — the usual "half sheet"
-    "half-rip": ((8 * FT, 2 * FT), 2),   # ripped in half — stays long and narrow
+    "full": (1.0, 1.0, 1),
+    "half": (0.5, 1.0, 2),      # crosscut in half — the usual "half sheet"
+    "half-rip": (1.0, 0.5, 2),  # ripped in half — stays long and narrow
 }
-SHEET = SHEET_PIECES["full"][0]  # backwards-compatible default
 
+
+# --- boards (1D) -------------------------------------------------------------
 
 class Board:
-    """One physical board bought, and the parts cut from it."""
+    """One physical board bought, and the parts cut from it.
 
-    def __init__(self, stock, length):
-        self.stock = stock
+    `length` is the nominal stock you buy (and pay for and carry). `usable` is
+    what is left to cut into after end-trim; it is what parts are packed against.
+    """
+
+    def __init__(self, length, usable=None):
         self.length = length
+        self.usable = length if usable is None else usable
         self.cuts = []      # [(name, length)]
         self.used = 0.0     # material consumed, kerf included
 
     def fits(self, length, kerf):
         need = length + (kerf if self.cuts else 0.0)
-        return self.used + need <= self.length + 1e-6
+        return self.used + need <= self.usable + 1e-6
 
     def place(self, name, length, kerf):
         self.used += length + (kerf if self.cuts else 0.0)
@@ -64,8 +105,112 @@ class Board:
 
     @property
     def offcut(self):
-        return self.length - self.used
+        return self.usable - self.used
 
+
+class LinearPlan:
+    """The boards to buy, plus the parts that could not be planned."""
+
+    def __init__(self, boards, flagged):
+        self.boards = boards          # [Board]
+        self.flagged = flagged        # [(name, length, reason)]
+
+    def __iter__(self):               # so `for b in plan` still walks the boards
+        return iter(self.boards)
+
+    def __len__(self):
+        return len(self.boards)
+
+    def __getitem__(self, i):
+        return self.boards[i]
+
+
+_LINEAR_ORDERS = (
+    lambda p: -p[1],            # longest first (classic FFD)
+    lambda p: p[1],             # shortest first
+    lambda p: (round(-p[1]), p[0]),  # longest, ties by name (stable variety)
+)
+
+
+def _pack_linear(items, stock_len, usable, kerf):
+    boards = []
+    for name, length in items:
+        for b in boards:
+            if b.fits(length, kerf):
+                b.place(name, length, kerf)
+                break
+        else:
+            b = Board(stock_len, usable)
+            b.place(name, length, kerf)
+            boards.append(b)
+    return boards
+
+
+def plan_linear(parts, board_lengths=None, kerf=KERF, max_length=None,
+                end_trim=0.0, oversize=0.0):
+    """Pack (name, length) parts into stock boards. Returns a LinearPlan.
+
+    Tries each stock length on its own, and a few sort orders for each, and keeps
+    whichever buys the least material — a single length is what you actually want
+    at the yard, and multi-start FFD beats a single greedy pass often enough to
+    be worth the pennies of compute.
+
+    `max_length` is a transport limit: the longest board you can actually get
+    home. `end_trim` is squared off *each* end before parts are packed, so a
+    nominal 8ft board only holds (8ft - 2*end_trim) of parts. `oversize` grows
+    each part before packing — parts are cut rough and trimmed to final — so the
+    lengths in the plan are the rough sizes you actually crosscut.
+
+    Parts that cannot meet the limits — longer than the transport limit, or
+    longer than the longest usable stock after end-trim — are not forced into an
+    impossible plan; they are returned in `.flagged` with a reason, and the rest
+    are still planned.
+    """
+    board_lengths = board_lengths or BOARD_LENGTHS
+    items = [(n, l + oversize) for n, l in parts] if oversize else list(parts)
+
+    carriable = ([s for s in board_lengths if s <= max_length + 1e-6]
+                 if max_length else list(board_lengths))
+    cap = (max(carriable) - 2.0 * end_trim) if carriable else float("-inf")
+
+    plannable, flagged = [], []
+    for name, length in items:
+        if max_length and length > max_length + 1e-6:
+            flagged.append((name, length,
+                            "exceeds the %.0fmm transport limit" % max_length))
+        elif length > cap + 1e-6:
+            if carriable:
+                flagged.append((name, length,
+                                "longer than the longest usable stock "
+                                "(%.0fmm after %.0fmm end-trim)"
+                                % (cap, end_trim)))
+            else:
+                flagged.append((name, length,
+                                "no stock length is within the %.0fmm "
+                                "transport limit" % max_length))
+        else:
+            plannable.append((name, length))
+
+    if not plannable:
+        return LinearPlan([], flagged)
+
+    longest = max(l for _, l in plannable)
+    usable = [s for s in carriable if s - 2.0 * end_trim >= longest - 1e-6]
+
+    best = None
+    for stock_len in usable:
+        stock_cap = stock_len - 2.0 * end_trim
+        for order in _LINEAR_ORDERS:
+            boards = _pack_linear(sorted(plannable, key=order), stock_len,
+                                  stock_cap, kerf)
+            bought = sum(b.length for b in boards)
+            rank = (bought, len(boards))
+            if best is None or rank < best[0]:
+                best = (rank, boards)
+    return LinearPlan(best[1], flagged)
+
+
+# --- sheets (2D) -------------------------------------------------------------
 
 class Sheet:
     """One sheet, packed into horizontal strips (rip, then crosscut)."""
@@ -77,19 +222,26 @@ class Sheet:
         self.used_w = 0.0
 
     def place(self, name, pl, pw, kerf):
-        # Try an open strip first: same idea as a rip already made.
+        # A part longer than the sheet cannot go in any strip, new or open.
+        if pl > self.length + 1e-6:
+            return False
+        # Try an open strip first: same idea as a rip already made. Cuts within
+        # a strip are separated by one kerf each (n parts -> n-1 kerfs).
         for s in self.strips:
-            if pw <= s["depth"] + 1e-6 and s["x"] + pl + kerf <= self.length + 1e-6:
+            if pw <= s["depth"] + 1e-6 and s["x"] + kerf + pl <= self.length + 1e-6:
                 s["parts"].append((name, pl, pw))
-                s["x"] += pl + kerf
+                s["x"] += kerf + pl
                 return True
-        # Otherwise open a new strip, if there is width left to rip one.
-        if self.used_w + pw + kerf <= self.width + 1e-6:
+        # Otherwise open a new strip, if there is width left to rip one. The rip
+        # that separates it from the strip below eats a kerf; the first strip
+        # sits against the factory edge and does not.
+        gap = kerf if self.strips else 0.0
+        if self.used_w + gap + pw <= self.width + 1e-6:
+            y = self.used_w + gap
             self.strips.append(
-                {"depth": pw, "y": self.used_w, "x": pl + kerf,
-                 "parts": [(name, pl, pw)]}
+                {"depth": pw, "y": y, "x": pl, "parts": [(name, pl, pw)]}
             )
-            self.used_w += pw + kerf
+            self.used_w = y + pw
             return True
         return False
 
@@ -102,69 +254,29 @@ class Sheet:
         return self.length * self.width
 
 
-def plan_linear(parts, stock_lengths=None, kerf=KERF, max_length=None):
-    """Pack (name, length) parts into stock boards. Returns [Board].
-
-    Tries each stock length on its own and keeps whichever buys the least
-    material — a single length is what you actually want at the yard, and it
-    beats a mixed-length greedy plan often enough not to bother with more.
-
-    `max_length` is a transport limit: the longest board you can actually get
-    home. A 12ft board is a fine plan and a useless one if it will not go in the
-    truck.
-    """
-    stock_lengths = stock_lengths or STOCK_LENGTHS
-    items = sorted(parts, key=lambda p: -p[1])
-
-    longest = max((l for _, l in items), default=0.0)
-
-    if max_length:
-        # A part longer than the limit is not a packing problem, it is a design
-        # problem: even cut to size it will not fit in the vehicle.
-        toolong = [(n, l) for n, l in items if l > max_length + 1e-6]
-        if toolong:
-            raise ValueError(
-                "part(s) longer than the %.0fmm transport limit: %s"
-                % (max_length,
-                   ", ".join("%s (%.0fmm)" % (n, l) for n, l in toolong))
-            )
-        stock_lengths = [s for s in stock_lengths if s <= max_length + 1e-6]
-        if not stock_lengths:
-            raise ValueError(
-                "no stock length is within the %.0fmm transport limit"
-                % max_length
-            )
-
-    usable = [s for s in stock_lengths if s >= longest]
-    if not usable:
-        raise ValueError(
-            "no stock length holds a %.0fmm part (longest offered %.0fmm)"
-            % (longest, max(stock_lengths))
-        )
-
-    best = None
-    for stock_len in usable:
-        boards = []
-        for name, length in items:
-            for b in boards:
-                if b.fits(length, kerf):
-                    b.place(name, length, kerf)
-                    break
-            else:
-                b = Board(stock_len, stock_len)
-                b.place(name, length, kerf)
-                boards.append(b)
-        bought = sum(b.length for b in boards)
-        if best is None or bought < best[0]:
-            best = (bought, boards)
-    return best[1]
+def _fits(part, piece, allow_rotate):
+    """Does (name, l, w) fit an (already edge-trimmed) piece, grain respected?"""
+    _n, l, w = part
+    pl, pw = piece
+    if l <= pl + 1e-6 and w <= pw + 1e-6:
+        return True
+    if allow_rotate and w <= pl + 1e-6 and l <= pw + 1e-6:
+        return True
+    return False
 
 
-def plan_sheets(parts, sheet=SHEET, kerf=KERF, allow_rotate=False):
-    """Pack (name, length, width) parts into sheets of one size. Returns [Sheet]."""
-    sl, sw = sheet
-    items = sorted(parts, key=lambda p: (-p[2], -p[1]))  # widest strip first
+def _usable(piece, edge_trim):
+    return (piece[0] - 2.0 * edge_trim, piece[1] - 2.0 * edge_trim)
 
+
+_SHEET_ORDERS = (
+    lambda p: (-p[2], -p[1]),   # widest strip first (classic)
+    lambda p: (-p[1], -p[2]),   # longest first
+    lambda p: -(p[1] * p[2]),   # biggest area first
+)
+
+
+def _pack_shelf(items, sl, sw, kerf, allow_rotate):
     sheets = []
     for name, pl, pw in items:
         placed = False
@@ -189,14 +301,155 @@ def plan_sheets(parts, sheet=SHEET, kerf=KERF, allow_rotate=False):
     return sheets
 
 
+def plan_sheets(parts, sheet=SHEET, kerf=KERF, allow_rotate=False, edge_trim=0.0,
+                oversize=0.0):
+    """Pack (name, length, width) parts into sheets of one size. Returns [Sheet].
+
+    `edge_trim` is knocked off each edge before packing, so a nominal piece only
+    offers (L - 2*edge_trim) x (W - 2*edge_trim) of usable face. `oversize` grows
+    each part in both dimensions (cut rough, trim to final). Multi-start: tries a
+    few sort orders and keeps whichever needs the fewest sheets.
+    """
+    if oversize:
+        parts = [(n, l + oversize, w + oversize) for n, l, w in parts]
+    sl, sw = _usable(sheet, edge_trim)
+
+    best = None
+    for order in _SHEET_ORDERS:
+        packed = _pack_shelf(sorted(parts, key=order), sl, sw, kerf, allow_rotate)
+        if best is None or len(packed) < len(best):
+            best = packed
+    return best
+
+
+def _bands_from_placements(placements, sl, sw, eps=1.0):
+    """Reconstruct rip strips from free (rid, x, y, w, h) placements.
+
+    A shelf-cuttable layout is a stack of horizontal bands: within a band the
+    parts sit side by side along x; the bands stack along y. This groups
+    placements into such bands and *validates* that they really are disjoint
+    horizontal strips that fit the sheet. Returns the ordered bands, or None if
+    the layout does not reduce to clean rips (so the caller can reject it).
+    """
+    bands = []  # each: {"y", "depth", "items":[(rid,x,w,h)]}
+    for rid, x, y, w, h in placements:
+        band = None
+        for b in bands:
+            if abs(b["y"] - y) <= eps:
+                band = b
+                break
+        if band is None:
+            band = {"y": y, "depth": h, "items": []}
+            bands.append(band)
+        band["depth"] = max(band["depth"], h)
+        band["items"].append((rid, x, w, h))
+
+    bands.sort(key=lambda b: b["y"])
+
+    # Bands must not overlap in y, and must fit the sheet height.
+    for i in range(len(bands) - 1):
+        if bands[i]["y"] + bands[i]["depth"] > bands[i + 1]["y"] + eps:
+            return None
+    if bands and bands[-1]["y"] + bands[-1]["depth"] > sw + eps:
+        return None
+
+    # Within a band, parts must not overlap in x, and must fit the sheet length.
+    for b in bands:
+        b["items"].sort(key=lambda it: it[1])
+        cursor = 0.0
+        for _rid, x, w, _h in b["items"]:
+            if x + eps < cursor:
+                return None
+            if x + w > sl + eps:
+                return None
+            cursor = x + w
+    return bands
+
+
+def _pack_sheet_rectpack(parts, sheet, kerf, allow_rotate, edge_trim=0.0):
+    """Pack with `rectpack` if it is importable. Returns [Sheet] or None.
+
+    None means "not available or not cleanly cuttable" — the caller falls back to
+    the shelf packer. Kerf is handled by inflating each part (and the bin) by one
+    blade width; grain is handled by disabling rotation. The free-form placement
+    rectpack returns is reduced back to rip strips and rejected if it does not
+    form clean horizontal bands (see `_bands_from_placements`), so we never hand
+    over a layout you cannot actually cut.
+    """
+    try:
+        import rectpack
+    except Exception:
+        return None
+
+    sl, sw = _usable(sheet, edge_trim)
+    if not parts:
+        return []
+
+    packer = rectpack.newPacker(rotation=bool(allow_rotate))
+    for i, (_name, pl, pw) in enumerate(parts):
+        if pl + kerf > sl + 1e-6 or pw + kerf > sw + 1e-6:
+            if not (allow_rotate and pw + kerf <= sl + 1e-6
+                    and pl + kerf <= sw + 1e-6):
+                return None  # a part does not fit even one bin — let shelf raise
+        packer.add_rect(pl + kerf, pw + kerf, rid=i)
+    packer.add_bin(sl + kerf, sw + kerf, count=max(1, len(parts)))
+    packer.pack()
+
+    placed = set()
+    sheets = []
+    for abin in packer:
+        pls = []
+        for rect in abin:
+            pls.append((rect.rid, rect.x, rect.y,
+                        rect.width - kerf, rect.height - kerf))
+            placed.add(rect.rid)
+        if not pls:
+            continue
+        bands = _bands_from_placements(pls, sl, sw)
+        if bands is None:
+            return None
+        s = Sheet(sheet[0], sheet[1])
+        for b in bands:
+            s.strips.append({
+                "depth": b["depth"],
+                "y": b["y"],
+                "x": sum(w + kerf for (_rid, _x, w, _h) in b["items"]),
+                "parts": [(parts[rid][0], w, h) for (rid, _x, w, h) in b["items"]],
+            })
+        s.used_w = sum(b["depth"] for b in bands)
+        sheets.append(s)
+
+    if len(placed) != len(parts):
+        return None
+    return sheets
+
+
+def _pack_one_size(parts, sheet, kerf, allow_rotate, edge_trim, packer):
+    """Pack parts into one sheet size with the requested engine.
+
+    Returns (sheets, engine). "auto"/"rectpack" prefer rectpack when it is
+    importable and its layout reduces to clean rips; otherwise the shelf packer
+    runs and is reported as the engine used.
+    """
+    if packer in ("auto", "rectpack"):
+        rp = _pack_sheet_rectpack(parts, sheet, kerf, allow_rotate, edge_trim)
+        if rp is not None:
+            return rp, "rectpack"
+    return plan_sheets(parts, sheet, kerf, allow_rotate, edge_trim), "shelf"
+
+
 class SheetBuy:
     """A sheet plan plus what it costs you at the till and in the truck."""
 
-    def __init__(self, piece_name, piece, pieces, per_full):
+    def __init__(self, sheet_size, sheet_name, piece_name, piece, pieces,
+                 per_full, engine="shelf"):
+        self.sheet_size = sheet_size    # (grain, cross) of the bought sheet, mm
+        self.sheet_name = sheet_name    # "4x8", "5x5", ...
         self.piece_name = piece_name    # "full" | "half" | "half-rip"
-        self.piece = piece              # (grain, cross) mm
+        self.piece = piece              # (grain, cross) of the transport piece
         self.pieces = pieces            # [Sheet]
-        self.per_full = per_full        # pieces obtainable from one full sheet
+        self.per_full = per_full        # transport pieces from one full sheet
+        self.engine = engine            # "shelf" | "rectpack"
 
     @property
     def full_sheets(self):
@@ -209,49 +462,143 @@ class SheetBuy:
         return self.full_sheets * self.per_full - len(self.pieces)
 
     @property
+    def bought_area(self):
+        return self.full_sheets * self.sheet_size[0] * self.sheet_size[1]
+
+    @property
     def yield_pct(self):
         used = sum(s.area_used for s in self.pieces)
-        bought = self.full_sheets * SHEET_PIECES["full"][0][0] * \
-            SHEET_PIECES["full"][0][1]
+        bought = self.bought_area
         return 100.0 * used / bought if bought else 0.0
 
 
-def choose_sheets(parts, kerf=KERF, allow_rotate=False, max_length=None,
-                  prefer=None):
-    """Pick a sheet piece size and pack into it. Returns SheetBuy.
+class SheetPlan:
+    """The sheets to buy, any preference notes, and parts that could not fit."""
 
-    You always buy a full 4x8 — the choice is what the store cuts it into before
-    it goes in the truck. So candidates are ranked by full sheets purchased, and
-    ties are broken toward the *smaller* piece, because the smaller piece is the
-    one that fits in the vehicle and on the bench.
+    def __init__(self, buys, flagged, notes):
+        self.buys = buys              # [SheetBuy]
+        self.flagged = flagged        # [(name, l, w, reason)]
+        self.notes = notes            # [str]
 
-    `max_length` drops any piece too big to carry. `prefer` forces a piece name.
+
+def _candidates(sheet_sizes):
+    out = []
+    for (grain, cross, sname) in sheet_sizes:
+        for pname, (gf, cf, per_full) in SHEET_PIECES.items():
+            out.append({
+                "sheet_size": (grain, cross),
+                "sheet_name": sname,
+                "piece_name": pname,
+                "piece": (grain * gf, cross * cf),
+                "per_full": per_full,
+            })
+    return out
+
+
+def _cover(parts, cands, kerf, allow_rotate, edge_trim, packer):
+    """Greedily cover `parts` with buys, most-parts-then-least-material first.
+
+    A part can only ride a piece it fits; each round picks the candidate that
+    seats the most still-unplaced parts (ties: least material, then smaller
+    piece), packs them, and removes them. Returns (buys, leftover).
     """
-    names = [prefer] if prefer else list(SHEET_PIECES)
+    remaining = list(parts)
+    buys = []
+    while remaining:
+        best = None
+        for c in cands:
+            usable = _usable(c["piece"], edge_trim)
+            fit = [p for p in remaining if _fits(p, usable, allow_rotate)]
+            if not fit:
+                continue
+            packed, engine = _pack_one_size(
+                fit, c["piece"], kerf, allow_rotate, edge_trim, packer)
+            buy = SheetBuy(c["sheet_size"], c["sheet_name"], c["piece_name"],
+                           c["piece"], packed, c["per_full"], engine)
+            rank = (-len(fit), buy.bought_area, max(c["piece"]))
+            if best is None or rank < best[0]:
+                best = (rank, buy, fit)
+        if best is None:
+            break
+        buys.append(best[1])
+        for p in best[2]:
+            remaining.remove(p)
+    return buys, remaining
 
-    best = None
-    failures = []
-    for name in names:
-        piece, per_full = SHEET_PIECES[name]
-        if max_length and max(piece) > max_length + 1e-6:
-            failures.append("%s (%.0fmm > %.0fmm limit)"
-                            % (name, max(piece), max_length))
-            continue
-        try:
-            packed = plan_sheets(parts, piece, kerf, allow_rotate)
-        except ValueError as exc:
-            failures.append("%s (%s)" % (name, exc))
-            continue
-        buy = SheetBuy(name, piece, packed, per_full)
-        rank = (buy.full_sheets, max(piece))  # fewest sheets, then smallest piece
-        if best is None or rank < best[0]:
-            best = (rank, buy)
 
-    if best is None:
-        raise ValueError(
-            "no sheet size works: %s" % ("; ".join(failures) or "no candidates")
-        )
-    return best[1]
+def choose_sheets(parts, sheet_sizes=None, kerf=KERF, allow_rotate=False,
+                  max_length=None, edge_trim=0.0, prefer=None, packer="auto",
+                  oversize=0.0):
+    """Plan sheet goods from the catalog. Returns a SheetPlan.
+
+    Each part rides the sheet size + transport piece (full / half / half-rip) that
+    holds it for the least material. `prefer` is a *preference*, not a filter:
+    parts that fit it use it, and parts too big for it are upgraded to the
+    smallest piece that does fit, recorded in `.notes`. Parts that cannot meet
+    the limits at all — bigger than any stocked sheet, or too big to carry within
+    `max_length` — are returned in `.flagged`, and everything else is still
+    planned. `edge_trim` shrinks each piece before packing; `oversize` grows each
+    part (cut rough, trim to final); `packer` selects the engine.
+    """
+    sheet_sizes = sheet_sizes or SHEET_SIZES
+    cands = _candidates(sheet_sizes)
+    if oversize:
+        parts = [(n, l + oversize, w + oversize) for n, l, w in parts]
+
+    within = ([c for c in cands if max(c["piece"]) <= max_length + 1e-6]
+              if max_length else list(cands))
+
+    # Biggest usable face on offer, for the "does not fit any sheet" message.
+    biggest = max(((s[0] - 2.0 * edge_trim, s[1] - 2.0 * edge_trim)
+                   for s in sheet_sizes), key=lambda d: d[0] * d[1])
+
+    plannable, flagged = [], []
+    for part in parts:
+        fits_any = any(_fits(part, _usable(c["piece"], edge_trim), allow_rotate)
+                       for c in cands)
+        fits_within = any(
+            _fits(part, _usable(c["piece"], edge_trim), allow_rotate)
+            for c in within)
+        if not fits_any:
+            flagged.append((part[0], part[1], part[2],
+                            "bigger than any stocked sheet "
+                            "(largest usable %.0f x %.0f) — split it"
+                            % (biggest[0], biggest[1])))
+        elif not fits_within:
+            flagged.append((part[0], part[1], part[2],
+                            "does not fit any piece within the %.0fmm "
+                            "transport limit" % max_length))
+        else:
+            plannable.append(part)
+
+    notes = []
+    if not plannable:
+        return SheetPlan([], flagged, notes)
+
+    if prefer:
+        pref = [c for c in within if c["piece_name"] == prefer]
+        buys, leftover = _cover(plannable, pref, kerf, allow_rotate,
+                                edge_trim, packer)
+        if leftover:
+            esc_buys, still = _cover(leftover, within, kerf, allow_rotate,
+                                     edge_trim, packer)
+            upgraded = [p for p in leftover if p not in still]
+            if upgraded:
+                notes.append(
+                    "'%s' preferred, but %d part(s) needed a bigger piece: %s"
+                    % (prefer, len(upgraded),
+                       ", ".join(p[0] for p in upgraded)))
+            buys += esc_buys
+            leftover = still
+    else:
+        buys, leftover = _cover(plannable, within, kerf, allow_rotate,
+                                edge_trim, packer)
+
+    for p in leftover:
+        flagged.append((p[0], p[1], p[2],
+                        "could not be seated on any single stocked piece"))
+
+    return SheetPlan(buys, flagged, notes)
 
 
 def board_feet(stock_t, stock_w, length):

--- a/plugins-claude/freecad/lib/wwkit.py
+++ b/plugins-claude/freecad/lib/wwkit.py
@@ -142,8 +142,21 @@ MDF = {  # MDF is true to nominal, unlike ply
 }
 
 # --- appearance ----------------------------------------------------------
+# Colour + transparency are keyed by a part's `kind` (see Model.add). `kind` is
+# a free-form string, so a model can invent its own; anything not in KIND_STYLE
+# falls back to KIND_STYLE_DEFAULT. Transparency lets joinery read through a shell.
 WOOD = (0.80, 0.60, 0.35)
 PRINTED = (0.20, 0.55, 0.85)
+HARDWARE = (0.56, 0.58, 0.61)   # purchased metal: slides, casters, lift plates
+STEEL = (0.26, 0.28, 0.32)      # fasteners
+
+KIND_STYLE = {           # kind -> (rgb, transparency%)
+    "wood":     (WOOD, 35),
+    "printed":  (PRINTED, 0),
+    "hardware": (HARDWARE, 0),
+    "steel":    (STEEL, 0),
+}
+KIND_STYLE_DEFAULT = (PRINTED, 0)
 
 PLA_DENSITY = 1.24  # g/cm^3
 TESSELLATION = 0.05  # mm deviation for the printability mesh check
@@ -175,6 +188,54 @@ def solid(dx, dy, dz, at=(0, 0, 0)):
 
 def cyl(radius, height, at=(0, 0, 0), axis=(0, 0, 1)):
     return Part.makeCylinder(radius, height, App.Vector(*at), App.Vector(*axis))
+
+
+def frange(start, stop, step):
+    """range() for floats: start, start+step, ... up to (not including) stop.
+
+    range() is int-only, so fixed-pitch layouts -- rib grids, dog-hole fields,
+    screw on-centre spacing -- otherwise need a hand-rolled while-loop each time.
+    """
+    out, v = [], start
+    while v < stop:
+        out.append(v)
+        v += step
+    return out
+
+
+def prism(profile, length, along="y", at=(0, 0, 0)):
+    """Extrude a 2D profile into a solid -- the primitive for ANGLED joinery.
+
+    `profile` is a list of (u, v) points (a polygon, in order; auto-closed) drawn
+    in the plane perpendicular to `along`, then swept `length` along that axis:
+      along="y" -> (u, v) = (x, z)   along="x" -> (y, z)   along="z" -> (x, y)
+    `at` offsets the whole prism. Use it for cleats, ramps, bevels, tapers, and
+    dovetail keys -- the angled cuts chamfer()'s edge predicate can't place.
+    Returns a Part.Shape, so it drops into m.add(name, prism(...)) or
+    part.cut(prism(...)) directly.
+    """
+    ax = {"x": 0, "y": 1, "z": 2}[along]
+    plane = [i for i in (0, 1, 2) if i != ax]
+
+    def pt(u, v):
+        c = [0.0, 0.0, 0.0]
+        c[plane[0]], c[plane[1]] = u, v
+        return App.Vector(c[0] + at[0], c[1] + at[1], c[2] + at[2])
+
+    pts = [pt(u, v) for (u, v) in profile]
+    pts.append(pts[0])
+    ext = [0.0, 0.0, 0.0]
+    ext[ax] = length
+    return Part.Face(Part.makePolygon(pts)).extrude(App.Vector(*ext))
+
+
+def wedge(u0, u1, v0, v1, length, along="y", at=(0, 0, 0)):
+    """Right-triangle prism (a ramp) -- the common case of prism().
+
+    Triangle corners (u0,v0)-(u1,v0)-(u0,v1) swept `length`; the ramp is the
+    hypotenuse from (u1,v0) to (u0,v1). Same axis/plane convention as prism().
+    """
+    return prism([(u0, v0), (u1, v0), (u0, v1)], length, along=along, at=at)
 
 
 # --- edge selection by geometry, not by index ----------------------------
@@ -441,15 +502,20 @@ class Model:
             label, shape = shape.name, shape.shape
         mesh = Mesh.Mesh()
         mesh.addFacets(shape.tessellate(TESSELLATION))
+        # A shape split into two disconnected solids (e.g. a bevel that cut a
+        # shell in two, leaving a floating cap) is individually valid/closed/
+        # manifold per piece, so it would otherwise "pass" -- one body only.
+        solids = len(shape.Solids)
         ok = (
-            shape.isValid()
+            solids == 1
+            and shape.isValid()
             and shape.isClosed()
             and mesh.isSolid()
             and not mesh.hasNonManifolds()
             and not mesh.hasSelfIntersections()
         )
-        say("PRINTABLE %-14s %s  (valid=%s closed=%s manifold=%s no-self-isect=%s)"
-            % (label, "OK" if ok else "FAIL", shape.isValid(), shape.isClosed(),
+        say("PRINTABLE %-14s %s  (solids=%d valid=%s closed=%s manifold=%s no-self-isect=%s)"
+            % (label, "OK" if ok else "FAIL", solids, shape.isValid(), shape.isClosed(),
                not mesh.hasNonManifolds(), not mesh.hasSelfIntersections()))
         return ok
 
@@ -709,9 +775,9 @@ class Model:
 
         for p in self.parts:
             vo = p.obj.ViewObject
-            vo.ShapeColor = WOOD if p.kind == "wood" else PRINTED
-            if p.kind == "wood":
-                vo.Transparency = 35
+            color, transp = KIND_STYLE.get(p.kind, KIND_STYLE_DEFAULT)
+            vo.ShapeColor = color
+            vo.Transparency = transp
             vo.Visibility = True
         say("VIEW      %d part(s) coloured and shown" % len(self.parts))
         Gui.updateGui()

--- a/plugins-claude/freecad/lib/wwkit.py
+++ b/plugins-claude/freecad/lib/wwkit.py
@@ -272,12 +272,17 @@ def edges_at(shape, z=None, tol=1e-6):
 class Part_:
     """One real part: a named solid with a material role."""
 
-    def __init__(self, obj, kind, nominal=None, stock=None, form=None):
+    def __init__(self, obj, kind, nominal=None, stock=None, form=None,
+                 oversize=None):
         self.obj = obj
         self.kind = kind  # "wood" | "printed"
         self.nominal = nominal  # (dx, dy, dz) as authored, for the cut list
         self.stock = stock  # e.g. "2x4" — the nominal name you buy it under
         self.form = form  # "board" | "sheet" | None — how the planner packs it
+        # Rough-cut allowance for THIS part, or None to use the cutplan default.
+        # 0 exempts a part that is already final size, or a glue-up member whose
+        # trim happens at the assembly (set the assembly's oversize instead).
+        self.oversize = oversize
 
     @property
     def name(self):
@@ -328,18 +333,40 @@ class Model:
         self.parts = []
 
     # -- construction -----------------------------------------------------
-    def add(self, name, shape, kind="wood", nominal=None, stock=None, form=None):
+    def add(self, name, shape, kind="wood", nominal=None, stock=None, form=None,
+            oversize=None):
         o = self.doc.addObject("Part::Feature", name)
         o.Shape = shape
-        p = Part_(o, kind, nominal=nominal, stock=stock, form=form)
+        p = Part_(o, kind, nominal=nominal, stock=stock, form=form,
+                  oversize=oversize)
         self.parts.append(p)
         return p
 
-    def box(self, name, dx, dy, dz, at=(0, 0, 0), kind="wood"):
-        return self.add(name, solid(dx, dy, dz, at), kind, nominal=(dx, dy, dz))
+    def box(self, name, dx, dy, dz, at=(0, 0, 0), kind="wood", oversize=None,
+            form=None, stock=None):
+        """A plain rectangular solid. Pass form="board"/"sheet" and a stock name
+        to have cutplan buy it (e.g. a hardwood edge band as linear stock, a
+        laminate as a sheet); leave them off and it is a shape the plan skips."""
+        return self.add(name, solid(dx, dy, dz, at), kind, nominal=(dx, dy, dz),
+                        oversize=oversize, form=form, stock=stock)
+
+    def strip(self, name, shape, stock, kind="wood", oversize=None):
+        """A part cut to length from linear stock whose shape is not a plain
+        board() box — a ripped hardwood cleat, an angled edge band, an on-edge
+        ply strip. cutplan buys it as a board: its longest bounding dimension is
+        the length, and parts sharing a `stock` name come off the same sticks.
+
+        `shape` is any already-built Part shape (e.g. from ww.prism/wedge). Use
+        distinct `stock` names for distinct rip profiles so the plan does not
+        pool a wide band with a narrow cleat onto one stick."""
+        bb = shape.BoundBox
+        return self.add(name, shape, kind,
+                        nominal=(bb.XLength, bb.YLength, bb.ZLength),
+                        stock=stock, form="board", oversize=oversize)
 
     def board(self, name, stock, length, at=(0, 0, 0),
-              length_axis="x", thickness_axis="z", rip=None, kind="wood"):
+              length_axis="x", thickness_axis="z", rip=None, kind="wood",
+              oversize=None):
         """A board of real dimensional lumber. `stock` is nominal ("2x4").
 
         Orientation is given by two axes rather than one, because one is
@@ -358,10 +385,10 @@ class Model:
         by_axis = {length_axis: length, thickness_axis: t, width_axis: w}
         dims = (by_axis["x"], by_axis["y"], by_axis["z"])
         return self.add(name, solid(*dims, at=at), kind, nominal=dims,
-                        stock=stock, form="board")
+                        stock=stock, form="board", oversize=oversize)
 
     def panel(self, name, stock, length, width, at=(0, 0, 0),
-              thickness_axis="z", table=PLY, kind="wood"):
+              thickness_axis="z", table=PLY, kind="wood", oversize=None):
         """A sheet-goods panel. `stock` keys into PLY / BALTIC / MDF.
 
         thickness_axis matters: a cabinet bottom is thick in Z, a back panel is
@@ -376,7 +403,8 @@ class Model:
         by_axis = {thickness_axis: t, others[0]: length, others[1]: width}
         dims = (by_axis["x"], by_axis["y"], by_axis["z"])
         return self.add(name, solid(*dims, at=at), kind,
-                        nominal=dims, stock=stock, form="sheet")
+                        nominal=dims, stock=stock, form="sheet",
+                        oversize=oversize)
 
     def place(self, name, shape, at=(0, 0, 0), rot_z=0.0, kind="printed"):
         """Stamp an already-built shape into the model at a placement."""
@@ -565,19 +593,35 @@ class Model:
                 % (p.name, p.stock or "", fmt(dims[0]), fmt(dims[1]), fmt(dims[2])))
         return rows
 
-    def cutplan(self, stock_lengths=None, kerf=None, allow_rotate=False,
-                max_length=None, sheet_piece=None):
+    def cutplan(self, board_lengths=None, sheet_sizes=None, kerf=None,
+                allow_rotate=False, max_length=None, sheet_piece=None,
+                end_trim=None, edge_trim=None, oversize=None, packer="auto",
+                stock_lengths=None):
         """From a parts list to a shopping list and a cutting order.
 
         `cutlist()` says what parts you need. This says what to *buy*, and board
         by board what to cut from each one — the thing you take to the yard and
         then to the saw.
 
-        max_length   the longest piece you can actually get home. Stock longer
-                     than this is never offered, however well it would pack.
-        sheet_piece  "full" | "half" | "half-rip", or None to choose. You always
-                     buy a full 4x8; this is what you ask the store to cut it
-                     into before it goes in the vehicle.
+        board_lengths  sellable board lengths to choose from (default catalog).
+        sheet_sizes    sellable sheet sizes as [(grain, cross, name), ...].
+        max_length     the longest piece you can actually get home. Stock longer
+                       than this is never offered, however well it would pack.
+        sheet_piece    "full" | "half" | "half-rip", or None to choose. You always
+                       buy a full sheet; this is what you ask the store to cut it
+                       into before it goes in the vehicle.
+        end_trim       squared off each board end before packing (default 1").
+        edge_trim      trimmed off each sheet edge before packing (default 1/2").
+        oversize       default rough-cut allowance per part (default 1/8"): parts
+                       are cut oversize and trimmed to final for clean edges. A
+                       board grows only in length (its width is fixed rip stock);
+                       a sheet part grows in both faces. Any part can override via
+                       board()/panel()/box(oversize=...) — set 0 for a part that
+                       is already final, or a glue-up member trimmed at the
+                       assembly (put the allowance on the assembly instead).
+        packer         "auto" | "rectpack" | "shelf" sheet-packing engine.
+
+        `stock_lengths` is a deprecated alias for `board_lengths`.
 
         Parts made with box() are skipped: no stock, so nothing to buy them
         from. Use board() or panel() to have them planned.
@@ -585,6 +629,10 @@ class Model:
         import wwcut
 
         kerf = wwcut.KERF if kerf is None else kerf
+        end_trim = wwcut.END_TRIM if end_trim is None else end_trim
+        edge_trim = wwcut.EDGE_TRIM if edge_trim is None else edge_trim
+        oversize = wwcut.OVERSIZE if oversize is None else oversize
+        board_lengths = board_lengths if board_lengths is not None else stock_lengths
 
         boards = [p for p in self.parts if p.form == "board"]
         sheets = [p for p in self.parts if p.form == "sheet"]
@@ -593,9 +641,13 @@ class Model:
 
         say("=" * 64)
         limit = "  (transport limit %s)" % fmt(max_length) if max_length else ""
-        say("CUT PLAN  (kerf %s)%s" % (fmt(kerf), limit))
+        say("CUT PLAN  (kerf %s, end-trim %s, edge-trim %s, oversize %s)%s"
+            % (fmt(kerf), fmt(end_trim), fmt(edge_trim), fmt(oversize), limit))
+        if oversize:
+            say("          part sizes below are rough (cut oversize, trim to final)")
 
         buy = []
+        flags = []   # (name, reason) — parts that could not meet the limits
 
         # --- boards, grouped by the stock you buy them as -----------------
         by_stock = {}
@@ -603,17 +655,28 @@ class Model:
             by_stock.setdefault(p.stock, []).append(p)
 
         for stock in sorted(by_stock):
-            items = [(p.name, max(p.nominal)) for p in by_stock[stock]]
-            plan = wwcut.plan_linear(items, stock_lengths, kerf, max_length)
-            say("")
-            say("  %s  -- %d board(s) of %s"
-                % (stock, len(plan), fmt_stock(plan[0].length)))
-            for i, b in enumerate(plan, 1):
-                cuts = ", ".join("%s (%s)" % (n, fmt(l)) for n, l in b.cuts)
-                say("    #%d: %s" % (i, cuts))
-                say("        offcut %s" % fmt(b.offcut))
-            buy.append("%d x %s @ %s"
-                       % (len(plan), stock, fmt_stock(plan[0].length)))
+            # Per-part oversize (rough-cut allowance), defaulting to the cutplan
+            # default. On a board only the LENGTH grows — width is fixed stock
+            # you rip — so a glue-up member gets a trim-to-length allowance and
+            # never a cross-seam one.
+            items = [(p.name,
+                      max(p.nominal) + (oversize if p.oversize is None
+                                        else p.oversize))
+                     for p in by_stock[stock]]
+            plan = wwcut.plan_linear(items, board_lengths, kerf, max_length,
+                                     end_trim, 0.0)
+            for n, l, reason in plan.flagged:
+                flags.append(("%s %s (%s)" % (stock, n, fmt(l)), reason))
+            if len(plan):
+                say("")
+                say("  %s  -- %d board(s) of %s"
+                    % (stock, len(plan), fmt_stock(plan[0].length)))
+                for i, b in enumerate(plan, 1):
+                    cuts = ", ".join("%s (%s)" % (n, fmt(l)) for n, l in b.cuts)
+                    say("    #%d: %s" % (i, cuts))
+                    say("        offcut %s" % fmt(b.offcut))
+                buy.append("%d x %s @ %s"
+                           % (len(plan), stock, fmt_stock(plan[0].length)))
 
         # --- sheet goods, grouped by thickness ----------------------------
         by_sheet = {}
@@ -624,37 +687,60 @@ class Model:
             items = []
             for p in by_sheet[stock]:
                 dims = sorted(p.nominal, reverse=True)
-                items.append((p.name, dims[0], dims[1]))
+                # A sheet part IS the trimmed panel, so both faces grow by the
+                # part's oversize (default when None). Set oversize=0 on a part
+                # whose trimming happens at the assembly, not the part.
+                ov = oversize if p.oversize is None else p.oversize
+                items.append((p.name, dims[0] + ov, dims[1] + ov))
 
-            sb = wwcut.choose_sheets(items, kerf, allow_rotate,
-                                     max_length, sheet_piece)
-            say("")
-            say("  %s ply  -- %d x '%s' piece (%s x %s), from %d full sheet(s)"
-                % (stock, len(sb.pieces), sb.piece_name,
-                   fmt_stock(sb.piece[0]), fmt_stock(sb.piece[1]),
-                   sb.full_sheets))
-            say("      %.0f%% of the bought material used%s"
-                % (sb.yield_pct, "" if allow_rotate else ", grain respected"))
-            for i, s in enumerate(sb.pieces, 1):
-                say("    piece #%d:" % i)
-                for strip in s.strips:
-                    parts = ", ".join("%s (%s x %s)" % (n, fmt(pl), fmt(pw))
-                                      for n, pl, pw in strip["parts"])
-                    say("      rip %s wide: %s" % (fmt(strip["depth"]), parts))
+            sp = wwcut.choose_sheets(items, sheet_sizes, kerf, allow_rotate,
+                                     max_length, edge_trim, sheet_piece, packer,
+                                     0.0)
+            for note in sp.notes:
+                say("")
+                say("  NOTE (%s sheet): %s" % (stock, note))
+            for n, pl, pw, reason in sp.flagged:
+                flags.append(("%s %s (%s x %s)"
+                              % (stock, n, fmt(pl), fmt(pw)), reason))
 
-            if sb.piece_name == "full":
-                buy.append("%d x %s full sheet" % (sb.full_sheets, stock))
-            else:
-                cut = ("cut in half" if sb.piece_name == "half"
-                       else "ripped in half lengthwise")
-                spare = (", %d spare" % sb.spare_pieces) if sb.spare_pieces else ""
-                buy.append("%d x %s full sheet (%s at the store%s)"
-                           % (sb.full_sheets, stock, cut, spare))
+            for sb in sp.buys:
+                piece_of = ("" if sb.piece_name == "full"
+                            else " %s piece" % sb.piece_name)
+                say("")
+                say("  %s sheet  -- %d x %s%s (%s x %s), from %d full %s sheet(s) [%s]"
+                    % (stock, len(sb.pieces), sb.sheet_name, piece_of,
+                       fmt_stock(sb.piece[0]), fmt_stock(sb.piece[1]),
+                       sb.full_sheets, sb.sheet_name, sb.engine))
+                say("      %.0f%% of the bought material used%s"
+                    % (sb.yield_pct, "" if allow_rotate else ", grain respected"))
+                for i, s in enumerate(sb.pieces, 1):
+                    say("    piece #%d:" % i)
+                    for strip in s.strips:
+                        parts = ", ".join("%s (%s x %s)" % (n, fmt(pl), fmt(pw))
+                                          for n, pl, pw in strip["parts"])
+                        say("      rip %s wide: %s" % (fmt(strip["depth"]), parts))
+
+                if sb.piece_name == "full":
+                    buy.append("%d x %s %s full sheet"
+                               % (sb.full_sheets, stock, sb.sheet_name))
+                else:
+                    cut = ("cut in half" if sb.piece_name == "half"
+                           else "ripped in half lengthwise")
+                    spare = ((", %d spare" % sb.spare_pieces)
+                             if sb.spare_pieces else "")
+                    buy.append("%d x %s %s full sheet (%s at the store%s)"
+                               % (sb.full_sheets, stock, sb.sheet_name, cut, spare))
 
         if skipped:
             say("")
             say("  NOTE: %d part(s) not planned (made with box(), so no stock): %s"
                 % (len(skipped), ", ".join(p.name for p in skipped)))
+
+        if flags:
+            say("")
+            say("FLAGGED   %d part(s) cannot meet the size limits:" % len(flags))
+            for what, reason in flags:
+                say("  ! %s: %s" % (what, reason))
 
         say("")
         say("BUY       " + ("; ".join(buy) if buy else "nothing to plan"))

--- a/plugins-claude/freecad/scripts/fcopen
+++ b/plugins-claude/freecad/scripts/fcopen
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# fcopen — open a second document as a TAB in a running live session, instead of
+# spawning a whole new window. Use it to inspect one part or joint in isolation
+# (a detail study) without taking over the desktop.
+#
+# The target is either a wwkit model script (.py, built fresh in the session) or
+# a saved .FCStd. It opens as a new tab and, because ww.Model only closes its own
+# doc name on rebuild, survives the watched script's rebuilds. Snap it with
+# `fcsnap <session-model.py>` (it captures the active tab).
+#
+# Usage:
+#   fcopen <session-model.py> <file.py|.FCStd>
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./fcsession
+source "$HERE/fcsession"
+
+SESSION="${1:-}"
+TARGET="${2:-}"
+if [[ -z "$SESSION" || -z "$TARGET" ]]; then
+  echo "fcopen: usage: fcopen <session-model.py> <file.py|.FCStd>" >&2
+  exit 2
+fi
+if [[ ! -f "$TARGET" ]]; then
+  echo "fcopen: file not found: $TARGET" >&2
+  exit 2
+fi
+
+if ! _fc_running; then
+  echo "fcopen: no live session — start one with: fclive -b $(basename "$SESSION")" >&2
+  exit 3
+fi
+
+_fcsession_paths "$SESSION"
+
+TARGET_ABS="$(cd "$(dirname "$TARGET")" && pwd)/$(basename "$TARGET")"
+echo "$TARGET_ABS" >"$WW_OPEN"
+
+# The watcher polls once a second and removes the file once it has handled it.
+for _ in $(seq 1 20); do
+  [[ -f "$WW_OPEN" ]] || break
+  sleep 1
+done
+
+if [[ -f "$WW_OPEN" ]]; then
+  rm -f "$WW_OPEN"
+  echo "fcopen: session did not respond — is the watcher running? (see $WW_LOG)" >&2
+  exit 1
+fi
+
+echo "fcopen: opened '$(basename "$TARGET_ABS")' as a new tab (see $WW_LOG)"

--- a/plugins-claude/freecad/scripts/fcrender
+++ b/plugins-claude/freecad/scripts/fcrender
@@ -17,8 +17,20 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 LIB_DIR="$(cd "$HERE/../lib" && pwd)"
 
 DOC="${1:-}"
-if [[ -z "$DOC" || ! -f "$DOC" ]]; then
+if [[ -z "$DOC" ]]; then
   echo "fcrender: usage: fcrender <model.FCStd> [out_dir] [views]" >&2
+  exit 2
+fi
+if [[ ! -f "$DOC" ]]; then
+  echo "fcrender: file not found: $DOC" >&2
+  # ww.Model sanitises the doc name to [A-Za-z0-9_], so Model('a-b') saves
+  # 'a_b.FCStd' -- a hyphen or space in the name becomes '_' on disk. If the
+  # sanitised sibling exists, point at it instead of a bare usage line.
+  base="$(basename "$DOC")"
+  san="${base//[^A-Za-z0-9_.]/_}"
+  if [[ "$san" != "$base" && -f "$(dirname "$DOC")/$san" ]]; then
+    echo "fcrender: did you mean '$(dirname "$DOC")/$san'? (ww.Model sanitises the doc name)" >&2
+  fi
   exit 2
 fi
 

--- a/plugins-claude/freecad/scripts/fcsession
+++ b/plugins-claude/freecad/scripts/fcsession
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # fcsession — resolve the control-file paths for a live session.
 #
-# Sourced by fclive, fcquit and fcsnap so they all agree on where the control
-# files live for a given model script. Sets: WW_LOG, WW_STOP, WW_SNAP.
+# Sourced by fclive, fcquit, fcsnap and fcopen so they all agree on where the
+# control files live for a given model script. Sets: WW_LOG, WW_STOP, WW_SNAP,
+# WW_OPEN.
 
 _fcsession_paths() {
   local script="$1"
@@ -13,7 +14,8 @@ _fcsession_paths() {
   : "${WW_LOG:=${dir%/}/fclive-${base}.log}"
   : "${WW_STOP:=${dir%/}/fclive-${base}.stop}"
   : "${WW_SNAP:=${dir%/}/fclive-${base}.snap}"
-  export WW_LOG WW_STOP WW_SNAP
+  : "${WW_OPEN:=${dir%/}/fclive-${base}.open}"
+  export WW_LOG WW_STOP WW_SNAP WW_OPEN
 }
 
 # Is a FreeCAD instance up?

--- a/plugins-claude/freecad/scripts/fcsnap
+++ b/plugins-claude/freecad/scripts/fcsnap
@@ -5,15 +5,19 @@
 # human's manipulation is invisible to it and destroyed by the next rebuild.
 #
 # Emits, into <out_dir>:
-#   <doc>.snap.png   the user's ACTUAL camera, not a canned view
+#   <doc>.snap.png   the user's camera by default, or a canned view if given
 #   snapshot.json    { selected: [...], moved: [{name, delta_mm, delta_yaw_deg}] }
 #
 # `moved` is the payload that matters: it diffs each part's live placement
 # against where the script put it (recorded by wwkit in <doc>.intent.json), so a
 # drag becomes a concrete proposal to fold back into the script.
 #
+# The optional [view] renders a canned angle (iso/top/front/rear/left/right/
+# bottom) in the EXISTING window and snaps the user's camera right back -- so you
+# get any view you need without ever opening a fresh, focus-stealing window.
+#
 # Usage:
-#   fcsnap model.py [out_dir]
+#   fcsnap model.py [out_dir] [view]
 
 set -euo pipefail
 

--- a/plugins-claude/freecad/skills/live/SKILL.md
+++ b/plugins-claude/freecad/skills/live/SKILL.md
@@ -56,8 +56,9 @@ launch behind a modal dialog you cannot see.
 
 ## If navigation feels broken
 
-FreeCAD ships with three-button-mouse bindings that are unusable on a trackpad.
-Tell the user to set the navigation style to **Gesture** via the dropdown in the
-status bar (bottom right, shows `CAD` by default): left-drag rotates, two-finger
-drag pans, scroll zooms. Spacebar toggles visibility of the tree selection,
-which is how you isolate a part.
+`fclive` now sets sane defaults on first build — **Gesture** navigation (trackpad
+friendly: left-drag rotates, two-finger drag pans, scroll zooms), **Turntable**
+orbit (spins about vertical and keeps "up", instead of Trackball tumbling), and
+rotate-about-cursor. If it still feels off, the navigation style is the dropdown
+in the status bar (bottom right). Spacebar toggles visibility of the tree
+selection, which is how you isolate a part.

--- a/plugins-claude/freecad/skills/modeling/SKILL.md
+++ b/plugins-claude/freecad/skills/modeling/SKILL.md
@@ -22,14 +22,24 @@ disposable and regenerable.** Never hand-edit a `.FCStd`.
 
 | Command | Purpose |
 |---|---|
-| `${CLAUDE_PLUGIN_ROOT}/scripts/fcrun model.py` | Headless build: validation + exports, no GUI. Fast. Use while iterating alone. |
-| `${CLAUDE_PLUGIN_ROOT}/scripts/fclive -b model.py` | Start the live session the user watches. Leave it running. |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/fcrun model.py` | Headless build: validation + exports, no GUI, no window. Fast. Your default. |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/fclive -b model.py` | Start the live session the user watches. Leave it running — the ONE window. |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/fcsnap model.py [out] [view]` | See the live session in the user's own window — their camera, or a canned `view` (iso/top/front/...) that snaps back. Plus selection + drags. **No new window.** |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/fcopen model.py part.py` | Open a detail study as a TAB in the live window (no new window); `fcsnap` captures it. |
 | `${CLAUDE_PLUGIN_ROOT}/scripts/fcquit model.py` | Stop it cleanly. **Always use this — never `kill`.** |
-| `${CLAUDE_PLUGIN_ROOT}/scripts/fcsnap model.py` | Read the live session back: the user's camera, selection, and drags. |
-| `${CLAUDE_PLUGIN_ROOT}/scripts/fcrender doc.FCStd out/ iso,top,front` | Render PNGs, then `Read` them. This is how you see your own geometry. |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/fcrender doc.FCStd out/ iso,top,front` | Render PNGs to disk — but opens a throwaway GUI window that steals focus. Last resort; prefer `fcsnap`. |
 
 Look at your own renders before asking the user to look. Catching your own
 mistake costs a tool call; making them catch it costs their attention.
+
+**Do not take over the user's desktop.** Every `fcrun --gui` and every `fcrender`
+opens a FreeCAD window that steals focus — fine once, maddening on every
+iteration. So: verify **headless** (`fcrun` + `check_clashes()`, bounding boxes,
+`Shape.isInside` point checks — no window), and *see* results through the live
+session — `fcsnap` (their window, optional canned view) or a detail study in an
+`fcopen` tab. There is no headless PNG path on macOS (Qt-offscreen hangs, Coin's
+offscreen renderer errors), so reserve `fcrender`/`fcrun --gui` for when no live
+session is open at all.
 
 ## The loop runs both ways
 
@@ -109,6 +119,30 @@ Orientation is explicit: `board()` takes `length_axis` **and** `thickness_axis`,
 because one axis is ambiguous — a board lying flat and the same board on edge
 share a length axis and are not the same part.
 
+### Angled joinery, ramps, and grids
+
+`trench`/`dado`/`rabbet`/`notch` all cut axis-aligned boxes. For anything
+*angled* — a French-cleat ramp, a bevel, a taper, a dovetail key — reach for
+`ww.prism(profile, length, along=...)`: it extrudes a 2D `(u, v)` polygon (drawn
+in the plane perpendicular to `along`; `y`→`(x,z)`, `x`→`(y,z)`, `z`→`(x,y)`)
+into a solid you drop straight into `m.add(name, ...)` or `part.cut(...)`.
+`ww.wedge(u0, u1, v0, v1, length, along=...)` is the right-triangle (ramp) case.
+Both beat fighting `chamfer()`'s edge predicate when you want a specific angled
+face at a specific place.
+
+`ww.frange(start, stop, step)` is `range()` for floats — rib grids, dog-hole
+fields, screw on-centre spacing. Size the span to a whole multiple of the pitch
+so end margins come out even (e.g. a 192 mm rib grid with 96 mm dog holes offset
+48 mm lands no hole on a rib).
+
+### Part kinds set the colour
+
+`m.add`/`box`/`board`/`panel` take `kind=`: `"wood"` (default, brown, 35%
+see-through so joinery reads), `"printed"` (blue), `"hardware"` (grey — bought
+metal: slides, casters, plates), `"steel"` (fasteners). Unknown kinds fall back
+to blue, and `KIND_STYLE` is a plain dict you can extend. `kind` also drives the
+reports: `cutlist()` counts `wood`, `filament()` counts `printed`.
+
 ### Select edges by geometry, never by index
 
 `Edge7` is renumbered by a recompute — that is FreeCAD's topological naming
@@ -129,7 +163,10 @@ These are not hypotheticals; each one has already cost a debugging session.
 named `bracket_box`. Any lookup against the unsanitised name silently misses —
 which, in a live-reload loop, means every rebuild stacks *another* document
 (`bracket_box`, `bracket_box1`, ...) instead of replacing it. `ww.Model` handles
-this; if you call `App.newDocument` yourself, sanitise to `[A-Za-z0-9_]`.
+this; if you call `App.newDocument` yourself, sanitise to `[A-Za-z0-9_]`. The
+**saved file** uses the sanitised name too, so `Model("bt-band")` writes
+`bt_band.FCStd` — `fcrender bt-band.FCStd` misses (it now points you at the
+sanitised sibling, but the file on disk is always the underscored name).
 
 **Headless documents open invisible.** With no GUI, `obj.ViewObject` is `None` —
 no view providers exist, so a headless-authored `.FCStd` opens with everything
@@ -164,6 +201,12 @@ photographs the camera mid-flight. `fcrender` settles the event loop first.
 Start `fclive -b` once and leave it up for the session. Edit the script; do not
 restart FreeCAD to apply a change — the watcher reloads `wwkit` too, so library
 edits land live as well.
+
+**Don't point `fcrun` or `fcrender` at the folder a live session owns.** Writing
+the same `WW_OUT`/`.FCStd` that a `fclive` session holds open makes FreeCAD see
+an external change and can wedge the QTimer reloader (only "rebuild #1" ever
+logs, and `fcquit` then can't complete). Validate and render to a *temp* dir
+instead — e.g. `WW_OUT=$(mktemp -d) fcrun model.py`.
 
 Report what changed in terms they care about (panel dimensions, filament grams,
 clashes), not in terms of FreeCAD objects.

--- a/plugins-claude/freecad/skills/modeling/SKILL.md
+++ b/plugins-claude/freecad/skills/modeling/SKILL.md
@@ -95,18 +95,57 @@ never a 38x89).
 ### cutplan(), not just cutlist()
 
 `cutlist()` says what parts are needed. `cutplan()` says what to **buy** and what
-to **cut from each board** — that is the useful artefact. It only plans parts made
-with `board()` or `panel()`; a part made with `box()` has no stock, so there is
-nothing to buy it from, and it is reported as skipped. Prefer `board()`/`panel()`
-for anything real.
+to **cut from each board** — that is the useful artefact. It plans any part that
+carries a `stock` and a `form`: `board()`/`panel()` set them for you. A plain
+`box()` has neither, so it is reported as skipped — fine for a part cut from
+scrap, but give it `box(form="board"/"sheet", stock="…")` to have it bought. For
+a custom shape (a ripped hardwood cleat, an angled edge band from `ww.prism`),
+`m.strip(name, shape, stock=…)` declares it as linear stock — cutplan buys it as
+a board whose length is the shape's longest bounding dimension.
+
+Use distinct `stock` names for distinct rip **profiles**: a linear plan packs by
+length and ignores width, so parts sharing a `stock` are assumed to come off the
+same stick. That also means thin strips ripped many-to-a-board (narrow cleats)
+are *over-counted* — each is planned as its own full-length stick. For a handful
+of strips that is a safe over-estimate; when it matters, model them from a wider
+`board()` and rip, or account the hardwood in board-feet.
 
 Rotation of sheet parts is off by default because **grain runs the length of a
 sheet**. Do not enable it to improve yield unless the material has no grain.
 
 **This user drives a Tacoma (5ft bed) and prefers half sheets.** Default to
-`m.cutplan(max_length=ww.ft(8), sheet_piece="half")` unless told otherwise — a
-plan that buys a 12ft board or a full 4x8 is a plan he cannot get home. He always
-buys a full sheet and has the store cut it; `sheet_piece` says how.
+`m.cutplan(max_length=ww.ft(8), sheet_piece="half")` unless told otherwise — he
+always buys a full sheet and has the store cut it, and `sheet_piece` says how.
+These are *preferences*, not hard rules: a part too big for the preferred piece
+(a 1920×960 skin will not come from a 4×4 half) is **upgraded** to the smallest
+piece that fits, and the plan prints a NOTE naming it. A part that cannot meet
+the limits at all — bigger than any stocked sheet, or too big to carry within
+`max_length` — is listed under **FLAGGED** with a reason (and everything else is
+still planned) rather than crashing or, worse, printing an impossible cut.
+
+`cutplan()` knobs worth knowing:
+
+- **catalog** — `board_lengths=[...]` and `sheet_sizes=[(grain, cross, "name"), ...]`
+  are what the yard sells; least-material selection tries each and keeps the
+  cheapest that fits. Defaults: 6/8/10/12/16 ft boards, 4x8 + 5x5 sheets.
+- **margins** — `end_trim` is squared off each board *end* (default 1"),
+  `edge_trim` off each sheet *edge* (default ½"), before anything is packed.
+  Offcuts and yield are measured against the trimmed usable stock, not nominal.
+- **oversize** — parts are cut rough and trimmed to final, to align edges and
+  clean tearout, so each part is grown by `oversize` (default ⅛") before packing.
+  A **board** grows only in *length* (its width is fixed rip stock), which is
+  exactly right for a glue-up member — you trim the assembly to length at both
+  ends and never cut across the glued seams. A **sheet part** grows in *both*
+  faces, because a sheet part is itself the panel you trim to final. The plan
+  prints the *rough* cut sizes; `cutlist()` still lists final sizes. Override per
+  part with `board()/panel()/box(oversize=...)` — set `0` for a part already at
+  final size, or for a glue-up member whose trimming happens at the assembly
+  (model the assembly and give *it* the allowance). `cutplan(oversize=0)` turns
+  the default off everywhere.
+- **packer** — `"auto"` (default) uses `rectpack` when it is importable and its
+  layout reduces to clean rips, else the built-in shelf packer; `"shelf"` forces
+  the built-in. The report names which engine ran. `rectpack` (Apache-2.0) is a
+  soft dependency: `<freecad-python> -m pip install rectpack` to enable it.
 
 ### Joinery
 

--- a/tests/freecad/_cutplan_probe.py
+++ b/tests/freecad/_cutplan_probe.py
@@ -1,0 +1,74 @@
+"""Headless integration probe for Model.cutplan (the wwkit <-> wwcut wiring).
+
+Run inside FreeCAD by tests/freecad/test-cutplan-integration.sh. Asserts on the
+cut plan written to $WW_LOG: per-part oversize, stock grouping, preference
+escalation with a note, and flag aggregation for parts that can't meet limits.
+Any assertion failure raises -> fcrun reports it and the suite fails. On success
+the last line of the log is "PROBE OK".
+"""
+import os
+import sys
+
+sys.path.insert(0, os.environ["WWKIT_LIB"])
+import wwkit as ww  # noqa: E402
+
+ww.UNITS = "mm"  # predictable numbers for substring assertions
+
+m = ww.Model("cutplan_probe")
+
+# Two identical 2x4 boards, one at default oversize and one exempted, plus a
+# board too long to carry home.
+m.board("Def", "2x4", 600.0, length_axis="x")
+m.board("Exempt", "2x4", 600.0, at=(0, 200, 0), length_axis="x", oversize=0.0)
+m.board("TooLong", "2x4", 3000.0, at=(0, 400, 0), length_axis="x")
+
+# Sheet goods: two smalls that fit a half, a skin that must escalate to a full,
+# and a giant that fits no stocked sheet at all.
+m.panel("S1", "3/4", 500.0, 400.0)
+m.panel("S2", "3/4", 500.0, 400.0, at=(0, 600, 0))
+m.panel("Skin", "3/4", 1900.0, 950.0, at=(0, 1200, 0))
+m.panel("Giant", "3/4", ww.ft(9), ww.ft(9), at=(0, 2400, 0))
+
+# A custom-shaped part declared as linear strip stock, and a laminate as a sheet:
+# both must be *planned*, not dropped as unplannable box() shapes.
+m.strip("HW_Cleat", ww.prism([(0, 0), (14, 0), (0, 14)], 700.0, along="x"),
+        stock="Hardwood")
+m.box("Laminate", 900.0, 500.0, 1.2, at=(0, 3600, 0), form="sheet", stock="Formica")
+
+buy = m.cutplan(max_length=ww.ft(8), sheet_piece="half", oversize=3.0)
+
+m.finish(os.environ.get("WW_OUT", os.getcwd()))
+
+log = open(os.environ["WW_LOG"]).read()
+
+
+def want(cond, why):
+    if not cond:
+        raise AssertionError("cutplan probe: " + why)
+
+
+# Per-part oversize wiring: default board grows by 3mm in length, exempt does not.
+want("Def (603.0" in log, "default board length should be 603.0 (600 + 3 oversize)")
+want("Exempt (600.0" in log, "exempt board length should stay 600.0")
+
+# Preference escalation: the skin cannot ride a half, so it is upgraded to a full
+# sheet and the plan says so, naming it.
+want("NOTE" in log and "Skin" in log,
+     "the escalated skin should produce a NOTE naming it")
+
+# Flag aggregation: both impossible parts are called out, plan still produced.
+want("FLAGGED" in log, "there should be a FLAGGED section")
+want("TooLong" in log, "the over-long board should be flagged")
+want("Giant" in log, "the over-size panel should be flagged")
+
+# Custom-shaped parts declared with a stock get planned in their own group.
+want("Hardwood  --" in log and "HW_Cleat" in log,
+     "a strip()-declared hardwood part is planned as its own linear stock group")
+want("Formica sheet  --" in log and "Laminate" in log,
+     "a box(form='sheet') laminate is planned as a sheet group")
+
+# The rest is still bought.
+want(bool(buy), "cutplan should still return a non-empty buy list")
+want("BUY" in log, "the plan should print a BUY line")
+
+ww.say("PROBE OK")

--- a/tests/freecad/test-cutplan-integration.sh
+++ b/tests/freecad/test-cutplan-integration.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# test-cutplan-integration.sh — exercise the full Model.cutplan wiring inside
+# FreeCAD (per-part oversize, stock grouping, escalation notes, flag
+# aggregation). The wwcut logic is unit-tested headlessly in test-wwcut.sh; this
+# covers the wwkit <-> wwcut layer that needs a real FreeCAD to build parts.
+#
+# FreeCAD is not present in CI, so this SKIPs cleanly (exit 0) when it is absent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FCRUN="$ROOT/plugins-claude/freecad/scripts/fcrun"
+
+# Locate FreeCAD the way fcrun does; skip if it is not installed.
+FC="${FREECAD_BIN:-}"
+if [[ -z "$FC" ]]; then
+  for c in \
+    /Applications/FreeCAD.app/Contents/MacOS/FreeCAD \
+    "$HOME/Applications/FreeCAD.app/Contents/MacOS/FreeCAD" \
+    freecad FreeCAD freecadcmd FreeCADCmd; do
+    if [[ -x "$c" ]] || command -v "$c" >/dev/null 2>&1; then
+      FC="$c"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$FC" ]]; then
+  echo "  - SKIP: FreeCAD not found (cutplan integration test needs it)"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export WW_OUT="$TMP"
+export WW_LOG="$TMP/log.txt"
+
+if "$FCRUN" "$SCRIPT_DIR/_cutplan_probe.py" >"$TMP/out.txt" 2>&1 &&
+  grep -q "PROBE OK" "$TMP/log.txt" 2>/dev/null; then
+  echo "  ✓ cutplan wiring: oversize, grouping, escalation notes, flags"
+  exit 0
+fi
+
+echo "  ✗ cutplan integration probe failed" >&2
+echo "--- fcrun output ---" >&2
+cat "$TMP/out.txt" >&2 || true
+exit 1

--- a/tests/freecad/test-wwcut.sh
+++ b/tests/freecad/test-wwcut.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# test-wwcut.sh — run the wwcut cut-list optimizer unit tests.
+#
+# wwcut is pure Python (no FreeCAD import), so this just runs the Python test
+# module under whatever python3 is on PATH. Discovered and run by tests/test.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/test_wwcut.py"

--- a/tests/freecad/test_wwcut.py
+++ b/tests/freecad/test_wwcut.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Unit tests for wwcut — the cut-list optimizer.
+
+wwcut imports no FreeCAD/Part/Mesh, so it runs under a plain interpreter and is
+CI-testable. Plain asserts, no pytest dependency. Exits non-zero on any failure.
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_LIB = os.path.normpath(
+    os.path.join(_HERE, "..", "..", "plugins-claude", "freecad", "lib"))
+sys.path.insert(0, _LIB)
+
+import wwcut as wc  # noqa: E402
+
+FT = wc.FT
+IN = wc.IN
+
+_PASS = 0
+_FAIL = 0
+
+
+def check(cond, label):
+    global _PASS, _FAIL
+    if cond:
+        _PASS += 1
+        print("  \033[32m✓\033[0m %s" % label)
+    else:
+        _FAIL += 1
+        print("  \033[31m✗\033[0m %s" % label)
+
+
+def raises(fn, label):
+    try:
+        fn()
+    except ValueError:
+        check(True, label)
+    except Exception as exc:  # wrong exception type is still a failure
+        check(False, "%s (raised %r, wanted ValueError)" % (label, exc))
+    else:
+        check(False, "%s (did not raise)" % label)
+
+
+def approx(a, b, tol=0.5):
+    return abs(a - b) <= tol
+
+
+# --- boards -----------------------------------------------------------------
+
+print("-- boards: basic FFD --")
+plan = wc.plan_linear([("a", 600), ("b", 600), ("c", 600), ("d", 430)],
+                      end_trim=0.0)
+check(len(plan) == 1, "four short parts pack into one board")
+check(approx(plan[0].length, 8 * FT), "and it is the 8ft, not a longer stock")
+check(sum(len(b.cuts) for b in plan) == 4, "every part is placed exactly once")
+
+print("-- boards: kerf is consumed --")
+# Pin the catalog to a single 8ft so the only lever is kerf (otherwise the
+# planner legitimately buys one longer board to hold both halves).
+half = 8 * FT / 2.0
+eightft = [8 * FT]
+p0 = wc.plan_linear([("a", half), ("b", half)], board_lengths=eightft,
+                    kerf=0.0, end_trim=0.0)
+p1 = wc.plan_linear([("a", half), ("b", half)], board_lengths=eightft,
+                    kerf=3.2, end_trim=0.0)
+check(len(p0) == 1, "two exact-half parts fit one 8ft with no kerf")
+check(len(p1) == 2, "the same two need a second 8ft once kerf is counted")
+
+print("-- boards: end-trim shrinks usable length --")
+p_notrim = wc.plan_linear([("long", 2420)], end_trim=0.0)
+p_trim = wc.plan_linear([("long", 2420)], end_trim=1 * IN)
+check(approx(p_notrim[0].length, 8 * FT), "2420mm part uses an 8ft with no trim")
+check(approx(p_trim[0].length, 10 * FT),
+      "the same part needs a 10ft once 1in is squared off each end")
+check(p_trim[0].offcut < p_trim[0].usable,
+      "offcut is measured against the trimmed usable length")
+
+print("-- boards: transport limit flags, does not crash --")
+lim = wc.plan_linear([("x", 2500), ("ok", 600)], max_length=8 * FT, end_trim=0.0)
+check(len(lim.flagged) == 1 and lim.flagged[0][0] == "x",
+      "the over-limit part is flagged, not forced into an impossible plan")
+check("transport limit" in lim.flagged[0][2], "and the reason names the limit")
+check(len(lim.boards) == 1, "the part that does fit is still planned")
+check(all(b.length <= 8 * FT + 1e-6 for b in lim),
+      "no board longer than the transport limit is offered")
+
+print("-- boards: end-trim can outrun every stock length --")
+big = wc.plan_linear([("huge", 16 * FT - 10), ("ok", 600)], end_trim=1 * IN)
+check(len(big.flagged) == 1 and big.flagged[0][0] == "huge",
+      "a part longer than the longest usable length is flagged")
+check(len(big.boards) == 1, "the rest of the run is still planned")
+
+
+# --- sheets -----------------------------------------------------------------
+
+print("-- sheets: basic pack + grain --")
+FOURBYEIGHT = (8 * FT, 4 * FT)
+s = wc.plan_sheets([("panel", 1000, 300)], sheet=FOURBYEIGHT, edge_trim=0.0)
+check(len(s) == 1, "one small panel fits one 4x8")
+
+print("-- sheets: rotation is off by default (grain) --")
+narrow = (1200, 1400)  # a piece narrower than the part is long
+raises(lambda: wc.plan_sheets([("p", 1300, 1100)], sheet=narrow,
+                              allow_rotate=False, edge_trim=0.0),
+       "a part too long for the grain axis will not fit un-rotated")
+rot = wc.plan_sheets([("p", 1300, 1100)], sheet=narrow, allow_rotate=True,
+                     edge_trim=0.0)
+check(len(rot) == 1, "the same part fits once rotation is allowed")
+
+print("-- sheets: edge-trim shrinks usable face --")
+tight = (2438, 1219)  # essentially fills a 4x8
+ok = wc.plan_sheets([("p", 2438, 1219)], sheet=FOURBYEIGHT, edge_trim=0.0)
+check(len(ok) == 1, "a face-filling panel fits with no edge trim")
+raises(lambda: wc.plan_sheets([("p", 2438, 1219)], sheet=FOURBYEIGHT,
+                              edge_trim=1 * IN),
+       "the same panel no longer fits once 1in is trimmed off each edge")
+_ = tight  # documented intent
+
+print("-- sheets: multi-size catalog picks least material --")
+# A 1400x1400 part cannot fit a 4x8 (only 4ft across) but fits a 5x5.
+sp = wc.choose_sheets([("wide", 1400, 1400)], edge_trim=0.0)
+check(sp.buys[0].sheet_name == "5x5", "over-wide part is bought as a 5x5")
+# A 1200x1200 part fits both, but a 5x5 is less bought area.
+sp2 = wc.choose_sheets([("mid", 1200, 1200)], edge_trim=0.0)
+check(sp2.buys[0].sheet_name == "5x5", "when both fit, the smaller-area wins")
+
+print("-- sheets: preferred transport piece --")
+sph = wc.choose_sheets([("p", 500, 500)], prefer="half", edge_trim=0.0)
+check(sph.buys[0].piece_name == "half", "prefer='half' uses a crosscut half")
+check(sph.buys[0].full_sheets == 1 and sph.buys[0].spare_pieces == 1,
+      "one half used of a full sheet leaves one spare half")
+
+print("-- sheets: preference escalates, does not fail --")
+# A group where small parts fit a half but the big skin needs a full sheet.
+sp_esc = wc.choose_sheets(
+    [("skin", 1900, 950), ("a", 500, 400), ("b", 500, 400)],
+    prefer="half", max_length=8 * FT, edge_trim=0.0)
+piece_names = {b.piece_name for b in sp_esc.buys}
+check("full" in piece_names, "the oversized skin is upgraded to a full sheet")
+check("half" in piece_names, "the small parts still ride the preferred half")
+check(len(sp_esc.notes) == 1 and "skin" in sp_esc.notes[0],
+      "the upgrade is called out in a note naming the part")
+check(not sp_esc.flagged, "nothing is flagged — every part was planned")
+
+print("-- sheets: yield is a sane fraction --")
+spy = wc.choose_sheets([("p", 1200, 600)], sheet_sizes=[(8 * FT, 4 * FT, "4x8")],
+                       prefer="full", edge_trim=0.0)
+check(0.0 < spy.buys[0].yield_pct <= 100.0, "yield percentage is within (0, 100]")
+
+print("-- sheets: impossible parts are flagged, the rest planned --")
+sp_big = wc.choose_sheets([("giant", 9 * FT, 9 * FT), ("ok", 600, 400)],
+                          edge_trim=0.0)
+check(len(sp_big.flagged) == 1 and sp_big.flagged[0][0] == "giant",
+      "a part bigger than every catalog sheet is flagged, not crashed on")
+check("bigger than any stocked sheet" in sp_big.flagged[0][3],
+      "and the reason says to split it")
+check(len(sp_big.buys) == 1, "the part that fits is still bought and planned")
+
+print("-- sheets: forced-half skin over transport limit is flagged --")
+# max_length below a half's long axis: a part longer than every carriable piece.
+sp_lim = wc.choose_sheets([("long", 1300, 300)],
+                          sheet_sizes=[(8 * FT, 4 * FT, "4x8")],
+                          max_length=1200.0, edge_trim=0.0)
+check(len(sp_lim.flagged) == 1 and "transport limit" in sp_lim.flagged[0][3],
+      "a part too big for any carriable piece is flagged with the limit")
+
+
+# --- oversize: parts are cut rough and trimmed to final ----------------------
+
+print("-- oversize: boards --")
+p2 = wc.plan_linear([("y", 600)], board_lengths=[8 * FT], end_trim=0.0,
+                    oversize=10.0)
+check(approx(p2.boards[0].cuts[0][1], 610),
+      "the planned board cut is the rough (final + oversize) length")
+near = wc.plan_linear([("x", 2435)], board_lengths=[8 * FT], end_trim=0.0,
+                      oversize=0.0)
+rough = wc.plan_linear([("x", 2435)], board_lengths=[8 * FT], end_trim=0.0,
+                       oversize=10.0)
+check(len(near.boards) == 1 and not near.flagged,
+      "a 2435mm final part fits an 8ft")
+check(bool(rough.flagged),
+      "cut 10mm oversize the same part no longer fits and is flagged")
+
+print("-- oversize: sheets --")
+s_ok = wc.plan_sheets([("p", 2430, 1200)], sheet=(8 * FT, 4 * FT),
+                      edge_trim=0.0, oversize=0.0)
+check(len(s_ok) == 1, "a near-full panel fits at final size")
+raises(lambda: wc.plan_sheets([("p", 2430, 1200)], sheet=(8 * FT, 4 * FT),
+                              edge_trim=0.0, oversize=20.0),
+       "cut 20mm oversize the same panel overflows the sheet")
+sp_ov = wc.choose_sheets([("p", 1000, 300)],
+                         sheet_sizes=[(8 * FT, 4 * FT, "4x8")], prefer="full",
+                         edge_trim=0.0, oversize=10.0)
+rough_part = sp_ov.buys[0].pieces[0].strips[0]["parts"][0]
+check(approx(rough_part[1], 1010) and approx(rough_part[2], 310),
+      "sheet parts are packed and reported at rough (final + oversize) size")
+
+
+# --- rectpack band reconstruction (engine-agnostic, no dependency needed) ----
+
+print("-- bands: clean layout reconstructs --")
+# two parts side by side in one rip, a third in a rip above it
+good = [(0, 0.0, 0.0, 100.0, 50.0),
+        (1, 100.0, 0.0, 100.0, 50.0),
+        (2, 0.0, 50.0, 120.0, 40.0)]
+bands = wc._bands_from_placements(good, 300.0, 100.0)
+check(bands is not None and len(bands) == 2, "two clean rips reconstruct")
+check(bands is not None and len(bands[0]["items"]) == 2,
+      "the lower rip holds both side-by-side parts")
+
+print("-- bands: overlaps and overflow are rejected --")
+xoverlap = [(0, 0.0, 0.0, 100.0, 50.0), (1, 50.0, 0.0, 100.0, 50.0)]
+check(wc._bands_from_placements(xoverlap, 300.0, 100.0) is None,
+      "parts overlapping along a rip are rejected")
+xoverflow = [(0, 0.0, 0.0, 400.0, 50.0)]
+check(wc._bands_from_placements(xoverflow, 300.0, 100.0) is None,
+      "a part wider than the sheet is rejected")
+yoverlap = [(0, 0.0, 0.0, 100.0, 80.0), (1, 0.0, 50.0, 100.0, 40.0)]
+check(wc._bands_from_placements(yoverlap, 300.0, 100.0) is None,
+      "rips that overlap in depth are rejected")
+yoverflow = [(0, 0.0, 0.0, 100.0, 50.0), (1, 0.0, 60.0, 100.0, 50.0)]
+check(wc._bands_from_placements(yoverflow, 300.0, 100.0) is None,
+      "rips that run past the sheet width are rejected")
+
+
+# --- rectpack engine path: absent -> shelf fallback, no crash ----------------
+
+print("-- engine: rectpack soft-import falls back cleanly --")
+res = wc._pack_sheet_rectpack([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2, False)
+try:
+    import rectpack  # noqa: F401
+    _have_rp = True
+except Exception:
+    _have_rp = False
+check(res is None if not _have_rp else res is not None,
+      "returns None when rectpack is missing (shelf takes over)")
+sheets, engine = wc._pack_one_size([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2,
+                                   False, 0.0, "auto")
+check(len(sheets) == 1 and engine in ("shelf", "rectpack"),
+      "auto packer always produces a plan and names its engine")
+sheets2, engine2 = wc._pack_one_size([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2,
+                                     False, 0.0, "shelf")
+check(engine2 == "shelf", "explicit packer='shelf' uses the shelf engine")
+
+
+# --- boards: extended -------------------------------------------------------
+
+print("-- boards: cheapest single length across the catalog --")
+# Three 1800mm parts: a 6ft holds one each (3 boards, 5.5m), every longer stock
+# either holds one (more material) or two (fewer boards, still more material).
+three = wc.plan_linear([("a", 1800), ("b", 1800), ("c", 1800)], end_trim=0.0)
+check(approx(three[0].length, 6 * FT) and len(three) == 3,
+      "the planner buys three 6ft, the least-material single length")
+
+print("-- boards: no stock within the transport limit --")
+none_fit = wc.plan_linear([("a", 600)], max_length=5 * FT)
+check(not none_fit.boards and len(none_fit.flagged) == 1,
+      "nothing is planned when no catalog board is carriable")
+check("no stock length is within" in none_fit.flagged[0][2],
+      "and the reason says so")
+
+print("-- boards: empty input is empty, not an error --")
+empty_b = wc.plan_linear([])
+check(len(empty_b) == 0 and not empty_b.flagged, "no parts -> no boards, no flags")
+
+print("-- boards: offcut is exact --")
+one = wc.plan_linear([("a", 600)], board_lengths=[8 * FT], end_trim=0.0, kerf=3.2)
+check(approx(one[0].offcut, 8 * FT - 600), "offcut = usable - used (no leading kerf)")
+
+
+# --- sheets: strip geometry (regression for the length/kerf fix) ------------
+
+print("-- Sheet.place: first cut has no kerf, later cuts do --")
+sh = wc.Sheet(1000.0, 500.0)
+check(sh.place("a", 400.0, 100.0, 10.0), "first part seats")
+check(approx(sh.strips[0]["x"], 400.0), "the first cut consumes no leading kerf")
+check(sh.place("b", 400.0, 100.0, 10.0), "a second part seats in the same rip")
+check(approx(sh.strips[0]["x"], 810.0), "the second cut adds one kerf (400+10+400)")
+check(sh.place("c", 100.0, 350.0, 10.0), "a third part opens a new rip")
+check(approx(sh.strips[1]["y"], 110.0), "the new rip sits one kerf above the first")
+
+print("-- Sheet.place: a part longer than the sheet never seats --")
+sh2 = wc.Sheet(500.0, 500.0)
+check(not sh2.place("toolong", 600.0, 100.0, 3.0),
+      "a part longer than the sheet is refused, not silently overhung")
+
+
+# --- sheets: extended -------------------------------------------------------
+
+print("-- sheets: half-rip piece --")
+spr = wc.choose_sheets([("p", 2000, 300)], sheet_sizes=[(8 * FT, 4 * FT, "4x8")],
+                       prefer="half-rip", max_length=8 * FT, edge_trim=0.0)
+check(spr.buys[0].piece_name == "half-rip", "prefer='half-rip' rips a long strip")
+check(spr.buys[0].per_full == 2 and spr.buys[0].spare_pieces == 1,
+      "a full sheet yields two rips, one spare here")
+
+print("-- sheets: allow_rotate flips a fit in choose_sheets --")
+cat = [(1400, 600, "strip")]
+no_rot = wc.choose_sheets([("p", 500, 1300)], sheet_sizes=cat,
+                          allow_rotate=False, edge_trim=0.0)
+yes_rot = wc.choose_sheets([("p", 500, 1300)], sheet_sizes=cat,
+                           allow_rotate=True, edge_trim=0.0)
+check(no_rot.flagged and not no_rot.buys, "grain-locked, the part does not fit")
+check(yes_rot.buys and not yes_rot.flagged, "rotation allowed, it fits and is bought")
+
+print("-- sheets: spare-piece math with an odd count of halves --")
+odd = wc.choose_sheets(
+    [("a", 1200, 1100), ("b", 1200, 1100), ("c", 1200, 1100)],
+    sheet_sizes=[(8 * FT, 4 * FT, "4x8")], prefer="half", max_length=8 * FT,
+    edge_trim=0.0)
+check(len(odd.buys) == 1 and len(odd.buys[0].pieces) == 3,
+      "three parts too big to share a half take three half pieces")
+check(odd.buys[0].full_sheets == 2 and odd.buys[0].spare_pieces == 1,
+      "three halves come from two full sheets, leaving one spare half")
+
+print("-- sheets: default catalog + no preference picks least material --")
+dfl = wc.choose_sheets([("p", 600, 400)], edge_trim=0.0)
+check(dfl.buys[0].sheet_name == "5x5",
+      "a small part is bought from the smaller-area 5x5")
+
+print("-- sheets: empty input is empty, not an error --")
+empty_s = wc.choose_sheets([])
+check(not empty_s.buys and not empty_s.flagged, "no parts -> no buys, no flags")
+
+print("-- engine: empty parts pack to nothing --")
+es, _eng = wc._pack_one_size([], (8 * FT, 4 * FT), 3.2, False, 0.0, "auto")
+check(es == [], "no parts -> no sheets")
+
+
+# --- board feet -------------------------------------------------------------
+
+print("-- board feet --")
+bf = wc.board_feet(1.5 * IN, 3.5 * IN, 8 * FT)
+check(approx(bf, 3.5, 0.01), "a 2x4x8 is 3.5 board feet")
+bf2 = wc.board_feet(0.75 * IN, 5.5 * IN, 6 * FT)
+check(approx(bf2, 2.0625, 0.01), "a 1x6x6 is ~2.06 board feet")
+
+
+# --- summary ----------------------------------------------------------------
+
+print()
+print("wwcut: %d passed, %d failed" % (_PASS, _FAIL))
+sys.exit(1 if _FAIL else 0)


### PR DESCRIPTION
## What

Introduces the **freecad** plugin — agent-scripted parametric CAD with a live
GUI loop the user steers — and two rounds of improvements on top, ending with a
configurable cut-list optimizer. Three commits:

1. **`feat: add freecad plugin`** — the `freecad:modeling` skill, the `wwkit`
   library (parts, joinery, clash/printable/envelope checks, cutlist/cutplan),
   the live-reload session, and the `fc*` scripts.
2. **`headless-friendly workflow + angled-joinery/kind helpers`** — `ww.prism`/
   `ww.wedge`/`ww.frange`, per-part `kind` colours, `check_printable` single-solid
   check, the don't-take-over-the-desktop workflow (`fcsnap` views, `fcopen`
   tabs, auto nav defaults), `fcrender` error hint.
3. **`configurable cut-list optimizer`** — the focus of this session (below).

## Cut-list optimizer (commit 3)

- **Catalog**: configurable board lengths + sheet sizes (grain-aware);
  least-material selection tries each. Sheet sizes are first-class (was 4x8-only).
- **Trims**: `end_trim` (board ends) and `edge_trim` (sheet edges) reduce usable
  stock; offcuts/yield measure against trimmed stock.
- **Oversize**: per-part rough-cut allowance (cut big, trim to final). Boards
  grow in length only; sheet parts in both faces; overridable per part, `0` to
  exempt a final-size part or a glue-up member.
- **Preferences, not hard rules**: a part too big for the preferred `sheet_piece`
  is upgraded to the smallest piece that fits (noted); a part that cannot meet
  the limits (bigger than any sheet, over the transport limit) is **FLAGGED** by
  name and the rest is still planned — no crash, no impossible cut.
- **Packer**: optional `rectpack` (Apache-2.0, soft import) with a shelf-packer
  fallback; a rectpack layout that will not reduce to clean rips is rejected.
- **`m.strip()` / `box(form=, stock=)`**: custom-shaped (box/prism) parts can be
  planned as linear or sheet stock instead of skipped.
- **Fix**: `Sheet.place` now validates a part against the sheet length and
  charges kerf correctly (latent bug, harmless under the old 4x8-only path).

## Tests

- `tests/freecad/test-wwcut.sh` — **70 pure-Python unit cases**, run by the repo
  test runner, verified to pass **with and without `rectpack`** installed.
- `tests/freecad/test-cutplan-integration.sh` — FreeCAD-guarded integration test
  of the `wwkit`↔`wwcut` wiring; **SKIPs cleanly where FreeCAD is absent** (CI).

Verified locally: 70/70 unit (both packers), integration probe, full suite 30/0,
shellcheck `--severity=error`, rumdl, plugin validation (299/0), and a headless
end-to-end on a real workbench model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
