### PR TITLE
chore(freecad): bump plugin to 1.1.0

### DIFF
--- a/plugins-claude/freecad/.claude-plugin/plugin.json
+++ b/plugins-claude/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/freecad/.claude-plugin/plugin.json
+++ b/plugins-copilot/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"


### PR DESCRIPTION
Bumps the freecad plugin (claude + copilot) 1.0.0 → 1.1.0.

The headless-workflow and cut-list-optimizer batches merged in #160 without a version bump, so `/plugin` kept serving the cached 1.0.0 and never re-pulled — leaving live sessions building against a `wwkit` that lacks `m.strip` / `box(form=, stock=)`. This bump makes a normal update fetch the merged library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)