### PR TITLE
fix(freecad): plywood grain is cosmetic, not a nesting constraint (v1.2.1)

### DIFF
--- a/plugins-claude/freecad/.claude-plugin/plugin.json
+++ b/plugins-claude/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/freecad/README.md
+++ b/plugins-claude/freecad/README.md
@@ -153,9 +153,13 @@ quality per cost tier, then least material), `"cost"`, or `"quality"` — but
 never across types: you declared `framing`, so the plan will never suggest
 hardwood instead.
 
-**Grain and rotation are a property of the material now**, not a cutplan
-setting — grainless sheet goods like MDF and laminate rotate freely to improve
-yield; ply and hardwood never do.
+**Grain is a property of the material, not a cutplan setting** — and for sheet
+goods it is cosmetic, not a constraint. Plywood is cross-laminated, so its face
+grain is a veneer look, not structure, and a hidden part (a drawer box side, a
+cabinet back) has no grain worth respecting. Sheet parts therefore rotate freely
+to improve yield by default; a material sets `grain=True` only to keep a show
+veneer running one way. Solid-wood rip strips (framing, hardwood) always run
+grain-along-length and are never rotated.
 
 Packing is first-fit-decreasing, not optimal. Optimal bin packing is NP-hard and
 pointless at this scale: with a dozen parts FFD lands within a board of optimal,

--- a/plugins-claude/freecad/lib/wwcut.py
+++ b/plugins-claude/freecad/lib/wwcut.py
@@ -24,10 +24,14 @@ parts FFD lands within a board or two of optimal, and the saw is not that precis
                because that is how you cut a sheet (or rip a board): make the
                long rips first, then crosscut each strip.
 
-Three things a raw bin-packer does not know but a woodworker cares about: grain
-runs the length of a sheet (so rotation is OFF by default); every cut eats a
-kerf; and stock is not dead square, so a margin is trimmed off each end/edge
-before anything is packed into the usable region.
+Two things a raw bin-packer does not know but a woodworker cares about: every cut
+eats a kerf; and stock is not dead square, so a margin is trimmed off each
+end/edge before anything is packed into the usable region. Sheet parts rotate
+freely by default -- plywood is cross-laminated, so face grain is a cosmetic
+veneer detail, not structure, and a hidden part (a drawer box side, a cabinet
+back) has no grain worth respecting. A material can set grain=True to keep a show
+veneer running one way; solid-wood rip strips (framing, hardwood) always run
+grain-along-length and are never rotated.
 
 Transport is deliberately NOT modelled as a constraint. Whether a 12ft board or
 a full 4x8 gets home is the shopper's call (rent a truck, pay for delivery, have
@@ -118,13 +122,17 @@ MATERIALS = {
     "hardwood": solidwood(
         ["4/4", "5/4", "6/4", "8/4"], [8 * FT, 10 * FT, 12 * FT], tier="$$"),
     # sheet qualities. Baltic birch is 5x5 and premium; the rest are 4x8.
+    # Sheet-good "grain" is a COSMETIC face-veneer preference, not structure:
+    # plywood is cross-laminated (alternating plies), so its strength is the same
+    # both ways and parts rotate freely to improve yield. Default off; set a
+    # material's grain=True only to keep a show veneer running one direction.
     "mdf": sheet([(8 * FT, 4 * FT, "4x8")], grain=False,
                  thicknesses=["1/4", "1/2", "3/4"], tier="$", quality=1),
-    "pine-ply": sheet([(8 * FT, 4 * FT, "4x8")], grain=True,
+    "pine-ply": sheet([(8 * FT, 4 * FT, "4x8")], grain=False,
                       thicknesses=["1/2", "3/4"], tier="$", quality=2),
-    "birch-ply": sheet([(5 * FT, 5 * FT, "5x5")], grain=True,
+    "birch-ply": sheet([(5 * FT, 5 * FT, "5x5")], grain=False,
                        thicknesses=["1/2", "3/4"], tier="$$$", quality=4),
-    "solid-core": sheet([(8 * FT, 4 * FT, "4x8")], grain=True,
+    "solid-core": sheet([(8 * FT, 4 * FT, "4x8")], grain=False,
                         thicknesses=["1/2", "3/4"], tier="$$", quality=3),
     # plastic laminate (Formica): a facing sheet, no grain worth respecting
     "laminate": sheet([(8 * FT, 4 * FT, "4x8")], grain=False,
@@ -785,7 +793,7 @@ def _options_sheet(parts, spec, kerf, edge_trim, oversize, packer):
             buy=[{"count": len(sheets), "nominal": name}],
             layout=sheets, layout_kind="sheets", tier=spec["tier"],
             quality=spec["quality"], sheet_count=len(sheets),
-            tradeoffs=["grain respected" if spec["grain"] else "no grain"],
+            tradeoffs=(["face grain kept"] if spec["grain"] else ["rotated for yield"]),
             annotations=annotations, engine=engine))
 
     return options, flagged, []

--- a/plugins-claude/freecad/skills/modeling/SKILL.md
+++ b/plugins-claude/freecad/skills/modeling/SKILL.md
@@ -122,9 +122,13 @@ count, cost tier, and cut layout — with the rest collapsed to one-line
 picks which ranking wins *within* a material type; the tool never substitutes
 one type for another, because the material is what you, the human, declared.
 
-Grain and rotation are a property of the material itself now — sheet goods
-without grain (MDF, laminate) rotate freely to improve yield; ply and hardwood
-never do. There is no cutplan-level rotation knob to set.
+Grain is a property of the material, and for sheet goods it is cosmetic, not a
+constraint: plywood is cross-laminated, so face grain is a veneer look rather
+than structure, and a hidden part (a drawer box side, a cabinet back) has no
+grain worth respecting. Sheet parts rotate freely to improve yield by default; a
+material sets `grain=True` only to keep a show veneer running one way. Solid-wood
+rip strips (framing, hardwood) always run grain-along-length and never rotate.
+There is no cutplan-level rotation knob.
 
 **Transport is not something the plan solves for anymore.** It nests parts onto
 full stock — a full board length, a full sheet — and only *annotates* what could

--- a/plugins-copilot/freecad/.claude-plugin/plugin.json
+++ b/plugins-copilot/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/tests/freecad/test_wwcut.py
+++ b/tests/freecad/test_wwcut.py
@@ -262,12 +262,18 @@ check(osp.recommended.sheet_count is not None and osp.recommended.board_feet
 check(any("store-cut in half" in a for a in osp.recommended.annotations),
       "a full 4x8 is annotated as store-cuttable, not forced")
 
-print("-- sheet: grain drives rotation (mdf has none) --")
-tall = [("post", 300, 1400)]  # long in the CROSS (4ft) axis, short in grain
-check(wc.source_options(tall, "pine-ply", thickness="3/4").flagged,
-      "grain-locked pine-ply cannot fit a part longer than 4ft across")
+print("-- sheet: plywood rotates freely; grain is an opt-in cosmetic lock --")
+tall = [("post", 300, 1400)]  # too long for the 4ft cross axis unless rotated
+check(not wc.source_options(tall, "pine-ply", thickness="3/4").flagged,
+      "cross-laminated plywood rotates to fit -- no grain lock by default")
 check(not wc.source_options(tall, "mdf", thickness="3/4").flagged,
-      "grainless MDF rotates the same part to fit")
+      "grainless MDF rotates the same part to fit too")
+# Opting into a face-grain lock keeps the veneer one way and refuses the rotate.
+wc.MATERIALS["_veneer"] = wc.sheet([(8 * FT, 4 * FT, "4x8")], grain=True,
+                                   thicknesses=["3/4"], tier="$$", quality=3)
+check(wc.source_options(tall, "_veneer", thickness="3/4").flagged,
+      "grain=True keeps a show veneer and will not rotate the part")
+del wc.MATERIALS["_veneer"]
 
 print("-- sheet: a part bigger than the quality's sheet is flagged --")
 osb = wc.source_options(SKINS, "birch-ply", thickness="3/4")


### PR DESCRIPTION
Plywood is cross-laminated — face grain is a veneer look, not structure — and drawer box sides/backs and cabinet backs are hidden under a face anyway. The cut planner was defaulting grain **on** for plywood, forcing no-rotation and hurting yield for nothing.

- `pine-ply` / `birch-ply` / `solid-core` now default to `grain=False` (rotate freely). `grain=True` is a rare opt-in to keep a show veneer running one way. Solid-wood rip strips (framing, hardwood) still never rotate.
- Engine docstring, per-option label, tests, and skill/README grain sections corrected to match.
- 59 unit tests green.

Plugin bumped to **1.2.1** (claude + copilot in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)