### PR TITLE
feat(freecad): material types + sourcing options (v1.2.0)

### DIFF
--- a/plugins-claude/freecad/.claude-plugin/plugin.json
+++ b/plugins-claude/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/freecad/README.md
+++ b/plugins-claude/freecad/README.md
@@ -108,75 +108,86 @@ ignores boolean results — which is every part with a joint cut into it.
 
 ## From a parts list to a cutting plan
 
-`cutlist()` says what parts you need. `cutplan()` says what to **buy**, and
-board by board what to **cut from each one** — the thing you take to the yard
-and then to the saw.
+`cutlist()` says what parts you need. `cutplan()` says what to **buy** and what
+to **cut from each board** — the thing you take to the yard and then to the saw.
+
+A part doesn't carry a stock size — it carries a **material type**
+(`framing`, `hardwood`, `pine-ply`, ...), set by `board()` / `panel()` /
+`strip()` / `box()`. `cutplan()` owns the buying decision: it groups parts by
+`(material, thickness)` and, for each group, works out every way to source it,
+ranks the options, and prints the winner in full with the rest collapsed to one
+line.
 
 ```text
-CUT PLAN  (kerf 3.2 (1/8"))
+CUT PLAN  (kerf 3.2 (1/8"), end-trim 25.4 (1"), edge-trim 12.7 (1/2"), oversize 3.2 (1/8"), prefer value)
 
-  1x10  -- 1 board(s) of 12 ft
-    #1: Side_Left (914.4 (36")), Side_Right (914.4 (36")), Shelf_0 (590.5 (23-1/4")), ...
-        offcut 44.4 (1-3/4")
+  framing -- 6 x 2x4 @ 8 ft   (21.0 bd-ft, $)
+      factory (eased) edges, no ripping
+      #1 [8 ft, offcut 6.6 (1/4")]: Frame_Front (1747.0 (68-3/4")), Post_AF_0 (630.9 (24-13/16"))
+      ...
+      also works: 3 x 2x10 @ 8 ft  --  27.8 bd-ft, $$ [2 clean strips/board, all-square edges, clearer grade]
 
-  1/4 sheet  -- 1 of 8 ft x 4 ft  (18% used, grain respected)
-    sheet #1:
-      rip 590.5 (23-1/4") wide: Back (914.4 (36") x 590.5 (23-1/4"))
+  hardwood 4/4 -- 2 x 4/4 >=164.5 (6-1/2") wide @ 10 ft   (10.8 bd-ft, $$)
+      board/sheet #1:
+        rip 102.2 (4") wide: Band_Front (1942.2 x 102.2), Band_Right (982.2 x 102.2)
+        rip 44.4 (1-3/4") wide: Cleat_F+Key_F (1850.1 x 44.4), Cleat_L+Key_L (890.1 x 44.4)
 
-BUY       1 x 1x10 @ 12 ft; 1 x 2x2 @ 6 ft; 1 x 1/4 sheet
+  mdf 3/4 -- 1 x 4x8   (1 sheet(s), $)
+      note: full 4x8 - each could be store-cut in half
+
+BUY       6 x 2x4 @ 8 ft; 2 x 4/4 >=164.5 (6-1/2") wide @ 10 ft; 1 x 4x8; ...
 ```
 
-Boards are packed by length into stock lengths; sheets are packed into strips,
-because that is how you actually cut a sheet — rip it, then crosscut the strips.
-Kerf is accounted for in both.
+Each group's recommended option prints in full: the buy line, board-feet or
+sheet count and cost tier, and the board-by-board (or sheet-by-sheet) cut
+layout. Dimensional lumber can be bought as-is — factory edges, planned by
+length only — or ripped from a wider nominal, trading bd-ft for square edges
+and clearer grade (a 2x10 yields two clean 3.5" strips; a 2x8 yields only one,
+so it is never offered — that's the trap this avoids). Hardwood nests every rip
+profile across a board's random width and phrases the buy as "≥N boards ≥W
+wide × L". Options that lose the ranking still show up, just collapsed to a
+single "also works:" line so you can see what you gave up.
 
-**Grain runs the length of a sheet**, so rotating a part 90° to squeeze it in
-turns the grain the wrong way. Rotation is therefore **off by default** — a plan
-that saves half a sheet by cross-graining your cabinet sides is not a saving.
-Pass `allow_rotate=True` for MDF or when you genuinely do not care.
+`prefer` ranks options **within** a material type — `"value"` (default: best
+quality per cost tier, then least material), `"cost"`, or `"quality"` — but
+never across types: you declared `framing`, so the plan will never suggest
+hardwood instead.
+
+**Grain and rotation are a property of the material now**, not a cutplan
+setting — grainless sheet goods like MDF and laminate rotate freely to improve
+yield; ply and hardwood never do.
 
 Packing is first-fit-decreasing, not optimal. Optimal bin packing is NP-hard and
 pointless at this scale: with a dozen parts FFD lands within a board of optimal,
 and the saw is not that precise anyway.
 
-### Transport, which is a real constraint
+### Transport is the shopper's call
 
-A plan that buys a 12ft board is useless if the board will not go in the truck.
-
-```python
-m.cutplan(max_length=ww.ft(8),     # longest thing you can get home
-          sheet_piece="half")      # have the store cut sheets in half
-```
-
-`max_length` removes over-long stock from consideration entirely — the planner
-will buy two 8ft boards rather than one 12ft one. A *part* longer than the limit
-raises: that is a design problem, not a packing one, since even cut to size it
-will not fit in the vehicle.
-
-**You always buy a full 4x8 sheet** — `sheet_piece` is what you ask the store's
-panel saw to do to it before it goes in the vehicle:
-
-| `sheet_piece` | piece | grain |
-|---|---|---|
-| `"full"` | 8ft x 4ft | along the 8ft |
-| `"half"` | 4ft x 4ft | along a 4ft axis (crosscut) |
-| `"half-rip"` | 8ft x 2ft | still along the 8ft |
-
-A crosscut half and a ripped half have the **same area and different grain**, so
-they are not interchangeable. Leave `sheet_piece` unset to let the planner pick
-the fewest full sheets, breaking ties toward the smaller piece.
-
-The shopping list says what to ask for:
+Earlier versions solved for the truck bed as a hard constraint. It doesn't
+anymore. `cutplan()` nests parts onto full stock — a full board length, a full
+sheet — and simply **annotates** what could be broken down before it leaves the
+store, the way the `mdf` group above does:
 
 ```text
-BUY  2 x 1x10 @ 8 ft; 1 x 2x2 @ 6 ft; 1 x 1/4 full sheet (cut in half at the store, 1 spare)
+mdf 3/4 -- 1 x 4x8   (1 sheet(s), $)
+    note: full 4x8 - each could be store-cut in half
 ```
 
-Override what your yard actually stocks:
+Renting a truck, paying for delivery, or asking the store to cut a board or
+sheet down before it goes in the vehicle is the shopper's call — the plan just
+tells you the option exists. The only thing still **flagged** is genuine
+impossibility: a part wider than every stocked nominal, longer than the longest
+board, or bigger than every stocked sheet. Everything else in the plan is still
+planned rather than the whole thing crashing, or worse, printing an impossible
+cut.
 
-```python
-m.cutplan(stock_lengths=[ww.ft(6), ww.ft(8)], kerf=3.2)
-```
+### Override what your yard actually stocks
+
+The catalog lives in `wwcut.MATERIALS` — a plain, user-extensible dict, so add
+a species, a grade, or a sheet size your yard actually carries — and
+`wwcut.TOOLING`, which sets tool allowances (`edge_cleanup`, `jointer`,
+`planer`, `saw_rip`). Set any of them to `0` for a tool you don't own, and
+`cutplan()` stops offering options that assume it.
 
 ### Units: metric shop, imperial lumberyard
 

--- a/plugins-claude/freecad/lib/wwcut.py
+++ b/plugins-claude/freecad/lib/wwcut.py
@@ -1,54 +1,57 @@
-"""wwcut - turn a parts list into a cutting plan and a shopping list.
+"""wwcut - turn a parts list into sourcing options and a cutting plan.
 
 A cut list says "I need a 610mm shelf". A *cut plan* says "buy three 8ft 1x10s,
 and out of board #1 cut 610, 610, 610, 430, with 118 left over". The second one
 is the thing you take to the lumberyard and the saw. This module does that.
 
-Two packing problems, both solved greedily (first-fit-decreasing, multi-start).
-Optimal bin packing is NP-hard and pointless here: with a dozen parts, FFD lands
-within a board or two of optimal, and the saw is not that precise anyway.
+The model that feeds this declares a part's *material type* — "framing lumber",
+"hardwood", "birch-ply" — never a stock size. Turning a type into a buy is this
+module's job, and there is usually more than one way to do it: a 3.5"-wide frame
+strip is a 2x4 bought as-is, *or* two clean strips ripped from a 2x10. So the
+planner emits a small ranked list of **sourcing options** per material group and
+lets the shopper choose at the yard. It never picks the material *type* — the
+human did that in the model — so cost and quality only ever compete *within* a
+type (which framing nominal, how wide a hardwood board).
 
-  * linear   - boards. Parts have one meaningful dimension (length); they get
-               packed into stock lengths (6ft, 8ft, ...).
-  * sheet    - plywood/MDF. Parts are 2D; they get packed into sheets, using a
-               shelf/guillotine layout because that is how you actually cut a
-               sheet: rip it into strips, then crosscut each strip.
+Two low-level packing engines do the geometry, both greedy (first-fit-decreasing,
+multi-start). Optimal bin packing is NP-hard and pointless here: with a dozen
+parts FFD lands within a board or two of optimal, and the saw is not that precise.
 
-Three things a raw bin-packer does not know but a woodworker cares about:
+  * linear   - boards. Parts have one meaningful dimension (length); they pack
+               into stock lengths (8ft, 10ft, ...).
+  * sheet    - plywood/MDF, *and* ripping strips from a wide board. Parts are 2D;
+               they pack into a rectangle using a shelf/guillotine layout,
+               because that is how you cut a sheet (or rip a board): make the
+               long rips first, then crosscut each strip.
 
-  * Grain runs the length of a sheet. Rotating a part 90 degrees to squeeze it in
-    turns the grain the wrong way, so rotation is OFF by default for sheet goods
-    - a plan that saves half a sheet by cross-graining your cabinet sides is not
-    a saving. Pass allow_rotate=True if the material has no grain (MDF).
-  * Kerf. Every cut eats a saw-blade's width; the plan accounts for it.
-  * Trim. Stock does not arrive dead square. `end_trim`/`edge_trim` knock a
-    margin off each end/edge before anything is packed into the usable region.
+Three things a raw bin-packer does not know but a woodworker cares about: grain
+runs the length of a sheet (so rotation is OFF by default); every cut eats a
+kerf; and stock is not dead square, so a margin is trimmed off each end/edge
+before anything is packed into the usable region.
 
-Nothing here is hard-coded policy. The catalog - board lengths, sheet sizes and
-their grain axis - is configurable, and the transport limit and preferred cut are
-*preferences*: the planner honours them when it can, quietly upgrades a part to a
-bigger piece when the preferred one is too small (with a note), and **flags** any
-part that simply cannot meet the limits (bigger than any stocked sheet, or longer
-than the truck) instead of failing or - worse - lying about an impossible cut.
+Transport is deliberately NOT modelled as a constraint. Whether a 12ft board or
+a full 4x8 gets home is the shopper's call (rent a truck, pay for delivery, have
+the store cut it) — the planner nests onto full stock and merely *annotates*
+("could be store-cut in half"). Only genuine impossibility — a part bigger than
+every stocked sheet, wider than every nominal — is flagged.
 
 An optional stronger sheet packer (`rectpack`, Apache-2.0) is used when it is
-importable; otherwise the built-in shelf packer runs. Either way the result is a
-set of rip strips you can actually cut, and a rectpack layout that does not
-reduce to clean rips is rejected in favour of the shelf plan.
+importable; otherwise the built-in shelf packer runs. A rectpack layout that does
+not reduce to clean rips is rejected in favour of the shelf plan.
 """
 
 IN = 25.4
 FT = 304.8
 
-# --- the catalog: what the yard actually sells. Override per project. --------
+# --- defaults: the shop's habits. Override per project or per call. ----------
 
-# Board stock lengths.
-BOARD_LENGTHS = [6 * FT, 8 * FT, 10 * FT, 12 * FT, 16 * FT]
+# Board stock lengths a yard will sell (framing default; each material may carry
+# its own ladder).
+BOARD_LENGTHS = [8 * FT, 10 * FT, 12 * FT, 16 * FT]
 STOCK_LENGTHS = BOARD_LENGTHS  # backwards-compatible alias
 
-# Sheet stock sizes, as (grain, cross, name). The first dimension is the grain
-# direction. 4x8 is the everything sheet; 5x5 is Baltic-birch ply; add project
-# panels or precut sizes here.
+# Sheet stock sizes, as (grain, cross, name); first dim is the grain direction.
+# Only used as plan_sheets' default; real sheet sourcing comes from MATERIALS.
 SHEET_SIZES = [
     (8 * FT, 4 * FT, "4x8"),
     (5 * FT, 5 * FT, "5x5"),
@@ -60,23 +63,72 @@ END_TRIM = 1 * IN     # squared off each board END before use (snipe / square-up
 EDGE_TRIM = 0.5 * IN  # trimmed off each sheet EDGE before use (factory edge)
 
 # Parts are cut oversize and trimmed to final, to align edges and clean tearout.
-# This grows each part's footprint in each dimension (independent of KERF, which
-# is the blade width *between* parts, and of the trims, which square the stock).
+# Grows each part's footprint per dimension (independent of KERF, the blade width
+# *between* parts, and of the trims, which square the stock).
 OVERSIZE = IN / 8.0   # 1/8" bigger per dimension, then trimmed to final
 
-# How a bought sheet gets cut down for the truck, as fractions of the sheet it
-# came from. You always *buy* the full sheet; the store's panel saw turns it into
-# something that fits in the bed.
-#
-# A crosscut half and a ripped half are not interchangeable: crosscutting a 4x8
-# gives two 4x4s whose grain runs along a 4ft axis, while ripping gives two 2x8s
-# whose grain still runs the full 8ft. Same area, different material.
-#
-#   name          (grain_frac, cross_frac, pieces_per_full)
-SHEET_PIECES = {
-    "full": (1.0, 1.0, 1),
-    "half": (0.5, 1.0, 2),      # crosscut in half — the usual "half sheet"
-    "half-rip": (1.0, 0.5, 2),  # ripped in half — stays long and narrow
+# What tools the shop has, as the allowance each takes off. `0` means "don't have
+# it" — the planner then leans on the table saw instead. `edge_cleanup` is how
+# much a squared-up rip edge costs per edge (a table-saw rip pass with no jointer)
+# and is what a rip-from-wider plan spends to turn a factory edge into a clean one.
+TOOLING = {
+    "edge_cleanup": 0.25 * IN,  # squared off each ripped edge (table-saw clean-up)
+    "jointer": 0.0,             # jointer pass allowance; 0 = no jointer
+    "planer": 0.0,              # planer pass allowance; 0 = no planer
+    "saw_rip": KERF,            # a rip cut's kerf
+}
+
+
+# --- the material catalog ----------------------------------------------------
+# Each entry describes how a material *type* is sold, so the option generator can
+# reason about it. Three families; add species, grades, sizes freely.
+
+def dimensional(thick, widths, lengths, tier="$"):
+    """Softwood dimensional lumber: fixed thickness, a ladder of nominal widths,
+    stock lengths, sold by the board."""
+    return {"family": "dimensional", "thick": thick, "widths": sorted(widths),
+            "lengths": sorted(lengths), "tier": tier}
+
+
+def solidwood(thicknesses, lengths, tier="$$"):
+    """Hardwood: thickness families (4/4, 5/4, ...), random width and length,
+    sold by the board-foot. The planner rips profiles across a board's width."""
+    return {"family": "solidwood", "thicknesses": list(thicknesses),
+            "lengths": sorted(lengths), "tier": tier}
+
+
+def sheet(sizes, grain, thicknesses, tier="$", quality=1):
+    """Sheet goods of one quality: its own sheet sizes as (grain, cross, name),
+    a grain rule, a set of thickness labels, a cost tier and a quality rank."""
+    return {"family": "sheet", "sizes": list(sizes), "grain": bool(grain),
+            "thicknesses": list(thicknesses), "tier": tier, "quality": quality}
+
+
+MATERIALS = {
+    # dimensional softwood — 2x nominal (actual 1.5" thick)
+    "framing": dimensional(
+        1.5 * IN, [3.5 * IN, 5.5 * IN, 7.25 * IN, 9.25 * IN, 11.25 * IN],
+        [8 * FT, 10 * FT, 12 * FT, 16 * FT], tier="$"),
+    # dimensional softwood — 1x nominal (actual 0.75" thick)
+    "softwood-1x": dimensional(
+        0.75 * IN, [1.5 * IN, 2.5 * IN, 3.5 * IN, 5.5 * IN, 7.25 * IN,
+                    9.25 * IN, 11.25 * IN],
+        [8 * FT, 10 * FT, 12 * FT], tier="$"),
+    # hardwood, S3S, priced by the board-foot on nominal quarter thickness
+    "hardwood": solidwood(
+        ["4/4", "5/4", "6/4", "8/4"], [8 * FT, 10 * FT, 12 * FT], tier="$$"),
+    # sheet qualities. Baltic birch is 5x5 and premium; the rest are 4x8.
+    "mdf": sheet([(8 * FT, 4 * FT, "4x8")], grain=False,
+                 thicknesses=["1/4", "1/2", "3/4"], tier="$", quality=1),
+    "pine-ply": sheet([(8 * FT, 4 * FT, "4x8")], grain=True,
+                      thicknesses=["1/2", "3/4"], tier="$", quality=2),
+    "birch-ply": sheet([(5 * FT, 5 * FT, "5x5")], grain=True,
+                       thicknesses=["1/2", "3/4"], tier="$$$", quality=4),
+    "solid-core": sheet([(8 * FT, 4 * FT, "4x8")], grain=True,
+                        thicknesses=["1/2", "3/4"], tier="$$", quality=3),
+    # plastic laminate (Formica): a facing sheet, no grain worth respecting
+    "laminate": sheet([(8 * FT, 4 * FT, "4x8")], grain=False,
+                      thicknesses=["1.2mm"], tier="$", quality=1),
 }
 
 
@@ -86,7 +138,7 @@ class Board:
     """One physical board bought, and the parts cut from it.
 
     `length` is the nominal stock you buy (and pay for and carry). `usable` is
-    what is left to cut into after end-trim; it is what parts are packed against.
+    what is left to cut into after end-trim; parts are packed against it.
     """
 
     def __init__(self, length, usable=None):
@@ -106,23 +158,6 @@ class Board:
     @property
     def offcut(self):
         return self.usable - self.used
-
-
-class LinearPlan:
-    """The boards to buy, plus the parts that could not be planned."""
-
-    def __init__(self, boards, flagged):
-        self.boards = boards          # [Board]
-        self.flagged = flagged        # [(name, length, reason)]
-
-    def __iter__(self):               # so `for b in plan` still walks the boards
-        return iter(self.boards)
-
-    def __len__(self):
-        return len(self.boards)
-
-    def __getitem__(self, i):
-        return self.boards[i]
 
 
 _LINEAR_ORDERS = (
@@ -146,74 +181,49 @@ def _pack_linear(items, stock_len, usable, kerf):
     return boards
 
 
-def plan_linear(parts, board_lengths=None, kerf=KERF, max_length=None,
-                end_trim=0.0, oversize=0.0):
-    """Pack (name, length) parts into stock boards. Returns a LinearPlan.
+def plan_linear(parts, board_lengths=None, kerf=KERF, end_trim=0.0, oversize=0.0):
+    """Pack (name, length) parts into stock boards of one chosen length.
 
-    Tries each stock length on its own, and a few sort orders for each, and keeps
-    whichever buys the least material — a single length is what you actually want
-    at the yard, and multi-start FFD beats a single greedy pass often enough to
-    be worth the pennies of compute.
-
-    `max_length` is a transport limit: the longest board you can actually get
-    home. `end_trim` is squared off *each* end before parts are packed, so a
-    nominal 8ft board only holds (8ft - 2*end_trim) of parts. `oversize` grows
-    each part before packing — parts are cut rough and trimmed to final — so the
-    lengths in the plan are the rough sizes you actually crosscut.
-
-    Parts that cannot meet the limits — longer than the transport limit, or
-    longer than the longest usable stock after end-trim — are not forced into an
-    impossible plan; they are returned in `.flagged` with a reason, and the rest
-    are still planned.
+    Returns a list of Board, or None if the longest part will not fit any stock
+    length (after end-trim) — the caller decides how to flag that. Tries each
+    usable stock length on its own, and a few sort orders, and keeps whichever
+    buys the least material: a single length is what you actually want at the
+    yard, and multi-start FFD beats a single greedy pass often enough to be worth
+    the pennies of compute. `end_trim` is squared off *each* end before packing;
+    `oversize` grows each part (cut rough, trim to final).
     """
     board_lengths = board_lengths or BOARD_LENGTHS
     items = [(n, l + oversize) for n, l in parts] if oversize else list(parts)
+    if not items:
+        return []
 
-    carriable = ([s for s in board_lengths if s <= max_length + 1e-6]
-                 if max_length else list(board_lengths))
-    cap = (max(carriable) - 2.0 * end_trim) if carriable else float("-inf")
-
-    plannable, flagged = [], []
-    for name, length in items:
-        if max_length and length > max_length + 1e-6:
-            flagged.append((name, length,
-                            "exceeds the %.0fmm transport limit" % max_length))
-        elif length > cap + 1e-6:
-            if carriable:
-                flagged.append((name, length,
-                                "longer than the longest usable stock "
-                                "(%.0fmm after %.0fmm end-trim)"
-                                % (cap, end_trim)))
-            else:
-                flagged.append((name, length,
-                                "no stock length is within the %.0fmm "
-                                "transport limit" % max_length))
-        else:
-            plannable.append((name, length))
-
-    if not plannable:
-        return LinearPlan([], flagged)
-
-    longest = max(l for _, l in plannable)
-    usable = [s for s in carriable if s - 2.0 * end_trim >= longest - 1e-6]
+    longest = max(l for _, l in items)
+    usable_lengths = [s for s in board_lengths
+                      if s - 2.0 * end_trim >= longest - 1e-6]
+    if not usable_lengths:
+        return None
 
     best = None
-    for stock_len in usable:
+    for stock_len in usable_lengths:
         stock_cap = stock_len - 2.0 * end_trim
         for order in _LINEAR_ORDERS:
-            boards = _pack_linear(sorted(plannable, key=order), stock_len,
+            boards = _pack_linear(sorted(items, key=order), stock_len,
                                   stock_cap, kerf)
-            bought = sum(b.length for b in boards)
-            rank = (bought, len(boards))
+            # Least material first; on a tie (48ft is 6x8 or 3x16 alike) prefer
+            # the SHORTER stock — more standard, easier to get home — then fewer
+            # boards. Transport is not a hard limit, but the sane default is 8ft.
+            rank = (round(sum(b.length for b in boards)), stock_len,
+                    len(boards))
             if best is None or rank < best[0]:
                 best = (rank, boards)
-    return LinearPlan(best[1], flagged)
+    return best[1]
 
 
 # --- sheets (2D) -------------------------------------------------------------
 
 class Sheet:
-    """One sheet, packed into horizontal strips (rip, then crosscut)."""
+    """One sheet (or one wide board being ripped), packed into horizontal strips
+    (rip, then crosscut)."""
 
     def __init__(self, length, width):
         self.length = length
@@ -225,16 +235,16 @@ class Sheet:
         # A part longer than the sheet cannot go in any strip, new or open.
         if pl > self.length + 1e-6:
             return False
-        # Try an open strip first: same idea as a rip already made. Cuts within
-        # a strip are separated by one kerf each (n parts -> n-1 kerfs).
+        # Try an open strip first (a rip already made). Cuts within a strip are
+        # separated by one kerf each (n parts -> n-1 kerfs).
         for s in self.strips:
             if pw <= s["depth"] + 1e-6 and s["x"] + kerf + pl <= self.length + 1e-6:
                 s["parts"].append((name, pl, pw))
                 s["x"] += kerf + pl
                 return True
         # Otherwise open a new strip, if there is width left to rip one. The rip
-        # that separates it from the strip below eats a kerf; the first strip
-        # sits against the factory edge and does not.
+        # separating it from the strip below eats a kerf; the first strip sits
+        # against the factory edge and does not.
         gap = kerf if self.strips else 0.0
         if self.used_w + gap + pw <= self.width + 1e-6:
             y = self.used_w + gap
@@ -303,12 +313,12 @@ def _pack_shelf(items, sl, sw, kerf, allow_rotate):
 
 def plan_sheets(parts, sheet=SHEET, kerf=KERF, allow_rotate=False, edge_trim=0.0,
                 oversize=0.0):
-    """Pack (name, length, width) parts into sheets of one size. Returns [Sheet].
+    """Pack (name, length, width) parts into rectangles of one size. Returns
+    [Sheet]. Raises ValueError if a part does not fit even one empty rectangle.
 
-    `edge_trim` is knocked off each edge before packing, so a nominal piece only
-    offers (L - 2*edge_trim) x (W - 2*edge_trim) of usable face. `oversize` grows
-    each part in both dimensions (cut rough, trim to final). Multi-start: tries a
-    few sort orders and keeps whichever needs the fewest sheets.
+    `edge_trim` is knocked off each edge before packing; `oversize` grows each
+    part in both dimensions (cut rough, trim to final). Multi-start: tries a few
+    sort orders and keeps whichever needs the fewest sheets.
     """
     if oversize:
         parts = [(n, l + oversize, w + oversize) for n, l, w in parts]
@@ -327,7 +337,7 @@ def _bands_from_placements(placements, sl, sw, eps=1.0):
 
     A shelf-cuttable layout is a stack of horizontal bands: within a band the
     parts sit side by side along x; the bands stack along y. This groups
-    placements into such bands and *validates* that they really are disjoint
+    placements into such bands and *validates* they really are disjoint
     horizontal strips that fit the sheet. Returns the ordered bands, or None if
     the layout does not reduce to clean rips (so the caller can reject it).
     """
@@ -371,10 +381,8 @@ def _pack_sheet_rectpack(parts, sheet, kerf, allow_rotate, edge_trim=0.0):
 
     None means "not available or not cleanly cuttable" — the caller falls back to
     the shelf packer. Kerf is handled by inflating each part (and the bin) by one
-    blade width; grain is handled by disabling rotation. The free-form placement
-    rectpack returns is reduced back to rip strips and rejected if it does not
-    form clean horizontal bands (see `_bands_from_placements`), so we never hand
-    over a layout you cannot actually cut.
+    blade width; grain by disabling rotation. The free-form placement is reduced
+    back to rip strips and rejected if it does not form clean horizontal bands.
     """
     try:
         import rectpack
@@ -438,169 +446,346 @@ def _pack_one_size(parts, sheet, kerf, allow_rotate, edge_trim, packer):
     return plan_sheets(parts, sheet, kerf, allow_rotate, edge_trim), "shelf"
 
 
-class SheetBuy:
-    """A sheet plan plus what it costs you at the till and in the truck."""
-
-    def __init__(self, sheet_size, sheet_name, piece_name, piece, pieces,
-                 per_full, engine="shelf"):
-        self.sheet_size = sheet_size    # (grain, cross) of the bought sheet, mm
-        self.sheet_name = sheet_name    # "4x8", "5x5", ...
-        self.piece_name = piece_name    # "full" | "half" | "half-rip"
-        self.piece = piece              # (grain, cross) of the transport piece
-        self.pieces = pieces            # [Sheet]
-        self.per_full = per_full        # transport pieces from one full sheet
-        self.engine = engine            # "shelf" | "rectpack"
-
-    @property
-    def full_sheets(self):
-        """You buy full sheets. The store's saw is what gives you halves."""
-        n = len(self.pieces)
-        return (n + self.per_full - 1) // self.per_full
-
-    @property
-    def spare_pieces(self):
-        return self.full_sheets * self.per_full - len(self.pieces)
-
-    @property
-    def bought_area(self):
-        return self.full_sheets * self.sheet_size[0] * self.sheet_size[1]
-
-    @property
-    def yield_pct(self):
-        used = sum(s.area_used for s in self.pieces)
-        bought = self.bought_area
-        return 100.0 * used / bought if bought else 0.0
-
-
-class SheetPlan:
-    """The sheets to buy, any preference notes, and parts that could not fit."""
-
-    def __init__(self, buys, flagged, notes):
-        self.buys = buys              # [SheetBuy]
-        self.flagged = flagged        # [(name, l, w, reason)]
-        self.notes = notes            # [str]
-
-
-def _candidates(sheet_sizes):
-    out = []
-    for (grain, cross, sname) in sheet_sizes:
-        for pname, (gf, cf, per_full) in SHEET_PIECES.items():
-            out.append({
-                "sheet_size": (grain, cross),
-                "sheet_name": sname,
-                "piece_name": pname,
-                "piece": (grain * gf, cross * cf),
-                "per_full": per_full,
-            })
-    return out
-
-
-def _cover(parts, cands, kerf, allow_rotate, edge_trim, packer):
-    """Greedily cover `parts` with buys, most-parts-then-least-material first.
-
-    A part can only ride a piece it fits; each round picks the candidate that
-    seats the most still-unplaced parts (ties: least material, then smaller
-    piece), packs them, and removes them. Returns (buys, leftover).
-    """
-    remaining = list(parts)
-    buys = []
-    while remaining:
-        best = None
-        for c in cands:
-            usable = _usable(c["piece"], edge_trim)
-            fit = [p for p in remaining if _fits(p, usable, allow_rotate)]
-            if not fit:
-                continue
-            packed, engine = _pack_one_size(
-                fit, c["piece"], kerf, allow_rotate, edge_trim, packer)
-            buy = SheetBuy(c["sheet_size"], c["sheet_name"], c["piece_name"],
-                           c["piece"], packed, c["per_full"], engine)
-            rank = (-len(fit), buy.bought_area, max(c["piece"]))
-            if best is None or rank < best[0]:
-                best = (rank, buy, fit)
-        if best is None:
-            break
-        buys.append(best[1])
-        for p in best[2]:
-            remaining.remove(p)
-    return buys, remaining
-
-
-def choose_sheets(parts, sheet_sizes=None, kerf=KERF, allow_rotate=False,
-                  max_length=None, edge_trim=0.0, prefer=None, packer="auto",
-                  oversize=0.0):
-    """Plan sheet goods from the catalog. Returns a SheetPlan.
-
-    Each part rides the sheet size + transport piece (full / half / half-rip) that
-    holds it for the least material. `prefer` is a *preference*, not a filter:
-    parts that fit it use it, and parts too big for it are upgraded to the
-    smallest piece that does fit, recorded in `.notes`. Parts that cannot meet
-    the limits at all — bigger than any stocked sheet, or too big to carry within
-    `max_length` — are returned in `.flagged`, and everything else is still
-    planned. `edge_trim` shrinks each piece before packing; `oversize` grows each
-    part (cut rough, trim to final); `packer` selects the engine.
-    """
-    sheet_sizes = sheet_sizes or SHEET_SIZES
-    cands = _candidates(sheet_sizes)
-    if oversize:
-        parts = [(n, l + oversize, w + oversize) for n, l, w in parts]
-
-    within = ([c for c in cands if max(c["piece"]) <= max_length + 1e-6]
-              if max_length else list(cands))
-
-    # Biggest usable face on offer, for the "does not fit any sheet" message.
-    biggest = max(((s[0] - 2.0 * edge_trim, s[1] - 2.0 * edge_trim)
-                   for s in sheet_sizes), key=lambda d: d[0] * d[1])
-
-    plannable, flagged = [], []
-    for part in parts:
-        fits_any = any(_fits(part, _usable(c["piece"], edge_trim), allow_rotate)
-                       for c in cands)
-        fits_within = any(
-            _fits(part, _usable(c["piece"], edge_trim), allow_rotate)
-            for c in within)
-        if not fits_any:
-            flagged.append((part[0], part[1], part[2],
-                            "bigger than any stocked sheet "
-                            "(largest usable %.0f x %.0f) — split it"
-                            % (biggest[0], biggest[1])))
-        elif not fits_within:
-            flagged.append((part[0], part[1], part[2],
-                            "does not fit any piece within the %.0fmm "
-                            "transport limit" % max_length))
-        else:
-            plannable.append(part)
-
-    notes = []
-    if not plannable:
-        return SheetPlan([], flagged, notes)
-
-    if prefer:
-        pref = [c for c in within if c["piece_name"] == prefer]
-        buys, leftover = _cover(plannable, pref, kerf, allow_rotate,
-                                edge_trim, packer)
-        if leftover:
-            esc_buys, still = _cover(leftover, within, kerf, allow_rotate,
-                                     edge_trim, packer)
-            upgraded = [p for p in leftover if p not in still]
-            if upgraded:
-                notes.append(
-                    "'%s' preferred, but %d part(s) needed a bigger piece: %s"
-                    % (prefer, len(upgraded),
-                       ", ".join(p[0] for p in upgraded)))
-            buys += esc_buys
-            leftover = still
-    else:
-        buys, leftover = _cover(plannable, within, kerf, allow_rotate,
-                                edge_trim, packer)
-
-    for p in leftover:
-        flagged.append((p[0], p[1], p[2],
-                        "could not be seated on any single stocked piece"))
-
-    return SheetPlan(buys, flagged, notes)
-
-
 def board_feet(stock_t, stock_w, length):
     """Board feet — how lumber is actually priced."""
     return (stock_t / IN) * (stock_w / IN) * (length / IN) / 144.0
+
+
+# --- sourcing options --------------------------------------------------------
+
+_TIER_NUM = {"$": 1, "$$": 2, "$$$": 3}
+
+
+def _tier_num(tier):
+    return _TIER_NUM.get(tier, len(tier))
+
+
+def _bump_tier(tier):
+    """A cleaner grade / wider stock is usually a step up in price."""
+    return {"$": "$$", "$$": "$$$", "$$$": "$$$"}.get(tier, tier)
+
+
+def _nom_inch(mm):
+    """Actual mm -> the nominal inch a woodworker names it by (3.5" -> 4)."""
+    return int(round(mm / IN + 0.5))
+
+
+def _nominal_name(thick, width):
+    """(thick_mm, width_mm) -> "2x10"."""
+    return "%dx%d" % (_nom_inch(thick), _nom_inch(width))
+
+
+def _quarter_inch(label):
+    """A hardwood thickness label -> nominal inches for board-foot ("6/4" -> 1.5)."""
+    if "/" in label:
+        num, den = label.split("/")
+        return float(num) / float(den)
+    return float(label)
+
+
+class SourcingOption:
+    """One way to buy and break down a material group.
+
+    `layout` is the concrete cut plan; `layout_kind` says how to read it:
+      "boards" -> [Board], each a stick with crosscuts;
+      "sheets" -> [Sheet], each a sheet/board ripped into strips then crosscut.
+    `buy` is the shopping line(s) as dicts (count + nominal + length + min_width),
+    left unformatted so the caller can render in the shop's own units.
+    """
+
+    def __init__(self, label, buy, layout, layout_kind, tier, quality,
+                 board_feet=None, sheet_count=None, tradeoffs=None,
+                 annotations=None, engine=None):
+        self.label = label
+        self.buy = buy                    # [{count, nominal, length?, min_width?}]
+        self.layout = layout
+        self.layout_kind = layout_kind    # "boards" | "sheets"
+        self.tier = tier
+        self.quality = quality
+        self.board_feet = board_feet
+        self.sheet_count = sheet_count
+        self.tradeoffs = tradeoffs or []
+        self.annotations = annotations or []
+        self.engine = engine
+        self.recommended = False
+
+    @property
+    def amount(self):
+        return self.board_feet if self.board_feet is not None else self.sheet_count
+
+
+class OptionSet:
+    """Every sourcing option for one (material, thickness) group, ranked."""
+
+    def __init__(self, material, thickness, options, flagged, notes):
+        self.material = material
+        self.thickness = thickness
+        self.options = options          # [SourcingOption], best first
+        self.flagged = flagged          # [(name, reason)]
+        self.notes = notes              # [str]
+
+    @property
+    def recommended(self):
+        return self.options[0] if self.options else None
+
+    @property
+    def alternatives(self):
+        return self.options[1:]
+
+
+def _rank_key(o, prefer):
+    t = _tier_num(o.tier)
+    amt = o.amount if o.amount is not None else 0
+    if prefer == "cost":
+        return (t, amt)
+    if prefer == "quality":
+        return (-o.quality, t, amt)
+    # value (default): trade tier against quality, then least material, then the
+    # cheaper tier as a final tie-break.
+    return (t - o.quality, amt, t)
+
+
+def _rank(options, prefer):
+    options.sort(key=lambda o: _rank_key(o, prefer))
+    if options:
+        options[0].recommended = True
+    return options
+
+
+def source_options(parts, material, thickness=None, kerf=KERF, end_trim=END_TRIM,
+                   edge_trim=EDGE_TRIM, oversize=OVERSIZE, prefer="value",
+                   tooling=None, packer="auto"):
+    """Ranked ways to buy one material group. Returns an OptionSet.
+
+    `parts` are finished sizes as (name, length, width) — length the longest
+    dimension, width the next (thickness is the material's own and is not packed).
+    `material` keys into MATERIALS; `thickness` is its label where the family
+    needs one (hardwood quarters, sheet-good thickness). `prefer` is value /
+    cost / quality. The tool never chooses the material type, so ranking only
+    orders options *within* this type.
+    """
+    tooling = TOOLING if tooling is None else tooling
+    spec = MATERIALS[material]
+    fam = spec["family"]
+    if not parts:
+        return OptionSet(material, thickness, [], [], [])
+
+    if fam == "dimensional":
+        opts, flagged, notes = _options_dimensional(
+            parts, spec, kerf, end_trim, oversize, tooling)
+    elif fam == "solidwood":
+        opts, flagged, notes = _options_hardwood(
+            parts, spec, thickness, kerf, end_trim, oversize, tooling)
+    elif fam == "sheet":
+        opts, flagged, notes = _options_sheet(
+            parts, spec, kerf, edge_trim, oversize, packer)
+    else:
+        raise ValueError("unknown material family %r" % fam)
+
+    _rank(opts, prefer)
+    return OptionSet(material, thickness, opts, flagged, notes)
+
+
+def _options_dimensional(parts, spec, kerf, end_trim, oversize, tooling):
+    """Dimensional lumber: an exact-nominal buy used as-is, plus rip-from-wider
+    options for any nominal that yields two or more clean strips."""
+    widths = spec["widths"]
+    lengths = spec["lengths"]
+    thick = spec["thick"]
+    cleanup = tooling["edge_cleanup"]
+
+    flagged, plan_parts = [], []
+    max_usable_len = max(lengths) - 2.0 * end_trim
+    for n, l, w in parts:
+        if w > widths[-1] + 1e-6:
+            flagged.append((n, "wider (%.0f) than any stocked nominal" % w))
+        elif l + oversize > max_usable_len + 1e-6:
+            flagged.append((n, "longer (%.0f) than the longest stocked board" % l))
+        else:
+            plan_parts.append((n, l, w))
+    if not plan_parts:
+        return [], flagged, []
+
+    maxW = max(w for _, _, w in plan_parts)
+    options = []
+
+    # 1. exact-nominal: the narrowest nominal that holds the widest strip, bought
+    #    as-is (factory-eased edges), planned 1-D by length.
+    exact = next((w for w in widths if w >= maxW - 1e-6), None)
+    if exact is not None:
+        boards = plan_linear([(n, l) for n, l, _ in plan_parts], lengths,
+                             kerf, end_trim, oversize)
+        if boards:
+            bf = sum(board_feet(thick, exact, b.length) for b in boards)
+            options.append(SourcingOption(
+                label="%s, as-is" % _nominal_name(thick, exact),
+                buy=[{"count": len(boards),
+                      "nominal": _nominal_name(thick, exact),
+                      "length": boards[0].length}],
+                layout=boards, layout_kind="boards", tier=spec["tier"], quality=1,
+                board_feet=bf, tradeoffs=["factory (eased) edges", "no ripping"]))
+
+    # 2. rip-from-wider: any wider nominal that yields >= 2 clean strips. One
+    #    clean strip is no gain over buying the exact nominal — that is the "2x8
+    #    trap". Ripping is a 2-D nest onto a narrow "sheet" of (length, nominal).
+    for w in widths:
+        if exact is not None and w <= exact + 1e-6:
+            continue
+        lanes = int((w - 2.0 * cleanup + kerf) // (maxW + kerf))
+        if lanes < 2:
+            continue
+        best = None
+        for L in lengths:
+            try:
+                sheets = plan_sheets([(n, l, pw) for n, l, pw in plan_parts],
+                                     sheet=(L, w), kerf=kerf, allow_rotate=False,
+                                     edge_trim=cleanup, oversize=oversize)
+            except ValueError:
+                continue
+            # Least material (board count x length), then the shorter stock.
+            rank = (round(len(sheets) * L), L)
+            if best is None or rank < best[0]:
+                best = (rank, sheets, L)
+        if best is None:
+            continue
+        _, sheets, L = best
+        bf = len(sheets) * board_feet(thick, w, L)
+        options.append(SourcingOption(
+            label="rip from %s" % _nominal_name(thick, w),
+            buy=[{"count": len(sheets), "nominal": _nominal_name(thick, w),
+                  "length": L}],
+            layout=sheets, layout_kind="sheets", tier=_bump_tier(spec["tier"]),
+            quality=2, board_feet=bf,
+            tradeoffs=["%d clean strips/board" % lanes, "all-square edges",
+                       "clearer grade"]))
+
+    return options, flagged, []
+
+
+def _options_hardwood(parts, spec, thickness, kerf, end_trim, oversize, tooling):
+    """Hardwood: nest the rip profiles across a board's width. Random-width stock,
+    so options are phrased "buy >= N boards >= W wide x L": a wide-board option
+    that stacks every profile onto few boards, and a narrow-board option, one
+    board width per distinct profile."""
+    thickness = thickness or spec["thicknesses"][0]
+    nom_thick = _quarter_inch(thickness) * IN
+    lengths = spec["lengths"]
+    cleanup = tooling["edge_cleanup"]
+
+    flagged, plan_parts = [], []
+    max_usable_len = max(lengths) - 2.0 * end_trim
+    for n, l, w in parts:
+        if l + oversize > max_usable_len + 1e-6:
+            flagged.append((n, "longer (%.0f) than the longest stocked board" % l))
+        else:
+            plan_parts.append((n, l, w))
+    if not plan_parts:
+        return [], flagged, []
+
+    widths = sorted({round(w, 1) for _, _, w in plan_parts})
+    options = []
+
+    def nest(group, board_w):
+        best = None
+        for L in lengths:
+            try:
+                sheets = plan_sheets(group, sheet=(L, board_w), kerf=kerf,
+                                     allow_rotate=False, edge_trim=cleanup,
+                                     oversize=oversize)
+            except ValueError:
+                continue
+            rank = (round(len(sheets) * L), L)
+            if best is None or rank < best[0]:
+                best = (rank, sheets, L)
+        return best
+
+    # wide-board option: one board carries a lane per distinct profile width.
+    # Each lane is packed at (profile width + oversize); the board must hold the
+    # lanes, the rip kerfs between them, and the cleaned-up edges.
+    lane = lambda w: w + oversize
+    wide_w = (sum(lane(w) for w in widths) + kerf * max(0, len(widths) - 1)
+              + 2.0 * cleanup + 2.0)
+    wide = nest(plan_parts, wide_w)
+    if wide:
+        _, sheets, L = wide
+        bf = len(sheets) * board_feet(nom_thick, wide_w, L)
+        options.append(SourcingOption(
+            label="wide boards",
+            buy=[{"count": len(sheets), "nominal": thickness,
+                  "min_width": wide_w, "length": L}],
+            layout=sheets, layout_kind="sheets", tier=spec["tier"], quality=1,
+            board_feet=bf,
+            tradeoffs=["fewest boards", "%d rip profiles/board" % len(widths)],
+            annotations=["random-width stock: real boards run wider; "
+                         "extra width is offcut"]))
+
+    # narrow-board option: a separate run per distinct profile width. Only worth
+    # showing when there is more than one profile (else it equals the wide one).
+    if len(widths) > 1:
+        buys, all_sheets, total_bf = [], [], 0.0
+        ok = True
+        for w in widths:
+            grp = [(n, l, pw) for n, l, pw in plan_parts if round(pw, 1) == w]
+            board_w = lane(w) + 2.0 * cleanup + 2.0
+            res = nest(grp, board_w)
+            if res is None:
+                ok = False
+                break
+            _, sheets, L = res
+            buys.append({"count": len(sheets), "nominal": thickness,
+                         "min_width": board_w, "length": L})
+            all_sheets.extend(sheets)
+            total_bf += len(sheets) * board_feet(nom_thick, w + 2.0 * cleanup, L)
+        if ok:
+            options.append(SourcingOption(
+                label="narrow boards",
+                buy=buys, layout=all_sheets, layout_kind="sheets",
+                tier=spec["tier"], quality=1, board_feet=total_bf,
+                tradeoffs=["one board width per profile", "more boards"],
+                annotations=["random-width stock: real boards run wider; "
+                             "extra width is offcut"]))
+
+    return options, flagged, []
+
+
+def _options_sheet(parts, spec, kerf, edge_trim, oversize, packer):
+    """Sheet goods: nest onto each of the quality's sheet sizes that holds every
+    part, one option per size. Transport is annotated, never forced."""
+    allow_rotate = not spec["grain"]
+    sizes = spec["sizes"]
+
+    # Flag parts bigger than every stocked size (grain respected).
+    flagged, plan_parts = [], []
+    for part in parts:
+        if any(_fits(part, _usable(s[:2], edge_trim), allow_rotate)
+               for s in sizes):
+            plan_parts.append(part)
+        else:
+            biggest = max(sizes, key=lambda s: s[0] * s[1])
+            u = _usable(biggest[:2], edge_trim)
+            flagged.append((part[0], "bigger than any stocked sheet "
+                            "(largest usable %.0f x %.0f) - split it"
+                            % (u[0], u[1])))
+    if not plan_parts:
+        return [], flagged, []
+
+    options = []
+    for (grain, cross, name) in sizes:
+        if not all(_fits(p, _usable((grain, cross), edge_trim), allow_rotate)
+                   for p in plan_parts):
+            continue
+        sheets, engine = _pack_one_size(plan_parts, (grain, cross), kerf,
+                                        allow_rotate, edge_trim, packer)
+        annotations = []
+        # Transport is informational: a full 4x8 you could have the store rip.
+        if grain >= 8 * FT - 1e-6 and cross >= 4 * FT - 1e-6:
+            annotations.append("full %s - each could be store-cut in half" % name)
+        options.append(SourcingOption(
+            label=name,
+            buy=[{"count": len(sheets), "nominal": name}],
+            layout=sheets, layout_kind="sheets", tier=spec["tier"],
+            quality=spec["quality"], sheet_count=len(sheets),
+            tradeoffs=["grain respected" if spec["grain"] else "no grain"],
+            annotations=annotations, engine=engine))
+
+    return options, flagged, []

--- a/plugins-claude/freecad/lib/wwkit.py
+++ b/plugins-claude/freecad/lib/wwkit.py
@@ -141,6 +141,18 @@ MDF = {  # MDF is true to nominal, unlike ply
     "3/4": inch("3/4"),
 }
 
+# A panel declares a sheet-goods *quality* (a wwcut.MATERIALS key) plus a nominal
+# thickness label; the actual mm the solid is built at comes from here. The model
+# picks the quality; the yield/sourcing is the cut plan's job. Keep these in step
+# with any thickness label offered by the matching wwcut sheet material.
+SHEET_ACTUAL = {
+    "mdf": MDF,
+    "pine-ply": PLY,
+    "solid-core": PLY,
+    "birch-ply": {"1/2": 12.0, "3/4": 18.0},  # Baltic is sold metric
+    "laminate": {"1.2mm": 1.2},               # plastic laminate (Formica)
+}
+
 # --- appearance ----------------------------------------------------------
 # Colour + transparency are keyed by a part's `kind` (see Model.add). `kind` is
 # a free-form string, so a model can invent its own; anything not in KIND_STYLE
@@ -270,15 +282,27 @@ def edges_at(shape, z=None, tol=1e-6):
 
 
 class Part_:
-    """One real part: a named solid with a material role."""
+    """One real part: a named solid with a material role.
 
-    def __init__(self, obj, kind, nominal=None, stock=None, form=None,
-                 oversize=None):
+    A part declares WHAT it is made of (a `material` type from wwcut.MATERIALS,
+    plus a `thickness` label where the family needs one) — never a stock size.
+    The finished cross-section and length come from the solid; turning the type
+    into "buy N of this nominal, cut it thus" is the cut plan's job.
+    """
+
+    def __init__(self, obj, kind, nominal=None, material=None, thickness=None,
+                 rip_with=None, from_scrap=False, oversize=None):
         self.obj = obj
         self.kind = kind  # "wood" | "printed"
         self.nominal = nominal  # (dx, dy, dz) as authored, for the cut list
-        self.stock = stock  # e.g. "2x4" — the nominal name you buy it under
-        self.form = form  # "board" | "sheet" | None — how the planner packs it
+        self.material = material  # wwcut.MATERIALS key, or None -> not planned
+        self.thickness = thickness  # thickness label where the family needs one
+        # This part is ripped from a sibling's blank (an adjacent profile on the
+        # same stick): it names the bearer part and is counted on the bearer's
+        # blank, not bought on its own.
+        self.rip_with = rip_with
+        # Cut from offcut/scrap, not bought: reported but never added to the buy.
+        self.from_scrap = from_scrap
         # Rough-cut allowance for THIS part, or None to use the cutplan default.
         # 0 exempts a part that is already final size, or a glue-up member whose
         # trim happens at the assembly (set the assembly's oversize instead).
@@ -333,78 +357,97 @@ class Model:
         self.parts = []
 
     # -- construction -----------------------------------------------------
-    def add(self, name, shape, kind="wood", nominal=None, stock=None, form=None,
-            oversize=None):
+    def add(self, name, shape, kind="wood", nominal=None, material=None,
+            thickness=None, rip_with=None, from_scrap=False, oversize=None):
         o = self.doc.addObject("Part::Feature", name)
         o.Shape = shape
-        p = Part_(o, kind, nominal=nominal, stock=stock, form=form,
+        p = Part_(o, kind, nominal=nominal, material=material,
+                  thickness=thickness, rip_with=rip_with, from_scrap=from_scrap,
                   oversize=oversize)
         self.parts.append(p)
         return p
 
-    def box(self, name, dx, dy, dz, at=(0, 0, 0), kind="wood", oversize=None,
-            form=None, stock=None):
-        """A plain rectangular solid. Pass form="board"/"sheet" and a stock name
-        to have cutplan buy it (e.g. a hardwood edge band as linear stock, a
-        laminate as a sheet); leave them off and it is a shape the plan skips."""
+    def box(self, name, dx, dy, dz, at=(0, 0, 0), kind="wood", material=None,
+            thickness=None, rip_with=None, from_scrap=False, oversize=None):
+        """A plain rectangular solid. Pass a `material` type to have cutplan
+        source it (e.g. material="hardwood" for an edge band, "laminate" for a
+        Formica facing); leave it off and it is a shape the plan skips. Set
+        from_scrap=True for a part cut from offcuts (reported, never bought)."""
         return self.add(name, solid(dx, dy, dz, at), kind, nominal=(dx, dy, dz),
-                        oversize=oversize, form=form, stock=stock)
+                        material=material, thickness=thickness, rip_with=rip_with,
+                        from_scrap=from_scrap, oversize=oversize)
 
-    def strip(self, name, shape, stock, kind="wood", oversize=None):
-        """A part cut to length from linear stock whose shape is not a plain
-        board() box — a ripped hardwood cleat, an angled edge band, an on-edge
-        ply strip. cutplan buys it as a board: its longest bounding dimension is
-        the length, and parts sharing a `stock` name come off the same sticks.
+    def strip(self, name, shape, material="hardwood", thickness="4/4",
+              rip_with=None, kind="wood", oversize=None):
+        """A part cut from stock whose shape is not a plain board() box — a
+        ripped hardwood cleat, an angled edge band, an on-edge ply strip.
+        cutplan sources it from `material`: its longest bounding dimension is the
+        length, the next is the rip width, and the material's own thickness is
+        the third.
 
-        `shape` is any already-built Part shape (e.g. from ww.prism/wedge). Use
-        distinct `stock` names for distinct rip profiles so the plan does not
-        pool a wide band with a narrow cleat onto one stick."""
+        `shape` is any already-built Part shape (e.g. from ww.prism/wedge). Pass
+        rip_with="OtherPart" when this rides an adjacent profile on a sibling's
+        blank (an interlocking key on a cleat's stick) — it is then counted on
+        that blank, not bought on its own."""
         bb = shape.BoundBox
         return self.add(name, shape, kind,
                         nominal=(bb.XLength, bb.YLength, bb.ZLength),
-                        stock=stock, form="board", oversize=oversize)
+                        material=material, thickness=thickness, rip_with=rip_with,
+                        oversize=oversize)
 
-    def board(self, name, stock, length, at=(0, 0, 0),
-              length_axis="x", thickness_axis="z", rip=None, kind="wood",
-              oversize=None):
-        """A board of real dimensional lumber. `stock` is nominal ("2x4").
+    def board(self, name, length, width, at=(0, 0, 0),
+              length_axis="x", thickness_axis="z", material="framing",
+              thickness=None, kind="wood", oversize=None):
+        """A board of dimensional lumber, sized to its FINISHED cross-section.
 
-        Orientation is given by two axes rather than one, because one is
-        ambiguous: a board lying flat and the same board standing on edge share
-        a length axis but are not the same part. Width takes the axis left over.
+        `material` is a type (default "framing"); the thickness comes from that
+        material unless given explicitly, and `width` is the finished width you
+        design. The cut plan decides how to buy it — the exact nominal as-is, or
+        clean strips ripped from a wider board. Orientation is two axes because
+        one is ambiguous: a board flat and the same board on edge share a length
+        axis but are different parts. Width takes the axis left over.
         """
-        if stock not in LUMBER:
-            raise KeyError("unknown lumber %r; known: %s"
-                           % (stock, ", ".join(sorted(LUMBER))))
+        import wwcut
+        spec = wwcut.MATERIALS.get(material)
+        if spec is None:
+            raise KeyError("unknown material %r; known: %s"
+                           % (material, ", ".join(sorted(wwcut.MATERIALS))))
+        t = spec.get("thick") if thickness is None else thickness
+        if t is None:
+            raise ValueError("material %r has no fixed thickness; pass thickness="
+                             % material)
         if length_axis == thickness_axis:
             raise ValueError("length and thickness cannot share an axis")
-        t, w = LUMBER[stock]
-        if rip:  # ripped narrower than the stock came
-            w = rip
         width_axis = ({"x", "y", "z"} - {length_axis, thickness_axis}).pop()
-        by_axis = {length_axis: length, thickness_axis: t, width_axis: w}
+        by_axis = {length_axis: length, thickness_axis: t, width_axis: width}
         dims = (by_axis["x"], by_axis["y"], by_axis["z"])
         return self.add(name, solid(*dims, at=at), kind, nominal=dims,
-                        stock=stock, form="board", oversize=oversize)
+                        material=material, thickness=thickness, oversize=oversize)
 
-    def panel(self, name, stock, length, width, at=(0, 0, 0),
-              thickness_axis="z", table=PLY, kind="wood", oversize=None):
-        """A sheet-goods panel. `stock` keys into PLY / BALTIC / MDF.
+    def panel(self, name, length, width, at=(0, 0, 0), thickness_axis="z",
+              material="pine-ply", thickness="3/4", kind="wood", oversize=None):
+        """A sheet-goods panel. `material` is a quality (a wwcut sheet type:
+        mdf / pine-ply / birch-ply / solid-core / laminate); `thickness` is a
+        nominal label. The solid is built at the real mm from SHEET_ACTUAL, and
+        the cut plan nests it onto that quality's sheet sizes.
 
         thickness_axis matters: a cabinet bottom is thick in Z, a back panel is
-        thick in Y. Getting it wrong produces a part with the right area and a
-        nonsensical thickness.
+        thick in Y. Getting it wrong produces the right area at a nonsense
+        thickness.
         """
-        if stock not in table:
-            raise KeyError("unknown sheet %r; known: %s"
-                           % (stock, ", ".join(sorted(table))))
-        t = table[stock]
+        table = SHEET_ACTUAL.get(material)
+        if table is None:
+            raise KeyError("unknown sheet material %r; known: %s"
+                           % (material, ", ".join(sorted(SHEET_ACTUAL))))
+        if thickness not in table:
+            raise KeyError("no actual thickness for %r %r; known: %s"
+                           % (material, thickness, ", ".join(sorted(table))))
+        t = table[thickness]
         others = [a for a in "xyz" if a != thickness_axis]
         by_axis = {thickness_axis: t, others[0]: length, others[1]: width}
         dims = (by_axis["x"], by_axis["y"], by_axis["z"])
-        return self.add(name, solid(*dims, at=at), kind,
-                        nominal=dims, stock=stock, form="sheet",
-                        oversize=oversize)
+        return self.add(name, solid(*dims, at=at), kind, nominal=dims,
+                        material=material, thickness=thickness, oversize=oversize)
 
     def place(self, name, shape, at=(0, 0, 0), rot_z=0.0, kind="printed"):
         """Stamp an already-built shape into the model at a placement."""
@@ -588,43 +631,42 @@ class Model:
         rows = []
         for p in wood:
             dims = sorted(p.nominal or _bbox_dims(p.shape), reverse=True)
-            rows.append((p.name, p.stock, dims))
-            say("  %-16s %-6s %8s x %8s x %8s"
-                % (p.name, p.stock or "", fmt(dims[0]), fmt(dims[1]), fmt(dims[2])))
+            mat = p.material or ""
+            if p.thickness:
+                mat = "%s %s" % (mat, p.thickness)
+            rows.append((p.name, mat, dims))
+            say("  %-16s %-14s %8s x %8s x %8s"
+                % (p.name, mat, fmt(dims[0]), fmt(dims[1]), fmt(dims[2])))
         return rows
 
-    def cutplan(self, board_lengths=None, sheet_sizes=None, kerf=None,
-                allow_rotate=False, max_length=None, sheet_piece=None,
-                end_trim=None, edge_trim=None, oversize=None, packer="auto",
-                stock_lengths=None):
+    def cutplan(self, kerf=None, end_trim=None, edge_trim=None, oversize=None,
+                prefer="value", tooling=None, packer="auto"):
         """From a parts list to a shopping list and a cutting order.
 
-        `cutlist()` says what parts you need. This says what to *buy*, and board
-        by board what to cut from each one — the thing you take to the yard and
-        then to the saw.
+        `cutlist()` says what parts you need. This says what to *buy*, and how to
+        break each board or sheet down — the thing you take to the yard and the
+        saw. Parts declare a material *type*, not a stock size, so each material
+        group gets a small ranked set of sourcing OPTIONS: the recommended one is
+        printed in full (buy line, board-feet or sheets, cost tier, cut layout),
+        the alternatives collapse to one line each ("also works: ...").
 
-        board_lengths  sellable board lengths to choose from (default catalog).
-        sheet_sizes    sellable sheet sizes as [(grain, cross, name), ...].
-        max_length     the longest piece you can actually get home. Stock longer
-                       than this is never offered, however well it would pack.
-        sheet_piece    "full" | "half" | "half-rip", or None to choose. You always
-                       buy a full sheet; this is what you ask the store to cut it
-                       into before it goes in the vehicle.
-        end_trim       squared off each board end before packing (default 1").
-        edge_trim      trimmed off each sheet edge before packing (default 1/2").
-        oversize       default rough-cut allowance per part (default 1/8"): parts
-                       are cut oversize and trimmed to final for clean edges. A
-                       board grows only in length (its width is fixed rip stock);
-                       a sheet part grows in both faces. Any part can override via
-                       board()/panel()/box(oversize=...) — set 0 for a part that
-                       is already final, or a glue-up member trimmed at the
-                       assembly (put the allowance on the assembly instead).
-        packer         "auto" | "rectpack" | "shelf" sheet-packing engine.
+        prefer     how to rank within a type: "value" (default — best quality per
+                   tier, then least material), "cost", or "quality".
+        end_trim   squared off each board end before packing (default 1").
+        edge_trim  trimmed off each sheet edge before packing (default 1/2").
+        oversize   default rough-cut allowance per part (default 1/8"): parts are
+                   cut oversize and trimmed to final for clean edges. Any part can
+                   override via board()/panel()/box/strip(oversize=...) — set 0
+                   for a part already at final size, or a glue-up member trimmed
+                   at the assembly (put the allowance on the assembly instead).
+        tooling    the shop's tool allowances (wwcut.TOOLING); edge_cleanup is the
+                   rip-edge clean-up a rip-from-wider plan spends per squared edge.
+        packer     "auto" | "rectpack" | "shelf" 2-D packing engine.
 
-        `stock_lengths` is a deprecated alias for `board_lengths`.
-
-        Parts made with box() are skipped: no stock, so nothing to buy them
-        from. Use board() or panel() to have them planned.
+        Transport is not a constraint: the planner nests onto full stock and
+        annotates ("could be store-cut in half"). A part with no material is
+        skipped (nothing to buy); from_scrap parts are reported, never bought.
+        Returns the list of OptionSet objects (one per material group).
         """
         import wwcut
 
@@ -632,120 +674,138 @@ class Model:
         end_trim = wwcut.END_TRIM if end_trim is None else end_trim
         edge_trim = wwcut.EDGE_TRIM if edge_trim is None else edge_trim
         oversize = wwcut.OVERSIZE if oversize is None else oversize
-        board_lengths = board_lengths if board_lengths is not None else stock_lengths
+        tooling = wwcut.TOOLING if tooling is None else tooling
 
-        boards = [p for p in self.parts if p.form == "board"]
-        sheets = [p for p in self.parts if p.form == "sheet"]
+        planned = [p for p in self.parts if p.material and not p.from_scrap]
+        scrap = [p for p in self.parts if p.from_scrap]
         skipped = [p for p in self.parts
-                   if p.kind == "wood" and p.form is None]
+                   if p.kind == "wood" and not p.material and not p.from_scrap]
+
+        # rip_with children ride a bearer's blank: fold each into its bearer.
+        riders = {}
+        for p in planned:
+            if p.rip_with:
+                riders.setdefault(p.rip_with, []).append(p)
+
+        def dims_of(p):
+            d = sorted(p.nominal or _bbox_dims(p.shape), reverse=True)
+            return d[0], d[1]   # length, rip width (thickness = d[2], material's)
+
+        # Build (name, length, width) per planned, non-rider part, per (material,
+        # thickness) group. A bearer swallows its riders' widths onto one blank.
+        groups = {}
+        for p in planned:
+            if p.rip_with:
+                continue
+            length, width = dims_of(p)
+            ov = oversize if p.oversize is None else p.oversize
+            name = p.name
+            for kid in riders.get(p.name, []):
+                kl, kw = dims_of(kid)
+                length = max(length, kl)
+                width += kw + kerf
+                name = "%s+%s" % (name, kid.name)
+            groups.setdefault((p.material, p.thickness), []).append(
+                (name, length, width, ov))
 
         say("=" * 64)
-        limit = "  (transport limit %s)" % fmt(max_length) if max_length else ""
-        say("CUT PLAN  (kerf %s, end-trim %s, edge-trim %s, oversize %s)%s"
-            % (fmt(kerf), fmt(end_trim), fmt(edge_trim), fmt(oversize), limit))
+        say("CUT PLAN  (kerf %s, end-trim %s, edge-trim %s, oversize %s, "
+            "prefer %s)" % (fmt(kerf), fmt(end_trim), fmt(edge_trim),
+                            fmt(oversize), prefer))
         if oversize:
             say("          part sizes below are rough (cut oversize, trim to final)")
 
         buy = []
-        flags = []   # (name, reason) — parts that could not meet the limits
+        results = []
+        for key in sorted(groups, key=lambda k: (k[0], k[1] or "")):
+            material, thickness = key
+            # A per-part oversize can differ; source_options takes one scalar, so
+            # apply each part's own allowance up front and pass oversize=0. A
+            # board/hardwood strip grows in LENGTH only — its rip width is cut to
+            # final, and growing it would push the exact-nominal match a size up.
+            # A sheet part is the trimmed panel, so both faces grow.
+            sheet_fam = wwcut.MATERIALS[material]["family"] == "sheet"
+            parts = [(n, l + ov, (w + ov) if sheet_fam else w)
+                     for (n, l, w, ov) in groups[key]]
+            opt = wwcut.source_options(parts, material, thickness, kerf, end_trim,
+                                       edge_trim, 0.0, prefer, tooling, packer)
+            results.append(opt)
+            self._say_options(opt, buy)
 
-        # --- boards, grouped by the stock you buy them as -----------------
-        by_stock = {}
-        for p in boards:
-            by_stock.setdefault(p.stock, []).append(p)
-
-        for stock in sorted(by_stock):
-            # Per-part oversize (rough-cut allowance), defaulting to the cutplan
-            # default. On a board only the LENGTH grows — width is fixed stock
-            # you rip — so a glue-up member gets a trim-to-length allowance and
-            # never a cross-seam one.
-            items = [(p.name,
-                      max(p.nominal) + (oversize if p.oversize is None
-                                        else p.oversize))
-                     for p in by_stock[stock]]
-            plan = wwcut.plan_linear(items, board_lengths, kerf, max_length,
-                                     end_trim, 0.0)
-            for n, l, reason in plan.flagged:
-                flags.append(("%s %s (%s)" % (stock, n, fmt(l)), reason))
-            if len(plan):
-                say("")
-                say("  %s  -- %d board(s) of %s"
-                    % (stock, len(plan), fmt_stock(plan[0].length)))
-                for i, b in enumerate(plan, 1):
-                    cuts = ", ".join("%s (%s)" % (n, fmt(l)) for n, l in b.cuts)
-                    say("    #%d: %s" % (i, cuts))
-                    say("        offcut %s" % fmt(b.offcut))
-                buy.append("%d x %s @ %s"
-                           % (len(plan), stock, fmt_stock(plan[0].length)))
-
-        # --- sheet goods, grouped by thickness ----------------------------
-        by_sheet = {}
-        for p in sheets:
-            by_sheet.setdefault(p.stock, []).append(p)
-
-        for stock in sorted(by_sheet):
-            items = []
-            for p in by_sheet[stock]:
-                dims = sorted(p.nominal, reverse=True)
-                # A sheet part IS the trimmed panel, so both faces grow by the
-                # part's oversize (default when None). Set oversize=0 on a part
-                # whose trimming happens at the assembly, not the part.
-                ov = oversize if p.oversize is None else p.oversize
-                items.append((p.name, dims[0] + ov, dims[1] + ov))
-
-            sp = wwcut.choose_sheets(items, sheet_sizes, kerf, allow_rotate,
-                                     max_length, edge_trim, sheet_piece, packer,
-                                     0.0)
-            for note in sp.notes:
-                say("")
-                say("  NOTE (%s sheet): %s" % (stock, note))
-            for n, pl, pw, reason in sp.flagged:
-                flags.append(("%s %s (%s x %s)"
-                              % (stock, n, fmt(pl), fmt(pw)), reason))
-
-            for sb in sp.buys:
-                piece_of = ("" if sb.piece_name == "full"
-                            else " %s piece" % sb.piece_name)
-                say("")
-                say("  %s sheet  -- %d x %s%s (%s x %s), from %d full %s sheet(s) [%s]"
-                    % (stock, len(sb.pieces), sb.sheet_name, piece_of,
-                       fmt_stock(sb.piece[0]), fmt_stock(sb.piece[1]),
-                       sb.full_sheets, sb.sheet_name, sb.engine))
-                say("      %.0f%% of the bought material used%s"
-                    % (sb.yield_pct, "" if allow_rotate else ", grain respected"))
-                for i, s in enumerate(sb.pieces, 1):
-                    say("    piece #%d:" % i)
-                    for strip in s.strips:
-                        parts = ", ".join("%s (%s x %s)" % (n, fmt(pl), fmt(pw))
-                                          for n, pl, pw in strip["parts"])
-                        say("      rip %s wide: %s" % (fmt(strip["depth"]), parts))
-
-                if sb.piece_name == "full":
-                    buy.append("%d x %s %s full sheet"
-                               % (sb.full_sheets, stock, sb.sheet_name))
-                else:
-                    cut = ("cut in half" if sb.piece_name == "half"
-                           else "ripped in half lengthwise")
-                    spare = ((", %d spare" % sb.spare_pieces)
-                             if sb.spare_pieces else "")
-                    buy.append("%d x %s %s full sheet (%s at the store%s)"
-                               % (sb.full_sheets, stock, sb.sheet_name, cut, spare))
-
+        if scrap:
+            say("")
+            say("  FROM SCRAP (%d part(s), cut from offcuts, not bought): %s"
+                % (len(scrap), ", ".join(p.name for p in scrap)))
         if skipped:
             say("")
-            say("  NOTE: %d part(s) not planned (made with box(), so no stock): %s"
+            say("  NOTE: %d part(s) not planned (no material declared): %s"
                 % (len(skipped), ", ".join(p.name for p in skipped)))
-
-        if flags:
-            say("")
-            say("FLAGGED   %d part(s) cannot meet the size limits:" % len(flags))
-            for what, reason in flags:
-                say("  ! %s: %s" % (what, reason))
 
         say("")
         say("BUY       " + ("; ".join(buy) if buy else "nothing to plan"))
         say("=" * 64)
-        return buy
+        return results
+
+    # -- cutplan rendering ------------------------------------------------
+    def _buylines(self, opt):
+        """A sourcing option's shopping line(s), e.g. '6 x 2x4 @ 8 ft'."""
+        out = []
+        for b in opt.buy:
+            s = "%d x %s" % (b["count"], b["nominal"])
+            if b.get("min_width") is not None:
+                s += " >=%s wide" % fmt(b["min_width"])
+            if b.get("length") is not None:
+                s += " @ %s" % fmt_stock(b["length"])
+            out.append(s)
+        return out
+
+    def _amount(self, opt):
+        if opt.board_feet is not None:
+            return "%.1f bd-ft" % opt.board_feet
+        return "%d sheet(s)" % opt.sheet_count
+
+    def _say_layout(self, opt):
+        if opt.layout_kind == "boards":
+            for i, b in enumerate(opt.layout, 1):
+                cuts = ", ".join("%s (%s)" % (n, fmt(l)) for n, l in b.cuts)
+                say("      #%d [%s, offcut %s]: %s"
+                    % (i, fmt_stock(b.length), fmt(b.offcut), cuts))
+        else:  # sheets / ripped boards, cut as rip strips then crosscuts
+            for i, s in enumerate(opt.layout, 1):
+                say("      board/sheet #%d:" % i)
+                for strip in s.strips:
+                    parts = ", ".join("%s (%s x %s)" % (n, fmt(pl), fmt(pw))
+                                      for n, pl, pw in strip["parts"])
+                    say("        rip %s wide: %s" % (fmt(strip["depth"]), parts))
+
+    def _say_options(self, opt, buy):
+        head = opt.material + ((" %s" % opt.thickness) if opt.thickness else "")
+        rec = opt.recommended
+        if rec is None:
+            say("")
+            say("  %s -- nothing planned" % head)
+            for n, reason in opt.flagged:
+                say("    ! %s: %s" % (n, reason))
+            return
+
+        say("")
+        say("  %s -- %s   (%s, %s)"
+            % (head, ", ".join(self._buylines(rec)), self._amount(rec), rec.tier))
+        if rec.tradeoffs:
+            say("      %s" % ", ".join(rec.tradeoffs))
+        for note in rec.annotations:
+            say("      note: %s" % note)
+        self._say_layout(rec)
+
+        for alt in opt.alternatives:
+            extra = (" [%s]" % ", ".join(alt.tradeoffs)) if alt.tradeoffs else ""
+            say("      also works: %s  --  %s, %s%s"
+                % (", ".join(self._buylines(alt)), self._amount(alt),
+                   alt.tier, extra))
+        for n, reason in opt.flagged:
+            say("    ! %s: %s" % (n, reason))
+
+        buy.extend(self._buylines(rec))
 
     def filament(self, density=PLA_DENSITY):
         printed = self.of_kind("printed")

--- a/plugins-claude/freecad/skills/modeling/SKILL.md
+++ b/plugins-claude/freecad/skills/modeling/SKILL.md
@@ -81,9 +81,14 @@ is the interface the user actually edits.
 ### Nominal sizes are lies — this is the one that bites
 
 A "2x4" is 1.5" x 3.5". "3/4" plywood is 23/32". **Never type the nominal number
-as a dimension.** Use `ww.LUMBER`, `ww.PLY`, `ww.MDF`, `ww.BALTIC`, or the
-`board()` / `panel()` constructors, which take the nominal *name* and produce
-actual geometry. `ww.inch()` accepts `3.5`, `"3/4"`, `"1 1/2"`.
+as a dimension.** `ww.LUMBER`, `ww.PLY`, `ww.MDF`, and `ww.BALTIC` still hold the
+actual geometry behind those names, but a constructor no longer takes a nominal
+*string* to get it: `board(name, length, width, ...)` takes an explicit finished
+`width` plus a `material` (thickness comes from the material unless you
+override it), and `panel(name, length, width, ..., material="pine-ply",
+thickness="3/4")` takes a sheet-quality `material` plus a thickness *label* —
+the real mm thickness is derived from it. `ww.inch()` accepts `3.5`, `"3/4"`,
+`"1 1/2"`.
 
 ### Units: metric shop, imperial lumberyard
 
@@ -95,53 +100,65 @@ never a 38x89).
 ### cutplan(), not just cutlist()
 
 `cutlist()` says what parts are needed. `cutplan()` says what to **buy** and what
-to **cut from each board** — that is the useful artefact. It plans any part that
-carries a `stock` and a `form`: `board()`/`panel()` set them for you. A plain
-`box()` has neither, so it is reported as skipped — fine for a part cut from
-scrap, but give it `box(form="board"/"sheet", stock="…")` to have it bought. For
-a custom shape (a ripped hardwood cleat, an angled edge band from `ww.prism`),
-`m.strip(name, shape, stock=…)` declares it as linear stock — cutplan buys it as
-a board whose length is the shape's longest bounding dimension.
+to **cut from each board** — that is the useful artefact. A part declares a
+**material type**, never a stock size — `board()`, `panel()`, and `strip()` set
+it for you (`material="framing"`, `material="pine-ply"`, `material="hardwood"`,
+...); `cutplan()` is what works out how to buy it. A plain `box()` has no
+material by default, so it is reported as skipped — fine for a part cut from
+scrap, and `from_scrap=True` says so explicitly (still reported, never bought).
+Give it `box(material=..., thickness=...)` to have it sourced instead.
 
-Use distinct `stock` names for distinct rip **profiles**: a linear plan packs by
-length and ignores width, so parts sharing a `stock` are assumed to come off the
-same stick. That also means thin strips ripped many-to-a-board (narrow cleats)
-are *over-counted* — each is planned as its own full-length stick. For a handful
-of strips that is a safe over-estimate; when it matters, model them from a wider
-`board()` and rip, or account the hardwood in board-feet.
+For a custom shape off `ww.prism`/`ww.wedge` — a ripped hardwood cleat, an
+angled edge band — `m.strip(name, shape, material=..., thickness=...)` declares
+it as linear stock. Pass `rip_with="OtherPart"` when the strip is really a
+co-located rip riding an adjacent profile — a key alongside a cleat on the same
+stick — and `cutplan()` folds it onto that sibling's blank instead of buying it
+separately.
 
-Rotation of sheet parts is off by default because **grain runs the length of a
-sheet**. Do not enable it to improve yield unless the material has no grain.
+`cutplan()` groups parts by `(material, thickness)` and, for each group, ranks
+every way to source it and prints the winner in full — buy line, bd-ft or sheet
+count, cost tier, and cut layout — with the rest collapsed to one-line
+"also works:" entries. `prefer="value"` (default), `"cost"`, or `"quality"`
+picks which ranking wins *within* a material type; the tool never substitutes
+one type for another, because the material is what you, the human, declared.
 
-**This user drives a Tacoma (5ft bed) and prefers half sheets.** Default to
-`m.cutplan(max_length=ww.ft(8), sheet_piece="half")` unless told otherwise — he
-always buys a full sheet and has the store cut it, and `sheet_piece` says how.
-These are *preferences*, not hard rules: a part too big for the preferred piece
-(a 1920×960 skin will not come from a 4×4 half) is **upgraded** to the smallest
-piece that fits, and the plan prints a NOTE naming it. A part that cannot meet
-the limits at all — bigger than any stocked sheet, or too big to carry within
-`max_length` — is listed under **FLAGGED** with a reason (and everything else is
-still planned) rather than crashing or, worse, printing an impossible cut.
+Grain and rotation are a property of the material itself now — sheet goods
+without grain (MDF, laminate) rotate freely to improve yield; ply and hardwood
+never do. There is no cutplan-level rotation knob to set.
+
+**Transport is not something the plan solves for anymore.** It nests parts onto
+full stock — a full board length, a full sheet — and only *annotates* what could
+be broken down before it leaves the store (a full 4x8 sheet gets a NOTE that it
+could be store-cut in half). Renting a truck, paying for delivery, or asking for
+a store cut is the shopper's call, not the planner's. The only thing still
+**flagged** is genuine impossibility — a part wider than every stocked nominal,
+longer than the longest board, or bigger than every stocked sheet — and even
+then everything else in the plan still goes ahead, rather than crashing or,
+worse, printing an impossible cut.
 
 `cutplan()` knobs worth knowing:
 
-- **catalog** — `board_lengths=[...]` and `sheet_sizes=[(grain, cross, "name"), ...]`
-  are what the yard sells; least-material selection tries each and keeps the
-  cheapest that fits. Defaults: 6/8/10/12/16 ft boards, 4x8 + 5x5 sheets.
+- **material catalog** — `wwcut.MATERIALS` is a plain, user-extensible dict:
+  add a species, a grade, a sheet size your yard actually stocks. `wwcut.TOOLING`
+  sets allowances (`edge_cleanup`, `jointer`, `planer`, `saw_rip`); `0` means you
+  don't have that tool, and options that assume it stop being offered.
 - **margins** — `end_trim` is squared off each board *end* (default 1"),
   `edge_trim` off each sheet *edge* (default ½"), before anything is packed.
   Offcuts and yield are measured against the trimmed usable stock, not nominal.
 - **oversize** — parts are cut rough and trimmed to final, to align edges and
   clean tearout, so each part is grown by `oversize` (default ⅛") before packing.
-  A **board** grows only in *length* (its width is fixed rip stock), which is
-  exactly right for a glue-up member — you trim the assembly to length at both
-  ends and never cut across the glued seams. A **sheet part** grows in *both*
-  faces, because a sheet part is itself the panel you trim to final. The plan
-  prints the *rough* cut sizes; `cutlist()` still lists final sizes. Override per
-  part with `board()/panel()/box(oversize=...)` — set `0` for a part already at
-  final size, or for a glue-up member whose trimming happens at the assembly
-  (model the assembly and give *it* the allowance). `cutplan(oversize=0)` turns
-  the default off everywhere.
+  A **board or hardwood strip** grows only in *length* (rip width is cut to
+  final), which is exactly right for a glue-up member — you trim the assembly to
+  length at both ends and never cut across the glued seams. A **sheet part**
+  grows in *both* faces, because a sheet part is itself the panel you trim to
+  final. The plan prints the *rough* cut sizes; `cutlist()` still lists final
+  sizes. Override per part with `board()/panel()/strip()/box(oversize=...)` —
+  set `0` for a part already at final size, or for a glue-up member whose
+  trimming happens at the assembly (model the assembly and give *it* the
+  allowance). `cutplan(oversize=0)` turns the default off everywhere.
+- **prefer** — `"value"` (default), `"cost"`, or `"quality"` ranks sourcing
+  options *within* a material type — it never substitutes a different type,
+  because the human declared the material.
 - **packer** — `"auto"` (default) uses `rectpack` when it is importable and its
   layout reduces to clean rips, else the built-in shelf packer; `"shelf"` forces
   the built-in. The report names which engine ran. `rectpack` (Apache-2.0) is a

--- a/plugins-copilot/freecad/.claude-plugin/plugin.json
+++ b/plugins-copilot/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/tests/freecad/_cutplan_probe.py
+++ b/tests/freecad/_cutplan_probe.py
@@ -1,8 +1,9 @@
 """Headless integration probe for Model.cutplan (the wwkit <-> wwcut wiring).
 
 Run inside FreeCAD by tests/freecad/test-cutplan-integration.sh. Asserts on the
-cut plan written to $WW_LOG: per-part oversize, stock grouping, preference
-escalation with a note, and flag aggregation for parts that can't meet limits.
+cut plan written to $WW_LOG: material grouping, per-part oversize, co-located
+rips folded onto one blank (rip_with), from_scrap reporting, sourcing options
+(recommended + "also works" alternatives), and flagging of impossible parts.
 Any assertion failure raises -> fcrun reports it and the suite fails. On success
 the last line of the log is "PROBE OK".
 """
@@ -16,26 +17,32 @@ ww.UNITS = "mm"  # predictable numbers for substring assertions
 
 m = ww.Model("cutplan_probe")
 
-# Two identical 2x4 boards, one at default oversize and one exempted, plus a
-# board too long to carry home.
-m.board("Def", "2x4", 600.0, length_axis="x")
-m.board("Exempt", "2x4", 600.0, at=(0, 200, 0), length_axis="x", oversize=0.0)
-m.board("TooLong", "2x4", 3000.0, at=(0, 400, 0), length_axis="x")
+# framing: two short strips, one at default oversize and one exempted, plus a
+# strip too wide for any framing nominal (must be flagged, not forced).
+m.board("Def", 600.0, ww.inch(3.5), length_axis="x", material="framing")
+m.board("Exempt", 600.0, ww.inch(3.5), at=(0, 200, 0), length_axis="x",
+        material="framing", oversize=0.0)
+m.board("Slab", 800.0, 400.0, at=(0, 400, 0), length_axis="x",
+        material="framing")
 
-# Sheet goods: two smalls that fit a half, a skin that must escalate to a full,
-# and a giant that fits no stocked sheet at all.
-m.panel("S1", "3/4", 500.0, 400.0)
-m.panel("S2", "3/4", 500.0, 400.0, at=(0, 600, 0))
-m.panel("Skin", "3/4", 1900.0, 950.0, at=(0, 1200, 0))
-m.panel("Giant", "3/4", ww.ft(9), ww.ft(9), at=(0, 2400, 0))
+# hardwood: a cleat and its interlocking key ride ONE blank (rip_with folds the
+# key onto the cleat's stick — it must not be bought or flagged on its own).
+cleat = ww.prism([(0, 0), (14, 0), (0, 14)], 700.0, along="x")
+key = ww.prism([(0, 14), (13, 1), (13, 26), (0, 26)], 700.0, along="x")
+m.strip("Cleat_F", cleat, material="hardwood", thickness="4/4")
+m.strip("Key_F", key, material="hardwood", thickness="4/4", rip_with="Cleat_F")
 
-# A custom-shaped part declared as linear strip stock, and a laminate as a sheet:
-# both must be *planned*, not dropped as unplannable box() shapes.
-m.strip("HW_Cleat", ww.prism([(0, 0), (14, 0), (0, 14)], 700.0, along="x"),
-        stock="Hardwood")
-m.box("Laminate", 900.0, 500.0, 1.2, at=(0, 3600, 0), form="sheet", stock="Formica")
+# sheet goods: two ply panels (nest onto a 4x8) and a laminate facing.
+m.panel("Ply1", 1200.0, 600.0, material="pine-ply", thickness="3/4")
+m.panel("Ply2", 1200.0, 600.0, at=(0, 900, 0), material="pine-ply",
+        thickness="3/4")
+m.box("Lam", 900.0, 500.0, 1.2, at=(0, 1700, 0), material="laminate",
+      thickness="1.2mm")
 
-buy = m.cutplan(max_length=ww.ft(8), sheet_piece="half", oversize=3.0)
+# a block cut from offcuts: reported, never bought.
+m.box("Cap", 60.0, 60.0, 82.0, at=(0, 2500, 0), from_scrap=True)
+
+results = m.cutplan(oversize=3.0)
 
 m.finish(os.environ.get("WW_OUT", os.getcwd()))
 
@@ -47,28 +54,33 @@ def want(cond, why):
         raise AssertionError("cutplan probe: " + why)
 
 
-# Per-part oversize wiring: default board grows by 3mm in length, exempt does not.
+# Material grouping: each type gets its own section header.
+want("framing --" in log, "framing parts are grouped and headed")
+want("hardwood 4/4 --" in log, "hardwood parts are grouped by thickness")
+want("pine-ply 3/4 --" in log, "sheet goods are grouped by quality + thickness")
+want("laminate 1.2mm --" in log, "the laminate is planned as its own sheet group")
+
+# Per-part oversize wiring: default board grows 3mm in length, exempt does not.
 want("Def (603.0" in log, "default board length should be 603.0 (600 + 3 oversize)")
 want("Exempt (600.0" in log, "exempt board length should stay 600.0")
 
-# Preference escalation: the skin cannot ride a half, so it is upgraded to a full
-# sheet and the plan says so, naming it.
-want("NOTE" in log and "Skin" in log,
-     "the escalated skin should produce a NOTE naming it")
+# Co-located rip: the key is folded onto the cleat's blank (one combined part),
+# never listed as its own buy.
+want("Cleat_F+Key_F" in log, "the key rides the cleat's blank as one folded part")
 
-# Flag aggregation: both impossible parts are called out, plan still produced.
-want("FLAGGED" in log, "there should be a FLAGGED section")
-want("TooLong" in log, "the over-long board should be flagged")
-want("Giant" in log, "the over-size panel should be flagged")
+# Sourcing options: framing shows the exact-nominal 2x4 recommended plus at least
+# one rip alternative.
+want("2x4" in log, "the recommended framing option is the 2x4")
+want("also works" in log, "at least one alternative sourcing option is offered")
 
-# Custom-shaped parts declared with a stock get planned in their own group.
-want("Hardwood  --" in log and "HW_Cleat" in log,
-     "a strip()-declared hardwood part is planned as its own linear stock group")
-want("Formica sheet  --" in log and "Laminate" in log,
-     "a box(form='sheet') laminate is planned as a sheet group")
+# from_scrap reporting: reported, never in the BUY line.
+want("FROM SCRAP" in log and "Cap" in log, "the scrap block is reported")
 
-# The rest is still bought.
-want(bool(buy), "cutplan should still return a non-empty buy list")
-want("BUY" in log, "the plan should print a BUY line")
+# Flagging: the over-wide framing strip is flagged, the rest still planned.
+want("Slab" in log and "wider" in log, "the 400mm strip has no nominal -> flagged")
+
+# The rest is bought and returned.
+want(bool(results), "cutplan returns the list of option sets")
+want("BUY" in log, "the plan prints a BUY line")
 
 ww.say("PROBE OK")

--- a/tests/freecad/test_wwcut.py
+++ b/tests/freecad/test_wwcut.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for wwcut — the cut-list optimizer.
+"""Unit tests for wwcut — the cut-list optimizer and sourcing-option generator.
 
 wwcut imports no FreeCAD/Part/Mesh, so it runs under a plain interpreter and is
 CI-testable. Plain asserts, no pytest dependency. Exits non-zero on any failure.
@@ -47,18 +47,20 @@ def approx(a, b, tol=0.5):
     return abs(a - b) <= tol
 
 
-# --- boards -----------------------------------------------------------------
+def labels(optset):
+    return [o.label for o in optset.options]
 
-print("-- boards: basic FFD --")
+
+# --- low-level linear packer -------------------------------------------------
+
+print("-- linear: basic FFD --")
 plan = wc.plan_linear([("a", 600), ("b", 600), ("c", 600), ("d", 430)],
                       end_trim=0.0)
 check(len(plan) == 1, "four short parts pack into one board")
-check(approx(plan[0].length, 8 * FT), "and it is the 8ft, not a longer stock")
+check(approx(plan[0].length, 8 * FT), "and it is the 8ft, the least material")
 check(sum(len(b.cuts) for b in plan) == 4, "every part is placed exactly once")
 
-print("-- boards: kerf is consumed --")
-# Pin the catalog to a single 8ft so the only lever is kerf (otherwise the
-# planner legitimately buys one longer board to hold both halves).
+print("-- linear: kerf is consumed --")
 half = 8 * FT / 2.0
 eightft = [8 * FT]
 p0 = wc.plan_linear([("a", half), ("b", half)], board_lengths=eightft,
@@ -68,209 +70,54 @@ p1 = wc.plan_linear([("a", half), ("b", half)], board_lengths=eightft,
 check(len(p0) == 1, "two exact-half parts fit one 8ft with no kerf")
 check(len(p1) == 2, "the same two need a second 8ft once kerf is counted")
 
-print("-- boards: end-trim shrinks usable length --")
+print("-- linear: end-trim shrinks usable length --")
 p_notrim = wc.plan_linear([("long", 2420)], end_trim=0.0)
 p_trim = wc.plan_linear([("long", 2420)], end_trim=1 * IN)
 check(approx(p_notrim[0].length, 8 * FT), "2420mm part uses an 8ft with no trim")
 check(approx(p_trim[0].length, 10 * FT),
       "the same part needs a 10ft once 1in is squared off each end")
-check(p_trim[0].offcut < p_trim[0].usable,
-      "offcut is measured against the trimmed usable length")
 
-print("-- boards: transport limit flags, does not crash --")
-lim = wc.plan_linear([("x", 2500), ("ok", 600)], max_length=8 * FT, end_trim=0.0)
-check(len(lim.flagged) == 1 and lim.flagged[0][0] == "x",
-      "the over-limit part is flagged, not forced into an impossible plan")
-check("transport limit" in lim.flagged[0][2], "and the reason names the limit")
-check(len(lim.boards) == 1, "the part that does fit is still planned")
-check(all(b.length <= 8 * FT + 1e-6 for b in lim),
-      "no board longer than the transport limit is offered")
+print("-- linear: a part too long for every stock returns None --")
+big = wc.plan_linear([("huge", 16 * FT + 100)], end_trim=0.0)
+check(big is None, "no stock length holds it -> None (caller flags it)")
 
-print("-- boards: end-trim can outrun every stock length --")
-big = wc.plan_linear([("huge", 16 * FT - 10), ("ok", 600)], end_trim=1 * IN)
-check(len(big.flagged) == 1 and big.flagged[0][0] == "huge",
-      "a part longer than the longest usable length is flagged")
-check(len(big.boards) == 1, "the rest of the run is still planned")
+print("-- linear: prefer the shorter standard stock on a material tie --")
+# 15 frame parts, 12705mm: 6x8ft and 3x16ft both buy 48ft; 8ft is the sane pick.
+frame = [("Frame_Front", 1747), ("Frame_Back", 1747),
+         ("Frame_Cross_0", 863), ("Frame_Cross_1", 863), ("Frame_Cross_2", 863),
+         ("Frame_AssyEnd", 787), ("Frame_RouterEnd", 787)]
+frame += [("Post_%d" % i, 631) for i in range(8)]
+lp = wc.plan_linear([(n, l) for n, l in frame], end_trim=1 * IN)
+check(approx(lp[0].length, 8 * FT) and len(lp) == 6,
+      "the frame packs into six 8ft, not three 16ft")
+
+print("-- linear: empty and offcut --")
+check(wc.plan_linear([]) == [], "no parts -> empty list")
+one = wc.plan_linear([("a", 600)], board_lengths=[8 * FT], end_trim=0.0, kerf=3.2)
+check(approx(one[0].offcut, 8 * FT - 600), "offcut = usable - used (no leading kerf)")
+
+print("-- linear: oversize grows the cut --")
+p2 = wc.plan_linear([("y", 600)], board_lengths=[8 * FT], end_trim=0.0,
+                    oversize=10.0)
+check(approx(p2[0].cuts[0][1], 610),
+      "the planned cut is the rough (final + oversize) length")
 
 
-# --- sheets -----------------------------------------------------------------
+# --- low-level sheet packer --------------------------------------------------
 
 print("-- sheets: basic pack + grain --")
 FOURBYEIGHT = (8 * FT, 4 * FT)
 s = wc.plan_sheets([("panel", 1000, 300)], sheet=FOURBYEIGHT, edge_trim=0.0)
 check(len(s) == 1, "one small panel fits one 4x8")
 
-print("-- sheets: rotation is off by default (grain) --")
-narrow = (1200, 1400)  # a piece narrower than the part is long
+print("-- sheets: rotation off by default (grain) --")
+narrow = (1200, 1400)
 raises(lambda: wc.plan_sheets([("p", 1300, 1100)], sheet=narrow,
                               allow_rotate=False, edge_trim=0.0),
        "a part too long for the grain axis will not fit un-rotated")
 rot = wc.plan_sheets([("p", 1300, 1100)], sheet=narrow, allow_rotate=True,
                      edge_trim=0.0)
 check(len(rot) == 1, "the same part fits once rotation is allowed")
-
-print("-- sheets: edge-trim shrinks usable face --")
-tight = (2438, 1219)  # essentially fills a 4x8
-ok = wc.plan_sheets([("p", 2438, 1219)], sheet=FOURBYEIGHT, edge_trim=0.0)
-check(len(ok) == 1, "a face-filling panel fits with no edge trim")
-raises(lambda: wc.plan_sheets([("p", 2438, 1219)], sheet=FOURBYEIGHT,
-                              edge_trim=1 * IN),
-       "the same panel no longer fits once 1in is trimmed off each edge")
-_ = tight  # documented intent
-
-print("-- sheets: multi-size catalog picks least material --")
-# A 1400x1400 part cannot fit a 4x8 (only 4ft across) but fits a 5x5.
-sp = wc.choose_sheets([("wide", 1400, 1400)], edge_trim=0.0)
-check(sp.buys[0].sheet_name == "5x5", "over-wide part is bought as a 5x5")
-# A 1200x1200 part fits both, but a 5x5 is less bought area.
-sp2 = wc.choose_sheets([("mid", 1200, 1200)], edge_trim=0.0)
-check(sp2.buys[0].sheet_name == "5x5", "when both fit, the smaller-area wins")
-
-print("-- sheets: preferred transport piece --")
-sph = wc.choose_sheets([("p", 500, 500)], prefer="half", edge_trim=0.0)
-check(sph.buys[0].piece_name == "half", "prefer='half' uses a crosscut half")
-check(sph.buys[0].full_sheets == 1 and sph.buys[0].spare_pieces == 1,
-      "one half used of a full sheet leaves one spare half")
-
-print("-- sheets: preference escalates, does not fail --")
-# A group where small parts fit a half but the big skin needs a full sheet.
-sp_esc = wc.choose_sheets(
-    [("skin", 1900, 950), ("a", 500, 400), ("b", 500, 400)],
-    prefer="half", max_length=8 * FT, edge_trim=0.0)
-piece_names = {b.piece_name for b in sp_esc.buys}
-check("full" in piece_names, "the oversized skin is upgraded to a full sheet")
-check("half" in piece_names, "the small parts still ride the preferred half")
-check(len(sp_esc.notes) == 1 and "skin" in sp_esc.notes[0],
-      "the upgrade is called out in a note naming the part")
-check(not sp_esc.flagged, "nothing is flagged — every part was planned")
-
-print("-- sheets: yield is a sane fraction --")
-spy = wc.choose_sheets([("p", 1200, 600)], sheet_sizes=[(8 * FT, 4 * FT, "4x8")],
-                       prefer="full", edge_trim=0.0)
-check(0.0 < spy.buys[0].yield_pct <= 100.0, "yield percentage is within (0, 100]")
-
-print("-- sheets: impossible parts are flagged, the rest planned --")
-sp_big = wc.choose_sheets([("giant", 9 * FT, 9 * FT), ("ok", 600, 400)],
-                          edge_trim=0.0)
-check(len(sp_big.flagged) == 1 and sp_big.flagged[0][0] == "giant",
-      "a part bigger than every catalog sheet is flagged, not crashed on")
-check("bigger than any stocked sheet" in sp_big.flagged[0][3],
-      "and the reason says to split it")
-check(len(sp_big.buys) == 1, "the part that fits is still bought and planned")
-
-print("-- sheets: forced-half skin over transport limit is flagged --")
-# max_length below a half's long axis: a part longer than every carriable piece.
-sp_lim = wc.choose_sheets([("long", 1300, 300)],
-                          sheet_sizes=[(8 * FT, 4 * FT, "4x8")],
-                          max_length=1200.0, edge_trim=0.0)
-check(len(sp_lim.flagged) == 1 and "transport limit" in sp_lim.flagged[0][3],
-      "a part too big for any carriable piece is flagged with the limit")
-
-
-# --- oversize: parts are cut rough and trimmed to final ----------------------
-
-print("-- oversize: boards --")
-p2 = wc.plan_linear([("y", 600)], board_lengths=[8 * FT], end_trim=0.0,
-                    oversize=10.0)
-check(approx(p2.boards[0].cuts[0][1], 610),
-      "the planned board cut is the rough (final + oversize) length")
-near = wc.plan_linear([("x", 2435)], board_lengths=[8 * FT], end_trim=0.0,
-                      oversize=0.0)
-rough = wc.plan_linear([("x", 2435)], board_lengths=[8 * FT], end_trim=0.0,
-                       oversize=10.0)
-check(len(near.boards) == 1 and not near.flagged,
-      "a 2435mm final part fits an 8ft")
-check(bool(rough.flagged),
-      "cut 10mm oversize the same part no longer fits and is flagged")
-
-print("-- oversize: sheets --")
-s_ok = wc.plan_sheets([("p", 2430, 1200)], sheet=(8 * FT, 4 * FT),
-                      edge_trim=0.0, oversize=0.0)
-check(len(s_ok) == 1, "a near-full panel fits at final size")
-raises(lambda: wc.plan_sheets([("p", 2430, 1200)], sheet=(8 * FT, 4 * FT),
-                              edge_trim=0.0, oversize=20.0),
-       "cut 20mm oversize the same panel overflows the sheet")
-sp_ov = wc.choose_sheets([("p", 1000, 300)],
-                         sheet_sizes=[(8 * FT, 4 * FT, "4x8")], prefer="full",
-                         edge_trim=0.0, oversize=10.0)
-rough_part = sp_ov.buys[0].pieces[0].strips[0]["parts"][0]
-check(approx(rough_part[1], 1010) and approx(rough_part[2], 310),
-      "sheet parts are packed and reported at rough (final + oversize) size")
-
-
-# --- rectpack band reconstruction (engine-agnostic, no dependency needed) ----
-
-print("-- bands: clean layout reconstructs --")
-# two parts side by side in one rip, a third in a rip above it
-good = [(0, 0.0, 0.0, 100.0, 50.0),
-        (1, 100.0, 0.0, 100.0, 50.0),
-        (2, 0.0, 50.0, 120.0, 40.0)]
-bands = wc._bands_from_placements(good, 300.0, 100.0)
-check(bands is not None and len(bands) == 2, "two clean rips reconstruct")
-check(bands is not None and len(bands[0]["items"]) == 2,
-      "the lower rip holds both side-by-side parts")
-
-print("-- bands: overlaps and overflow are rejected --")
-xoverlap = [(0, 0.0, 0.0, 100.0, 50.0), (1, 50.0, 0.0, 100.0, 50.0)]
-check(wc._bands_from_placements(xoverlap, 300.0, 100.0) is None,
-      "parts overlapping along a rip are rejected")
-xoverflow = [(0, 0.0, 0.0, 400.0, 50.0)]
-check(wc._bands_from_placements(xoverflow, 300.0, 100.0) is None,
-      "a part wider than the sheet is rejected")
-yoverlap = [(0, 0.0, 0.0, 100.0, 80.0), (1, 0.0, 50.0, 100.0, 40.0)]
-check(wc._bands_from_placements(yoverlap, 300.0, 100.0) is None,
-      "rips that overlap in depth are rejected")
-yoverflow = [(0, 0.0, 0.0, 100.0, 50.0), (1, 0.0, 60.0, 100.0, 50.0)]
-check(wc._bands_from_placements(yoverflow, 300.0, 100.0) is None,
-      "rips that run past the sheet width are rejected")
-
-
-# --- rectpack engine path: absent -> shelf fallback, no crash ----------------
-
-print("-- engine: rectpack soft-import falls back cleanly --")
-res = wc._pack_sheet_rectpack([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2, False)
-try:
-    import rectpack  # noqa: F401
-    _have_rp = True
-except Exception:
-    _have_rp = False
-check(res is None if not _have_rp else res is not None,
-      "returns None when rectpack is missing (shelf takes over)")
-sheets, engine = wc._pack_one_size([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2,
-                                   False, 0.0, "auto")
-check(len(sheets) == 1 and engine in ("shelf", "rectpack"),
-      "auto packer always produces a plan and names its engine")
-sheets2, engine2 = wc._pack_one_size([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2,
-                                     False, 0.0, "shelf")
-check(engine2 == "shelf", "explicit packer='shelf' uses the shelf engine")
-
-
-# --- boards: extended -------------------------------------------------------
-
-print("-- boards: cheapest single length across the catalog --")
-# Three 1800mm parts: a 6ft holds one each (3 boards, 5.5m), every longer stock
-# either holds one (more material) or two (fewer boards, still more material).
-three = wc.plan_linear([("a", 1800), ("b", 1800), ("c", 1800)], end_trim=0.0)
-check(approx(three[0].length, 6 * FT) and len(three) == 3,
-      "the planner buys three 6ft, the least-material single length")
-
-print("-- boards: no stock within the transport limit --")
-none_fit = wc.plan_linear([("a", 600)], max_length=5 * FT)
-check(not none_fit.boards and len(none_fit.flagged) == 1,
-      "nothing is planned when no catalog board is carriable")
-check("no stock length is within" in none_fit.flagged[0][2],
-      "and the reason says so")
-
-print("-- boards: empty input is empty, not an error --")
-empty_b = wc.plan_linear([])
-check(len(empty_b) == 0 and not empty_b.flagged, "no parts -> no boards, no flags")
-
-print("-- boards: offcut is exact --")
-one = wc.plan_linear([("a", 600)], board_lengths=[8 * FT], end_trim=0.0, kerf=3.2)
-check(approx(one[0].offcut, 8 * FT - 600), "offcut = usable - used (no leading kerf)")
-
-
-# --- sheets: strip geometry (regression for the length/kerf fix) ------------
 
 print("-- Sheet.place: first cut has no kerf, later cuts do --")
 sh = wc.Sheet(1000.0, 500.0)
@@ -287,58 +134,161 @@ check(not sh2.place("toolong", 600.0, 100.0, 3.0),
       "a part longer than the sheet is refused, not silently overhung")
 
 
-# --- sheets: extended -------------------------------------------------------
+# --- band reconstruction (engine-agnostic) -----------------------------------
 
-print("-- sheets: half-rip piece --")
-spr = wc.choose_sheets([("p", 2000, 300)], sheet_sizes=[(8 * FT, 4 * FT, "4x8")],
-                       prefer="half-rip", max_length=8 * FT, edge_trim=0.0)
-check(spr.buys[0].piece_name == "half-rip", "prefer='half-rip' rips a long strip")
-check(spr.buys[0].per_full == 2 and spr.buys[0].spare_pieces == 1,
-      "a full sheet yields two rips, one spare here")
+print("-- bands: clean layout reconstructs --")
+good = [(0, 0.0, 0.0, 100.0, 50.0), (1, 100.0, 0.0, 100.0, 50.0),
+        (2, 0.0, 50.0, 120.0, 40.0)]
+bands = wc._bands_from_placements(good, 300.0, 100.0)
+check(bands is not None and len(bands) == 2, "two clean rips reconstruct")
+check(bands is not None and len(bands[0]["items"]) == 2,
+      "the lower rip holds both side-by-side parts")
 
-print("-- sheets: allow_rotate flips a fit in choose_sheets --")
-cat = [(1400, 600, "strip")]
-no_rot = wc.choose_sheets([("p", 500, 1300)], sheet_sizes=cat,
-                          allow_rotate=False, edge_trim=0.0)
-yes_rot = wc.choose_sheets([("p", 500, 1300)], sheet_sizes=cat,
-                           allow_rotate=True, edge_trim=0.0)
-check(no_rot.flagged and not no_rot.buys, "grain-locked, the part does not fit")
-check(yes_rot.buys and not yes_rot.flagged, "rotation allowed, it fits and is bought")
+print("-- bands: overlaps and overflow are rejected --")
+check(wc._bands_from_placements(
+    [(0, 0.0, 0.0, 100.0, 50.0), (1, 50.0, 0.0, 100.0, 50.0)],
+    300.0, 100.0) is None, "parts overlapping along a rip are rejected")
+check(wc._bands_from_placements([(0, 0.0, 0.0, 400.0, 50.0)], 300.0, 100.0)
+      is None, "a part wider than the sheet is rejected")
+check(wc._bands_from_placements(
+    [(0, 0.0, 0.0, 100.0, 80.0), (1, 0.0, 50.0, 100.0, 40.0)],
+    300.0, 100.0) is None, "rips that overlap in depth are rejected")
 
-print("-- sheets: spare-piece math with an odd count of halves --")
-odd = wc.choose_sheets(
-    [("a", 1200, 1100), ("b", 1200, 1100), ("c", 1200, 1100)],
-    sheet_sizes=[(8 * FT, 4 * FT, "4x8")], prefer="half", max_length=8 * FT,
-    edge_trim=0.0)
-check(len(odd.buys) == 1 and len(odd.buys[0].pieces) == 3,
-      "three parts too big to share a half take three half pieces")
-check(odd.buys[0].full_sheets == 2 and odd.buys[0].spare_pieces == 1,
-      "three halves come from two full sheets, leaving one spare half")
-
-print("-- sheets: default catalog + no preference picks least material --")
-dfl = wc.choose_sheets([("p", 600, 400)], edge_trim=0.0)
-check(dfl.buys[0].sheet_name == "5x5",
-      "a small part is bought from the smaller-area 5x5")
-
-print("-- sheets: empty input is empty, not an error --")
-empty_s = wc.choose_sheets([])
-check(not empty_s.buys and not empty_s.flagged, "no parts -> no buys, no flags")
-
-print("-- engine: empty parts pack to nothing --")
-es, _eng = wc._pack_one_size([], (8 * FT, 4 * FT), 3.2, False, 0.0, "auto")
-check(es == [], "no parts -> no sheets")
+print("-- engine: rectpack soft-import falls back cleanly --")
+res = wc._pack_sheet_rectpack([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2, False)
+try:
+    import rectpack  # noqa: F401
+    _have_rp = True
+except Exception:
+    _have_rp = False
+check(res is None if not _have_rp else res is not None,
+      "returns None when rectpack is missing (shelf takes over)")
+sheets, engine = wc._pack_one_size([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2,
+                                   False, 0.0, "auto")
+check(len(sheets) == 1 and engine in ("shelf", "rectpack"),
+      "auto packer always produces a plan and names its engine")
 
 
-# --- board feet -------------------------------------------------------------
+# --- board feet --------------------------------------------------------------
 
 print("-- board feet --")
-bf = wc.board_feet(1.5 * IN, 3.5 * IN, 8 * FT)
-check(approx(bf, 3.5, 0.01), "a 2x4x8 is 3.5 board feet")
-bf2 = wc.board_feet(0.75 * IN, 5.5 * IN, 6 * FT)
-check(approx(bf2, 2.0625, 0.01), "a 1x6x6 is ~2.06 board feet")
+check(approx(wc.board_feet(1.5 * IN, 3.5 * IN, 8 * FT), 3.5, 0.01),
+      "a 2x4x8 is 3.5 board feet")
+check(approx(wc.board_feet(0.75 * IN, 5.5 * IN, 6 * FT), 2.0625, 0.01),
+      "a 1x6x6 is ~2.06 board feet")
 
 
-# --- summary ----------------------------------------------------------------
+# --- sourcing options: dimensional ------------------------------------------
+
+# The frame strips: 15 parts, all 3.5" (88.9mm) wide.
+FRAME = [(n, l, 88.9) for n, l in frame]
+
+print("-- dimensional: exact-nominal is the value pick, rips are alternatives --")
+os_val = wc.source_options(FRAME, "framing", prefer="value")
+rec = os_val.recommended
+check(rec is not None and rec.label == "2x4, as-is",
+      "value recommends the 2x4 bought as-is")
+check(approx(rec.board_feet, 21.0, 0.2) and rec.buy[0]["count"] == 6,
+      "which is six 2x4 at 21.0 board-feet")
+check(rec.tier == "$", "and it is the cheapest tier")
+check(not os_val.flagged, "nothing is flagged")
+
+print("-- dimensional: the 1-lane nominals (2x6/2x8 trap) are not offered --")
+labs = labels(os_val)
+check(any("2x10" in la for la in labs), "2x10 (2 clean strips) IS offered")
+check(not any("2x6" in la or "2x8" in la for la in labs),
+      "2x6 and 2x8 yield only one clean strip -> no rip option (the trap)")
+
+print("-- dimensional: lane count reproduces the hand-checked case --")
+r10 = next(o for o in os_val.options if "2x10" in o.label)
+check(any("2 clean strips/board" in t for t in r10.tradeoffs),
+      "a 2x10 yields exactly two clean 3.5in strips")
+check(r10.layout_kind == "sheets" and len(r10.layout) == 3
+      and approx(r10.board_feet, 27.8, 0.2),
+      "ripping the frame from 2x10 is three boards, 27.8 board-feet")
+
+print("-- dimensional: prefer knob reorders the recommendation --")
+check(wc.source_options(FRAME, "framing", prefer="cost").recommended.label
+      == "2x4, as-is", "prefer=cost keeps the cheap 2x4")
+check("rip from 2x10" ==
+      wc.source_options(FRAME, "framing", prefer="quality").recommended.label,
+      "prefer=quality recommends the all-square-edge 2x10 rip")
+
+print("-- dimensional: a part wider than every nominal is flagged --")
+osf = wc.source_options([("slab", 800, 400)], "framing")
+check(len(osf.flagged) == 1 and "wider" in osf.flagged[0][1],
+      "a 400mm-wide strip has no framing nominal and is flagged")
+
+
+# --- sourcing options: hardwood ---------------------------------------------
+
+HW = [("Band_Front", 1942, 102), ("Band_Back", 1942, 102),
+      ("Band_Left", 982, 102), ("Band_Right", 982, 102),
+      ("Rail_Front", 1850, 45), ("Rail_Back", 1850, 45),
+      ("Rail_Left", 890, 45), ("Rail_Right", 890, 45)]
+
+print("-- hardwood: wide vs narrow boards, phrased as >=W wide --")
+osh = wc.source_options(HW, "hardwood", thickness="4/4", prefer="value")
+labs = labels(osh)
+check("wide boards" in labs and "narrow boards" in labs,
+      "both a wide-board and a narrow-board option are produced")
+check(osh.recommended.label == "wide boards",
+      "the wide-board option (fewest boards) is recommended")
+b = osh.recommended.buy[0]
+check(b.get("min_width") is not None and b["nominal"] == "4/4",
+      "the buy line is a 4/4 board >= some width, not a fixed nominal")
+check(not osh.flagged, "nothing flagged")
+
+print("-- hardwood: the narrow option carries one board width per profile --")
+narrow = next(o for o in osh.options if o.label == "narrow boards")
+check(len(narrow.buy) == 2, "two profile widths -> two separate buy lines")
+
+print("-- hardwood: a part longer than the longest board is flagged --")
+osl = wc.source_options([("toolong", 13 * FT, 100)], "hardwood", thickness="4/4")
+check(len(osl.flagged) == 1 and "longer" in osl.flagged[0][1],
+      "a 13ft profile exceeds the 12ft max stock and is flagged")
+
+
+# --- sourcing options: sheet -------------------------------------------------
+
+SKINS = [("Skin", 1920, 960), ("Rib0", 1900, 82), ("Shelf", 1820, 860)]
+
+print("-- sheet: nests onto the quality's sheet size, annotates transport --")
+osp = wc.source_options(SKINS, "pine-ply", thickness="3/4", prefer="value")
+check(osp.recommended is not None and osp.recommended.buy[0]["nominal"] == "4x8",
+      "pine-ply nests onto 4x8")
+check(osp.recommended.sheet_count is not None and osp.recommended.board_feet
+      is None, "a sheet option counts sheets, not board-feet")
+check(any("store-cut in half" in a for a in osp.recommended.annotations),
+      "a full 4x8 is annotated as store-cuttable, not forced")
+
+print("-- sheet: grain drives rotation (mdf has none) --")
+tall = [("post", 300, 1400)]  # long in the CROSS (4ft) axis, short in grain
+check(wc.source_options(tall, "pine-ply", thickness="3/4").flagged,
+      "grain-locked pine-ply cannot fit a part longer than 4ft across")
+check(not wc.source_options(tall, "mdf", thickness="3/4").flagged,
+      "grainless MDF rotates the same part to fit")
+
+print("-- sheet: a part bigger than the quality's sheet is flagged --")
+osb = wc.source_options(SKINS, "birch-ply", thickness="3/4")
+check(any("Skin" == n for n, _ in osb.flagged),
+      "the 1920mm skin does not fit a 5x5 Baltic sheet and is flagged")
+
+
+# --- registry ----------------------------------------------------------------
+
+print("-- registry: the catalog is a plain, inspectable dict --")
+check(wc.MATERIALS["framing"]["family"] == "dimensional",
+      "framing is a dimensional material")
+check(wc.MATERIALS["hardwood"]["family"] == "solidwood",
+      "hardwood is sold as solid wood (board-foot)")
+check(wc.MATERIALS["birch-ply"]["sizes"][0][2] == "5x5",
+      "Baltic birch is a 5x5 sheet")
+check(wc.TOOLING["jointer"] == 0.0,
+      "the default tooling profile has no jointer (table saw only)")
+
+
+# --- summary -----------------------------------------------------------------
 
 print()
 print("wwcut: %d passed, %d failed" % (_PASS, _FAIL))


### PR DESCRIPTION
## What

The model now declares a part's material **TYPE** (framing / hardwood / a sheet quality), never a stock size. `cutplan()` owns *how to buy it* and presents **ranked sourcing options** so the shopper chooses at the yard.

- **6 × 2×4** as-is, *or* **3 × 2×10** ripped to two clean strips — the recommended option in full, alternatives collapsed to one line.
- Hardwood phrased for random-width stock: "buy ≥2 4/4 boards ≥6½″ wide × 10 ft".
- A co-located key rides its cleat's blank (`rip_with`), retiring the old "not-planned" wart.

## Engine (`wwcut`)

- `MATERIALS` registry (dimensional / solidwood / sheet families) + `TOOLING` config (table-saw-only default; `0` = tool not owned).
- `source_options()` → recommended pick + alternatives, ranked by `prefer` = value / cost / quality **within** a type (the tool never picks the type). Cost as board-feet + `$`/`$$`/`$$$`.
- Dimensional: exact-nominal as-is + rip-from-wider for any nominal yielding ≥2 clean strips (2×8 gives one — the trap — so it's skipped; 2×10 gives two).
- **Transport is no longer a constraint**: nest onto full stock, annotate ("could be store-cut in half"); only genuine impossibility flags. Removed `choose_sheets`/`SheetBuy`/`SheetPlan`/`SHEET_PIECES` and `plan_linear`'s transport flagging.

## Model layer (`wwkit`)

- `Part_` carries `material`/`thickness`/`rip_with`/`from_scrap`; constructors take a material type; `cutplan()` rewritten around `source_options`. Dropped `max_length`/`sheet_piece`/`board_lengths`/`sheet_sizes`/`allow_rotate`.

## Verification

- 58 unit tests + the FreeCAD cutplan integration probe, both green.
- The full router-workbench model rebuilds clean (**0 clashes**) and emits the ranked plan above.
- Skill + README docs rewritten; markdown lint clean. Plugin bumped to **1.2.0** (claude + copilot in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)