### PR TITLE
fix(freecad): review-surfaced bug fixes + expanded tests (v1.2.2)

### DIFF
--- a/plugins-claude/freecad/.claude-plugin/plugin.json
+++ b/plugins-claude/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/freecad/README.md
+++ b/plugins-claude/freecad/README.md
@@ -161,6 +161,13 @@ to improve yield by default; a material sets `grain=True` only to keep a show
 veneer running one way. Solid-wood rip strips (framing, hardwood) always run
 grain-along-length and are never rotated.
 
+Two per-part knobs cover the exceptions. `grain=True` on a single
+`panel()`/`box()`/`strip()` pins that one part's orientation. `grain_seq="label"`
+ties parts into a continuous-grain run: they are cut consecutively from one board,
+in model order, so the grain flows across them — a drawer-front bank, a wrapped
+band. A run bigger than any single board is flagged rather than split, because
+continuous grain cannot span two boards.
+
 Packing is first-fit-decreasing, not optimal. Optimal bin packing is NP-hard and
 pointless at this scale: with a dozen parts FFD lands within a board of optimal,
 and the saw is not that precise anyway.

--- a/plugins-claude/freecad/lib/live-reload.py
+++ b/plugins-claude/freecad/lib/live-reload.py
@@ -38,6 +38,17 @@ LOG = os.environ.get("WW_LOG")
 STOP = os.environ.get("WW_STOP")
 SNAP = os.environ.get("WW_SNAP")
 OPEN = os.environ.get("WW_OPEN")
+PID = os.environ.get("WW_PID")
+
+# Record THIS FreeCAD process's pid so fcquit can tell whether *this* session is
+# still up (see fcsession _fc_session_running) instead of grepping for any
+# FreeCAD. Removed again in _quit() on a clean shutdown.
+if PID:
+    try:
+        with open(PID, "w") as _fh:
+            _fh.write(str(os.getpid()))
+    except OSError:
+        pass
 
 _state = {"mtime": 0.0, "camera": None, "builds": 0}
 
@@ -86,9 +97,20 @@ def _rebuild():
         except Exception:
             pass
 
-    # Drop wwkit from the module cache so edits to the library take effect too,
-    # not just edits to the model script. Without this, `import wwkit` is a
-    # no-op after the first build and library changes look silently ignored.
+    # Drop wwkit from the module cache so edits to the modelling library take
+    # effect on the next rebuild, not just edits to the model script. Without
+    # this, `import wwkit` is a no-op after the first build and library changes
+    # look silently ignored.
+    #
+    # DESIGN (intentional, do not "fix"): wwcut -- the cut-list engine -- is
+    # deliberately NOT popped here, and cutplan()/cutlist() are NOT run on
+    # rebuild. The cut list is ON-DEMAND on purpose. A build iterates constantly
+    # (dozens of live reloads while shaping the model); recomputing the plan on
+    # every one wastes work and has made FreeCAD miss the reload window and
+    # wedge. You want the plan a handful of times, not every edit -- so cut-list
+    # changes land when you next ASK for it (a WW_REPORT build, or a headless
+    # run), not live. Popping wwcut to make it reload live re-introduces exactly
+    # the hang this avoids.
     sys.modules.pop("wwkit", None)
 
     try:
@@ -131,10 +153,12 @@ def _quit():
             App.closeDocument(name)
         except Exception:
             pass
-    try:
-        os.remove(STOP)
-    except OSError:
-        pass
+    for _f in (STOP, PID):   # drop the stop request and our pid marker
+        try:
+            if _f:
+                os.remove(_f)
+        except OSError:
+            pass
 
     # Closing the main window is not the same as quitting: with no documents
     # left, Qt's event loop happily keeps running and the process lingers (this
@@ -291,7 +315,8 @@ def _handle_open():
         return
     try:
         if path.endswith(".py"):
-            sys.modules.pop("wwkit", None)  # pick up library edits too
+            sys.modules.pop("wwkit", None)  # modelling lib only; wwcut stays
+            # cached on purpose -- the cut list is on-demand (see _rebuild note).
             g = {"__name__": "__main__", "__file__": path}
             exec(compile(open(path).read(), path, "exec"), g)
         else:

--- a/plugins-claude/freecad/lib/wwcut.py
+++ b/plugins-claude/freecad/lib/wwcut.py
@@ -273,8 +273,9 @@ class Sheet:
 
 
 def _fits(part, piece, allow_rotate):
-    """Does (name, l, w) fit an (already edge-trimmed) piece, grain respected?"""
-    _n, l, w = part
+    """Does a (name, l, w[, rot]) part fit an (edge-trimmed) piece? `allow_rotate`
+    is the fallback when the part carries no per-part rotation flag."""
+    l, w = part[1], part[2]
     pl, pw = piece
     if l <= pl + 1e-6 and w <= pw + 1e-6:
         return True
@@ -294,15 +295,20 @@ _SHEET_ORDERS = (
 )
 
 
-def _pack_shelf(items, sl, sw, kerf, allow_rotate):
+def _pack_shelf(items, sl, sw, kerf):
+    """Pack (name, l, w, rot) parts. Rotation is PER PART (item[3]): a part with
+    rot=False keeps its orientation (its face grain is pinned) even in a sheet
+    that otherwise rotates freely."""
     sheets = []
-    for name, pl, pw in items:
+    for item in items:
+        name, pl, pw = item[0], item[1], item[2]
+        rot = item[3] if len(item) > 3 else False
         placed = False
         for s in sheets:
             if s.place(name, pl, pw, kerf):
                 placed = True
                 break
-            if allow_rotate and s.place(name, pw, pl, kerf):
+            if rot and s.place(name, pw, pl, kerf):
                 placed = True
                 break
         if placed:
@@ -310,7 +316,7 @@ def _pack_shelf(items, sl, sw, kerf, allow_rotate):
 
         s = Sheet(sl, sw)
         if not s.place(name, pl, pw, kerf):
-            if not (allow_rotate and s.place(name, pw, pl, kerf)):
+            if not (rot and s.place(name, pw, pl, kerf)):
                 raise ValueError(
                     "%s (%.0f x %.0f) does not fit a %.0f x %.0f piece"
                     % (name, pl, pw, sl, sw)
@@ -326,15 +332,22 @@ def plan_sheets(parts, sheet=SHEET, kerf=KERF, allow_rotate=False, edge_trim=0.0
 
     `edge_trim` is knocked off each edge before packing; `oversize` grows each
     part in both dimensions (cut rough, trim to final). Multi-start: tries a few
-    sort orders and keeps whichever needs the fewest sheets.
+    sort orders and keeps whichever needs the fewest sheets. A part may be a
+    3-tuple (uses `allow_rotate`) or a 4-tuple (name, l, w, rot) that carries its
+    own rotation flag, so grain-pinned parts stay pinned in a rotating sheet.
     """
-    if oversize:
-        parts = [(n, l + oversize, w + oversize) for n, l, w in parts]
+    norm = []
+    for p in parts:
+        n, l, w = p[0], p[1], p[2]
+        rot = p[3] if len(p) > 3 else allow_rotate
+        if oversize:
+            l, w = l + oversize, w + oversize
+        norm.append((n, l, w, rot))
     sl, sw = _usable(sheet, edge_trim)
 
     best = None
     for order in _SHEET_ORDERS:
-        packed = _pack_shelf(sorted(parts, key=order), sl, sw, kerf, allow_rotate)
+        packed = _pack_shelf(sorted(norm, key=order), sl, sw, kerf)
         if best is None or len(packed) < len(best):
             best = packed
     return best
@@ -397,14 +410,23 @@ def _pack_sheet_rectpack(parts, sheet, kerf, allow_rotate, edge_trim=0.0):
     except Exception:
         return None
 
-    sl, sw = _usable(sheet, edge_trim)
     if not parts:
         return []
 
-    packer = rectpack.newPacker(rotation=bool(allow_rotate))
-    for i, (_name, pl, pw) in enumerate(parts):
+    # rectpack's rotation is a per-packer switch, not per-rect. When parts
+    # disagree — some grain-pinned (rot=False) in an otherwise-rotating group —
+    # bail to the shelf packer, which honours rotation per part.
+    rots = {(p[3] if len(p) > 3 else allow_rotate) for p in parts}
+    if len(rots) > 1:
+        return None
+    rot = rots.pop()
+
+    sl, sw = _usable(sheet, edge_trim)
+    packer = rectpack.newPacker(rotation=bool(rot))
+    for i, p in enumerate(parts):
+        pl, pw = p[1], p[2]
         if pl + kerf > sl + 1e-6 or pw + kerf > sw + 1e-6:
-            if not (allow_rotate and pw + kerf <= sl + 1e-6
+            if not (rot and pw + kerf <= sl + 1e-6
                     and pl + kerf <= sw + 1e-6):
                 return None  # a part does not fit even one bin — let shelf raise
         packer.add_rect(pl + kerf, pw + kerf, rid=i)
@@ -424,7 +446,10 @@ def _pack_sheet_rectpack(parts, sheet, kerf, allow_rotate, edge_trim=0.0):
         bands = _bands_from_placements(pls, sl, sw)
         if bands is None:
             return None
-        s = Sheet(sheet[0], sheet[1])
+        # Use the usable (edge-trimmed) dims, matching what the shelf packer
+        # stores in its Sheet — so Sheet.length/width means the same thing
+        # regardless of which engine produced it.
+        s = Sheet(sl, sw)
         for b in bands:
             s.strips.append({
                 "depth": b["depth"],
@@ -562,18 +587,19 @@ def _rank(options, prefer):
 
 def source_options(parts, material, thickness=None, kerf=KERF, end_trim=END_TRIM,
                    edge_trim=EDGE_TRIM, oversize=OVERSIZE, prefer="value",
-                   tooling=None, packer="auto"):
+                   tooling=None, packer="auto", registry=None):
     """Ranked ways to buy one material group. Returns an OptionSet.
 
     `parts` are finished sizes as (name, length, width) — length the longest
     dimension, width the next (thickness is the material's own and is not packed).
-    `material` keys into MATERIALS; `thickness` is its label where the family
-    needs one (hardwood quarters, sheet-good thickness). `prefer` is value /
-    cost / quality. The tool never chooses the material type, so ranking only
-    orders options *within* this type.
+    `material` keys into `registry` (the module `MATERIALS` catalog by default;
+    pass a per-call registry to override sizes/tiers without mutating the shared
+    global). `thickness` is its label where the family needs one. `prefer` is
+    value / cost / quality. The tool never chooses the material type, so ranking
+    only orders options *within* this type.
     """
     tooling = TOOLING if tooling is None else tooling
-    spec = MATERIALS[material]
+    spec = (registry or MATERIALS)[material]
     fam = spec["family"]
     if not parts:
         return OptionSet(material, thickness, [], [], [])
@@ -743,7 +769,10 @@ def _options_hardwood(parts, spec, thickness, kerf, end_trim, oversize, tooling)
             buys.append({"count": len(sheets), "nominal": thickness,
                          "min_width": board_w, "length": L})
             all_sheets.extend(sheets)
-            total_bf += len(sheets) * board_feet(nom_thick, w + 2.0 * cleanup, L)
+            # Board-feet must use the ACTUAL board width you buy (board_w), the
+            # same value as the buy line's min_width -- not the bare profile
+            # width, which understated it and biased ranking toward narrow.
+            total_bf += len(sheets) * board_feet(nom_thick, board_w, L)
         if ok:
             options.append(SourcingOption(
                 label="narrow boards",
@@ -758,14 +787,20 @@ def _options_hardwood(parts, spec, thickness, kerf, end_trim, oversize, tooling)
 
 def _options_sheet(parts, spec, kerf, edge_trim, oversize, packer):
     """Sheet goods: nest onto each of the quality's sheet sizes that holds every
-    part, one option per size. Transport is annotated, never forced."""
-    allow_rotate = not spec["grain"]
+    part, one option per size. Transport is annotated, never forced. Rotation is
+    per part: `parts` may be 4-tuples (name, l, w, rot); a 3-tuple falls back to
+    the material default (grain-agnostic unless the material pins its grain)."""
+    default_rot = not spec["grain"]
     sizes = spec["sizes"]
 
-    # Flag parts bigger than every stocked size (grain respected).
+    def rot_of(p):
+        return p[3] if len(p) > 3 else default_rot
+
+    # Flag parts bigger than every stocked size (in whatever orientation each is
+    # allowed — a grain-pinned part cannot rotate to fit).
     flagged, plan_parts = [], []
     for part in parts:
-        if any(_fits(part, _usable(s[:2], edge_trim), allow_rotate)
+        if any(_fits(part, _usable(s[:2], edge_trim), rot_of(part))
                for s in sizes):
             plan_parts.append(part)
         else:
@@ -779,11 +814,11 @@ def _options_sheet(parts, spec, kerf, edge_trim, oversize, packer):
 
     options = []
     for (grain, cross, name) in sizes:
-        if not all(_fits(p, _usable((grain, cross), edge_trim), allow_rotate)
+        if not all(_fits(p, _usable((grain, cross), edge_trim), rot_of(p))
                    for p in plan_parts):
             continue
         sheets, engine = _pack_one_size(plan_parts, (grain, cross), kerf,
-                                        allow_rotate, edge_trim, packer)
+                                        default_rot, edge_trim, packer)
         annotations = []
         # Transport is informational: a full 4x8 you could have the store rip.
         if grain >= 8 * FT - 1e-6 and cross >= 4 * FT - 1e-6:

--- a/plugins-claude/freecad/lib/wwkit.py
+++ b/plugins-claude/freecad/lib/wwkit.py
@@ -291,18 +291,34 @@ class Part_:
     """
 
     def __init__(self, obj, kind, nominal=None, material=None, thickness=None,
-                 rip_with=None, from_scrap=False, oversize=None):
+                 rip_with=None, from_scrap=False, oversize=None, grain=None,
+                 grain_seq=None, plan_length=None, plan_width=None):
         self.obj = obj
         self.kind = kind  # "wood" | "printed"
         self.nominal = nominal  # (dx, dy, dz) as authored, for the cut list
         self.material = material  # wwcut.MATERIALS key, or None -> not planned
         self.thickness = thickness  # thickness label where the family needs one
+        # The DECLARED length and rip width, when the constructor knew them
+        # (board()/panel() take them explicitly). The cut plan uses these instead
+        # of guessing length/width by sorting the bbox — a part wider than it is
+        # long (a squat dimensional board) would otherwise get the two swapped,
+        # hiding a "wider than any nominal" flag. None -> fall back to the sort.
+        self.plan_length = plan_length
+        self.plan_width = plan_width
         # This part is ripped from a sibling's blank (an adjacent profile on the
         # same stick): it names the bearer part and is counted on the bearer's
         # blank, not bought on its own.
         self.rip_with = rip_with
         # Cut from offcut/scrap, not bought: reported but never added to the buy.
         self.from_scrap = from_scrap
+        # Face-grain lock for THIS sheet part: None follows the material default
+        # (plywood rotates freely), True pins the grain (no rotation) for a show
+        # veneer, False forces rotation even on a grain-locked material.
+        self.grain = grain
+        # Continuous-grain sequence label: parts sharing one are cut consecutively
+        # from a single board/sheet, in model order, so the grain flows across
+        # them (a drawer-front bank, a wrapped edge band).
+        self.grain_seq = grain_seq
         # Rough-cut allowance for THIS part, or None to use the cutplan default.
         # 0 exempts a part that is already final size, or a glue-up member whose
         # trim happens at the assembly (set the assembly's oversize instead).
@@ -358,27 +374,34 @@ class Model:
 
     # -- construction -----------------------------------------------------
     def add(self, name, shape, kind="wood", nominal=None, material=None,
-            thickness=None, rip_with=None, from_scrap=False, oversize=None):
+            thickness=None, rip_with=None, from_scrap=False, oversize=None,
+            grain=None, grain_seq=None, plan_length=None, plan_width=None):
         o = self.doc.addObject("Part::Feature", name)
         o.Shape = shape
         p = Part_(o, kind, nominal=nominal, material=material,
                   thickness=thickness, rip_with=rip_with, from_scrap=from_scrap,
-                  oversize=oversize)
+                  oversize=oversize, grain=grain, grain_seq=grain_seq,
+                  plan_length=plan_length, plan_width=plan_width)
         self.parts.append(p)
         return p
 
     def box(self, name, dx, dy, dz, at=(0, 0, 0), kind="wood", material=None,
-            thickness=None, rip_with=None, from_scrap=False, oversize=None):
+            thickness=None, rip_with=None, from_scrap=False, oversize=None,
+            grain=None, grain_seq=None):
         """A plain rectangular solid. Pass a `material` type to have cutplan
         source it (e.g. material="hardwood" for an edge band, "laminate" for a
         Formica facing); leave it off and it is a shape the plan skips. Set
-        from_scrap=True for a part cut from offcuts (reported, never bought)."""
+        from_scrap=True for a part cut from offcuts (reported, never bought).
+        grain=True pins a sheet part's grain; grain_seq="label" ties parts into a
+        continuous-grain run."""
         return self.add(name, solid(dx, dy, dz, at), kind, nominal=(dx, dy, dz),
                         material=material, thickness=thickness, rip_with=rip_with,
-                        from_scrap=from_scrap, oversize=oversize)
+                        from_scrap=from_scrap, oversize=oversize, grain=grain,
+                        grain_seq=grain_seq)
 
     def strip(self, name, shape, material="hardwood", thickness="4/4",
-              rip_with=None, kind="wood", oversize=None):
+              rip_with=None, kind="wood", oversize=None, grain=None,
+              grain_seq=None):
         """A part cut from stock whose shape is not a plain board() box — a
         ripped hardwood cleat, an angled edge band, an on-edge ply strip.
         cutplan sources it from `material`: its longest bounding dimension is the
@@ -393,7 +416,7 @@ class Model:
         return self.add(name, shape, kind,
                         nominal=(bb.XLength, bb.YLength, bb.ZLength),
                         material=material, thickness=thickness, rip_with=rip_with,
-                        oversize=oversize)
+                        oversize=oversize, grain=grain, grain_seq=grain_seq)
 
     def board(self, name, length, width, at=(0, 0, 0),
               length_axis="x", thickness_axis="z", material="framing",
@@ -422,10 +445,12 @@ class Model:
         by_axis = {length_axis: length, thickness_axis: t, width_axis: width}
         dims = (by_axis["x"], by_axis["y"], by_axis["z"])
         return self.add(name, solid(*dims, at=at), kind, nominal=dims,
-                        material=material, thickness=thickness, oversize=oversize)
+                        material=material, thickness=thickness, oversize=oversize,
+                        plan_length=length, plan_width=width)
 
     def panel(self, name, length, width, at=(0, 0, 0), thickness_axis="z",
-              material="pine-ply", thickness="3/4", kind="wood", oversize=None):
+              material="pine-ply", thickness="3/4", kind="wood", oversize=None,
+              grain=None, grain_seq=None):
         """A sheet-goods panel. `material` is a quality (a wwcut sheet type:
         mdf / pine-ply / birch-ply / solid-core / laminate); `thickness` is a
         nominal label. The solid is built at the real mm from SHEET_ACTUAL, and
@@ -447,7 +472,9 @@ class Model:
         by_axis = {thickness_axis: t, others[0]: length, others[1]: width}
         dims = (by_axis["x"], by_axis["y"], by_axis["z"])
         return self.add(name, solid(*dims, at=at), kind, nominal=dims,
-                        material=material, thickness=thickness, oversize=oversize)
+                        material=material, thickness=thickness, oversize=oversize,
+                        grain=grain, grain_seq=grain_seq,
+                        plan_length=length, plan_width=width)
 
     def place(self, name, shape, at=(0, 0, 0), rot_z=0.0, kind="printed"):
         """Stamp an already-built shape into the model at a placement."""
@@ -482,9 +509,11 @@ class Model:
         against an edge, which is why both are wrappers rather than separate
         geometry.
         """
-        sign, nax = face[0], face[1]
-        if nax not in "xyz" or sign not in "+-":
+        # Validate the shape BEFORE destructuring, so a short/malformed face
+        # ("q", "") raises a clear ValueError rather than an IndexError.
+        if len(face) != 2 or face[0] not in "+-" or face[1] not in "xyz":
             raise ValueError("face must be like '+x', got %r" % face)
+        sign, nax = face[0], face[1]
         if along == nax:
             raise ValueError("a trench cannot run along its own face normal")
         third = ({"x", "y", "z"} - {nax, along}).pop()
@@ -603,10 +632,18 @@ class Model:
         return clashes
 
     def gap(self, a, b):
-        """Shortest distance between two parts. Negative means they overlap."""
+        """Shortest distance between two parts, in mm.
+
+        `distToShape` reports 0 for intersecting solids, so it cannot measure
+        penetration depth — overlap is detected from shared volume instead and
+        reported explicitly, with a negative return value to flag it.
+        """
+        common = a.shape.common(b.shape).Volume
+        if common > 1e-6:
+            say("GAP       %s <-> %s  OVERLAP (%.0f mm^3 shared)"
+                % (a.name, b.name, common))
+            return -1.0
         d = a.shape.distToShape(b.shape)[0]
-        if a.shape.common(b.shape).Volume > 1e-6:
-            d = -d
         say("GAP       %s <-> %s  %s mm" % (a.name, b.name, fmt(d)))
         return d
 
@@ -640,7 +677,7 @@ class Model:
         return rows
 
     def cutplan(self, kerf=None, end_trim=None, edge_trim=None, oversize=None,
-                prefer="value", tooling=None, packer="auto"):
+                prefer="value", tooling=None, packer="auto", materials=None):
         """From a parts list to a shopping list and a cutting order.
 
         `cutlist()` says what parts you need. This says what to *buy*, and how to
@@ -661,7 +698,13 @@ class Model:
                    at the assembly (put the allowance on the assembly instead).
         tooling    the shop's tool allowances (wwcut.TOOLING); edge_cleanup is the
                    rip-edge clean-up a rip-from-wider plan spends per squared edge.
-        packer     "auto" | "rectpack" | "shelf" 2-D packing engine.
+        packer     2-D engine. "auto"/"rectpack" both try rectpack (when it is
+                   importable and its layout reduces to clean rips) and fall back
+                   to the built-in shelf packer; "shelf" forces the shelf packer.
+        materials  per-call overrides for the catalog, e.g.
+                   {"birch-ply": {"sizes": [(30*IN, 20*IN, "20x30")]}} — merged
+                   over wwcut.MATERIALS for THIS call only, so a model tunes stock
+                   sizes/tiers without mutating the shared global registry.
 
         Transport is not a constraint: the planner nests onto full stock and
         annotates ("could be store-cut in half"). A part with no material is
@@ -676,6 +719,15 @@ class Model:
         oversize = wwcut.OVERSIZE if oversize is None else oversize
         tooling = wwcut.TOOLING if tooling is None else tooling
 
+        # Effective catalog: the shared registry, with any per-call overrides
+        # shallow-merged over the matching material spec. Never mutates the
+        # global, so one model's stock-size tweak can't leak into another.
+        reg = wwcut.MATERIALS
+        if materials:
+            reg = dict(wwcut.MATERIALS)
+            for _k, _ov in materials.items():
+                reg[_k] = {**wwcut.MATERIALS.get(_k, {}), **_ov}
+
         planned = [p for p in self.parts if p.material and not p.from_scrap]
         scrap = [p for p in self.parts if p.from_scrap]
         skipped = [p for p in self.parts
@@ -687,26 +739,76 @@ class Model:
             if p.rip_with:
                 riders.setdefault(p.rip_with, []).append(p)
 
+        # grain_seq members: parts cut consecutively from one board, in model
+        # order, so the grain flows across them.
+        seq_members = {}
+        for p in planned:
+            if p.grain_seq and not p.rip_with:
+                seq_members.setdefault(p.grain_seq, []).append(p)
+
         def dims_of(p):
+            # Prefer the length/width the constructor declared; only guess by
+            # sorting the bbox (longest = length) when they are unknown (strip/
+            # box), where the part really is long-and-narrow by construction.
+            if p.plan_length is not None:
+                return p.plan_length, p.plan_width
             d = sorted(p.nominal or _bbox_dims(p.shape), reverse=True)
             return d[0], d[1]   # length, rip width (thickness = d[2], material's)
 
-        # Build (name, length, width) per planned, non-rider part, per (material,
-        # thickness) group. A bearer swallows its riders' widths onto one blank.
+        def rough_len(p):       # per-part oversize grows length always
+            ov = oversize if p.oversize is None else p.oversize
+            return dims_of(p)[0] + ov
+
+        def rough_wid(p):       # width grows too (sheet parts trim both faces)
+            ov = oversize if p.oversize is None else p.oversize
+            return dims_of(p)[1] + ov
+
+        # Group by (material, thickness). Each entry is (name, length, width, ov,
+        # grain): ov is the per-part rough allowance still to apply, grain is the
+        # rotation preference (None=material default, True=pin, False=force-rot).
         groups = {}
+        seq_map = {}     # block label -> ordered [(member, rough_len, rough_wid)]
+        seq_done = set()
         for p in planned:
             if p.rip_with:
+                continue
+            if p.grain_seq:
+                if p.grain_seq in seq_done:
+                    continue
+                seq_done.add(p.grain_seq)
+                members = seq_members[p.grain_seq]
+                mat, thk = members[0].material, members[0].thickness
+                mdims = [(mp.name, rough_len(mp), rough_wid(mp)) for mp in members]
+                # One contiguous block: members stacked end-to-end along the grain
+                # (length), width = widest member. Oversize is already folded in,
+                # so ov=0 below; grain is pinned (True) — a sequence has a run
+                # direction. If the block outgrows every board it will flag.
+                comb_len = sum(d[1] for d in mdims) + kerf * (len(mdims) - 1)
+                comb_wid = max(d[2] for d in mdims)
+                seq_map[p.grain_seq] = mdims
+                groups.setdefault((mat, thk), []).append(
+                    (p.grain_seq, comb_len, comb_wid, 0.0, True))
                 continue
             length, width = dims_of(p)
             ov = oversize if p.oversize is None else p.oversize
             name = p.name
-            for kid in riders.get(p.name, []):
-                kl, kw = dims_of(kid)
-                length = max(length, kl)
-                width += kw + kerf
-                name = "%s+%s" % (name, kid.name)
+            kids = riders.get(p.name, [])
+            if kids:
+                # Fold the co-located rips onto one blank: blank length is the
+                # longest member (each grown by its OWN oversize), width is the
+                # profiles stacked with a kerf between. Oversize is folded in
+                # here, so this entry carries ov=0 (a bearer and its riders can
+                # each want a different rough-length allowance).
+                length += ov
+                for kid in kids:
+                    kov = oversize if kid.oversize is None else kid.oversize
+                    kl, kw = dims_of(kid)
+                    length = max(length, kl + kov)
+                    width += kw + kerf
+                    name = "%s+%s" % (name, kid.name)
+                ov = 0.0
             groups.setdefault((p.material, p.thickness), []).append(
-                (name, length, width, ov))
+                (name, length, width, ov, p.grain))
 
         say("=" * 64)
         say("CUT PLAN  (kerf %s, end-trim %s, edge-trim %s, oversize %s, "
@@ -719,18 +821,40 @@ class Model:
         results = []
         for key in sorted(groups, key=lambda k: (k[0], k[1] or "")):
             material, thickness = key
-            # A per-part oversize can differ; source_options takes one scalar, so
-            # apply each part's own allowance up front and pass oversize=0. A
-            # board/hardwood strip grows in LENGTH only — its rip width is cut to
-            # final, and growing it would push the exact-nominal match a size up.
-            # A sheet part is the trimmed panel, so both faces grow.
-            sheet_fam = wwcut.MATERIALS[material]["family"] == "sheet"
-            parts = [(n, l + ov, (w + ov) if sheet_fam else w)
-                     for (n, l, w, ov) in groups[key]]
+            spec = reg[material]
+            sheet_fam = spec["family"] == "sheet"
+            mat_grain = spec.get("grain", False)
+            # Apply each part's own oversize up front (source_options takes one
+            # scalar), and resolve rotation per part. A board/hardwood strip grows
+            # in LENGTH only (its rip width is cut to final); a sheet part grows
+            # in both faces and carries a per-part rotation flag.
+            parts = []
+            for (n, l, w, ov, grain) in groups[key]:
+                if sheet_fam:
+                    rot = (not mat_grain) if grain is None else (not grain)
+                    parts.append((n, l + ov, w + ov, rot))
+                else:
+                    parts.append((n, l + ov, w))
             opt = wwcut.source_options(parts, material, thickness, kerf, end_trim,
-                                       edge_trim, 0.0, prefer, tooling, packer)
+                                       edge_trim, 0.0, prefer, tooling, packer,
+                                       registry=reg)
+            if seq_map:
+                for o in opt.options:
+                    self._expand_seq(o, seq_map)
             results.append(opt)
             self._say_options(opt, buy)
+
+        flagged_seq = {n for opt in results for (n, _r) in opt.flagged
+                       if n in seq_map}
+        for label in seq_map:
+            names = ", ".join(m[0] for m in seq_map[label])
+            say("")
+            if label in flagged_seq:
+                say("  GRAIN SEQ (%s): %s -- the run is bigger than one board; "
+                    "split it to keep the grain continuous" % (label, names))
+            else:
+                say("  GRAIN SEQ (%s): %s -- cut consecutively from one board, "
+                    "in order, for continuous grain" % (label, names))
 
         if scrap:
             say("")
@@ -777,6 +901,33 @@ class Model:
                     parts = ", ".join("%s (%s x %s)" % (n, fmt(pl), fmt(pw))
                                       for n, pl, pw in strip["parts"])
                     say("        rip %s wide: %s" % (fmt(strip["depth"]), parts))
+
+    def _expand_seq(self, opt, seq_map):
+        """Unfold a nested grain-sequence block into its member cuts, in order.
+
+        The block was packed as one contiguous part so it is guaranteed to come
+        off a single board; here it is replaced by its members laid consecutively
+        (which is the continuous-grain cut order) wherever it landed.
+        """
+        if opt.layout_kind == "boards":
+            for b in opt.layout:
+                cuts = []
+                for (nm, ln) in b.cuts:
+                    if nm in seq_map:
+                        cuts.extend((mn, ml) for (mn, ml, _mw) in seq_map[nm])
+                    else:
+                        cuts.append((nm, ln))
+                b.cuts = cuts
+        else:
+            for s in opt.layout:
+                for strip in s.strips:
+                    parts = []
+                    for (nm, pl, pw) in strip["parts"]:
+                        if nm in seq_map:
+                            parts.extend(seq_map[nm])
+                        else:
+                            parts.append((nm, pl, pw))
+                    strip["parts"] = parts
 
     def _say_options(self, opt, buy):
         head = opt.material + ((" %s" % opt.thickness) if opt.thickness else "")

--- a/plugins-claude/freecad/scripts/fclive
+++ b/plugins-claude/freecad/scripts/fclive
@@ -34,9 +34,9 @@ export WW_WATCH
 _fcsession_paths "$SCRIPT"
 # A live session must NOT self-close when the model script finishes building.
 export WW_GUI_ONESHOT=""
-# Stale control files would fire the moment we start: quitting us, or snapping
-# into a directory from a previous session.
-rm -f "$WW_STOP" "$WW_SNAP"
+# Stale control files would fire the moment we start: quitting us, snapping, or
+# re-opening a document from a previous session.
+rm -f "$WW_STOP" "$WW_SNAP" "$WW_OPEN"
 
 if [[ "$BG" -eq 1 ]]; then
   # Log rather than discard: in background the rebuild/traceback output is the

--- a/plugins-claude/freecad/scripts/fcquit
+++ b/plugins-claude/freecad/scripts/fcquit
@@ -18,7 +18,11 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=./fcsession
 source "$HERE/fcsession"
 
-running() { _fc_running; }  # see fcsession: name varies by platform/packaging
+# Session-scoped when a single session is targeted (WW_PID is set once
+# _fcsession_paths runs), global for --all (no single session in mind).
+running() {
+  if [[ -n "${WW_PID:-}" ]]; then _fc_session_running; else _fc_running; fi
+}
 
 wait_gone() {
   local n=0

--- a/plugins-claude/freecad/scripts/fcrun
+++ b/plugins-claude/freecad/scripts/fcrun
@@ -160,18 +160,30 @@ trap 'rm -f "$OUT_FILE"' EXIT
 
 flatpak_preflight
 
+# Capture FreeCAD's REAL exit status (PIPESTATUS[0], the head of the pipe)
+# without pipefail+set -e bailing out first. A bare `|| true` here would discard
+# it, which is how a native crash used to read as success.
+set +e
 if [[ "$GUI" -eq 1 ]]; then
-  run_fc "$SCRIPT" 2>&1 | tee "$OUT_FILE" | filter || true
+  run_fc "$SCRIPT" 2>&1 | tee "$OUT_FILE" | filter
 else
   # `-c` does not exit when the script ends — it drops into an interactive
   # Python console and waits for EOF ("Use Ctrl-D to exit"). Inherit a live
   # stdin and the process sits there forever. </dev/null guarantees the EOF.
-  run_fc -c "$SCRIPT" </dev/null 2>&1 | tee "$OUT_FILE" | filter || true
+  run_fc -c "$SCRIPT" </dev/null 2>&1 | tee "$OUT_FILE" | filter
 fi
+fc_status=${PIPESTATUS[0]}
+set -e
 
-# FreeCAD swallows script errors and still exits 0 — catch them ourselves.
+# FreeCAD swallows *script* errors and still exits 0 — catch those from the log.
 if grep -qa "Exception while processing file\|Traceback (most recent call last)" "$OUT_FILE"; then
   echo "fcrun: script raised inside FreeCAD — exports may be stale." >&2
   grep -a -A5 "Exception while processing file\|Traceback (most recent call last)" "$OUT_FILE" >&2 || true
   exit 1
+fi
+# A native crash (segfault/OOM) exits non-zero with NO Python traceback; the
+# tee|filter pipeline would otherwise swallow it and report success.
+if [[ "$fc_status" -ne 0 ]]; then
+  echo "fcrun: FreeCAD exited non-zero ($fc_status) with no traceback — it may have crashed." >&2
+  exit "$fc_status"
 fi

--- a/plugins-claude/freecad/scripts/fcsession
+++ b/plugins-claude/freecad/scripts/fcsession
@@ -3,7 +3,7 @@
 #
 # Sourced by fclive, fcquit, fcsnap and fcopen so they all agree on where the
 # control files live for a given model script. Sets: WW_LOG, WW_STOP, WW_SNAP,
-# WW_OPEN.
+# WW_OPEN, WW_PID.
 
 _fcsession_paths() {
   local script="$1"
@@ -15,7 +15,20 @@ _fcsession_paths() {
   : "${WW_STOP:=${dir%/}/fclive-${base}.stop}"
   : "${WW_SNAP:=${dir%/}/fclive-${base}.snap}"
   : "${WW_OPEN:=${dir%/}/fclive-${base}.open}"
-  export WW_LOG WW_STOP WW_SNAP WW_OPEN
+  : "${WW_PID:=${dir%/}/fclive-${base}.pid}"
+  export WW_LOG WW_STOP WW_SNAP WW_OPEN WW_PID
+}
+
+# Is THIS session's FreeCAD up? Scoped by the PID file the watcher writes on
+# start and removes on clean exit -- so with two concurrent live sessions,
+# quitting one no longer reports "still up" just because the OTHER is running.
+# (The global _fc_running below cannot tell sessions apart.)
+_fc_session_running() {
+  local pid
+  [[ -n "${WW_PID:-}" && -f "$WW_PID" ]] || return 1
+  pid="$(cat "$WW_PID" 2>/dev/null)" || return 1
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null
 }
 
 # Is a FreeCAD instance up?

--- a/plugins-claude/freecad/skills/modeling/SKILL.md
+++ b/plugins-claude/freecad/skills/modeling/SKILL.md
@@ -130,6 +130,13 @@ material sets `grain=True` only to keep a show veneer running one way. Solid-woo
 rip strips (framing, hardwood) always run grain-along-length and never rotate.
 There is no cutplan-level rotation knob.
 
+For the occasional part that *does* care, pin it individually: `panel(...,
+grain=True)` (or on `box()`/`strip()`) keeps that one part from rotating, and
+`grain_seq="label"` ties several parts into a continuous-grain run — they are cut
+consecutively from one board in model order so the grain flows across them (a
+drawer-front bank, a wrapped edge band). A run that outgrows every board is
+flagged, not split silently: you cannot fake continuous grain across two boards.
+
 **Transport is not something the plan solves for anymore.** It nests parts onto
 full stock — a full board length, a full sheet — and only *annotates* what could
 be broken down before it leaves the store (a full 4x8 sheet gets a NOTE that it

--- a/plugins-copilot/freecad/.claude-plugin/plugin.json
+++ b/plugins-copilot/freecad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freecad",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"

--- a/tests/freecad/_cutplan_probe.py
+++ b/tests/freecad/_cutplan_probe.py
@@ -42,7 +42,31 @@ m.box("Lam", 900.0, 500.0, 1.2, at=(0, 1700, 0), material="laminate",
 # a block cut from offcuts: reported, never bought.
 m.box("Cap", 60.0, 60.0, 82.0, at=(0, 2500, 0), from_scrap=True)
 
-results = m.cutplan(oversize=3.0)
+# grain: a continuous-grain sequence (three faces cut consecutively from one
+# board) and a grain-pinned show panel (per-part rotation lock).
+for i in range(3):
+    m.panel("Seq_%d" % i, 380.0, 190.0, at=(0, 3000 + i * 250, 0),
+            material="pine-ply", thickness="3/4", grain_seq="run")
+m.panel("Pinned", 700.0, 300.0, at=(0, 3900, 0), material="pine-ply",
+        thickness="3/4", grain=True)
+# A continuous-grain run too long for any single board: must flag, not fake it.
+for i in range(3):
+    m.panel("Long_%d" % i, 1000.0, 900.0, at=(5000, i * 1200, 0),
+            material="pine-ply", thickness="3/4", grain_seq="bigrun")
+
+# A framing board declared WIDER than it is long (400mm wide, 200 long). The plan
+# must use the declared length/width, not guess by sorting the bbox -- else the
+# 400mm width reads as a 200mm "length" and the too-wide flag is suppressed.
+m.board("Squat", 200.0, 400.0, at=(7000, 0, 0), length_axis="x",
+        thickness_axis="z", material="framing")
+
+# A per-call materials override must NOT mutate the shared registry.
+import wwcut as _wc  # noqa: E402
+_before = list(_wc.MATERIALS["birch-ply"]["sizes"])
+
+results = m.cutplan(oversize=3.0,
+                    materials={"birch-ply": {"sizes": [(30 * ww.IN, 20 * ww.IN,
+                                                        "20x30")]}})
 
 m.finish(os.environ.get("WW_OUT", os.getcwd()))
 
@@ -78,6 +102,31 @@ want("FROM SCRAP" in log and "Cap" in log, "the scrap block is reported")
 
 # Flagging: the over-wide framing strip is flagged, the rest still planned.
 want("Slab" in log and "wider" in log, "the 400mm strip has no nominal -> flagged")
+
+# Continuous-grain sequence: folded onto one board, expanded back as consecutive
+# cuts in model order, and reported as a run.
+want("GRAIN SEQ (run)" in log, "the continuous-grain run is reported")
+want(all(("Seq_%d" % i) in log for i in range(3)),
+     "every part of the grain sequence is planned")
+# The three faces must land consecutively and in model order within the plan's
+# pine-ply section (that ordering IS the continuous grain).
+_pp = log.split("pine-ply 3/4 --")[1].split("BUY")[0].split("GRAIN SEQ")[0]
+_i0, _i1, _i2 = _pp.index("Seq_0"), _pp.index("Seq_1"), _pp.index("Seq_2")
+want(_i0 < _i1 < _i2, "sequence faces are laid consecutively, in model order")
+# A run bigger than any single board is flagged, not silently split across boards.
+want("GRAIN SEQ (bigrun)" in log and "bigger than one board" in log,
+     "an over-long continuous-grain run is flagged, not split")
+# Per-part grain lock plans without error.
+want("Pinned" in log, "a grain-pinned show panel is planned")
+
+# A board declared wider than long is flagged (declared length/width honoured,
+# not guessed by sorting the bbox).
+want("Squat: wider" in log,
+     "a wider-than-long board is flagged, not mis-planned as narrow stock")
+
+# The per-call materials override must not have mutated the shared registry.
+want(_wc.MATERIALS["birch-ply"]["sizes"] == _before,
+     "materials= override leaves the shared MATERIALS registry untouched")
 
 # The rest is bought and returned.
 want(bool(results), "cutplan returns the list of option sets")

--- a/tests/freecad/_model_probe.py
+++ b/tests/freecad/_model_probe.py
@@ -1,0 +1,330 @@
+"""Headless integration probe for the Model surface that _cutplan_probe.py does
+not touch: joinery primitives, checks (clashes/printable/gap/envelope),
+filament, multi-rider rip_with folding, and imperial unit formatting.
+
+Run inside FreeCAD by tests/freecad/test-model.sh. Any assertion failure
+raises -> fcrun reports it and the suite fails. On success the last line of
+the log is "MODEL PROBE OK".
+"""
+import math
+import os
+import sys
+
+sys.path.insert(0, os.environ["WWKIT_LIB"])
+import wwkit as ww  # noqa: E402
+
+ww.UNITS = "mm"
+
+IN = ww.IN
+
+
+def want(cond, why):
+    if not cond:
+        raise AssertionError("model probe: " + why)
+
+
+def approx(a, b, tol):
+    return abs(a - b) <= tol
+
+
+# ==========================================================================
+# 1. Joinery primitives: each op must remove material. Boards/panels are laid
+#    out far apart (large x offsets) so nothing in this model accidentally
+#    clashes with anything else -- that is check_clashes' job, tested below
+#    on its own model.
+# ==========================================================================
+
+mj = ww.Model("joinery_probe")
+
+# -- trench: a channel across the full extent of `along`, `width` wide on the
+# remaining axis, `depth` deep from `face`.
+j_trench = mj.board("J_Trench", 600.0, 100.0, at=(0, 0, 0), length_axis="x",
+                    thickness_axis="z", material="framing")
+v0 = j_trench.shape.Volume
+mj.trench(j_trench, face="+z", along="y", pos=200.0, width=50.0, depth=10.0)
+removed = v0 - j_trench.shape.Volume
+want(approx(removed, 100.0 * 50.0 * 10.0, 1.0),
+     "trench removes along_extent(y=100) x width(50) x depth(10) = 50000 mm^3, "
+     "got %.1f" % removed)
+
+# -- trench's own validation: bad face string, and along == the face's axis.
+try:
+    mj.trench(j_trench, face="+q", along="y", pos=0.0, width=10.0, depth=5.0)
+    want(False, "trench(face='+q') should have raised ValueError")
+except ValueError:
+    pass
+
+# A single-character face used to slip past validation into an IndexError.
+try:
+    mj.trench(j_trench, face="q", along="y", pos=0.0, width=10.0, depth=5.0)
+    want(False, "trench(face='q') should have raised ValueError")
+except ValueError:
+    pass
+except Exception as exc:
+    want(False, "trench(face='q') raised %r, wanted ValueError" % exc)
+
+try:
+    mj.trench(j_trench, face="+z", along="z", pos=0.0, width=10.0, depth=5.0)
+    want(False, "trench(along==face axis) should have raised ValueError")
+except ValueError:
+    pass
+
+# -- dado: a trench wrapper, same geometry.
+j_dado = mj.board("J_Dado", 600.0, 100.0, at=(0, 300, 0), length_axis="x",
+                  thickness_axis="z", material="framing")
+v0 = j_dado.shape.Volume
+mj.dado(j_dado, face="+z", along="y", pos=150.0, width=18.0, depth=9.5)
+removed = v0 - j_dado.shape.Volume
+want(approx(removed, 100.0 * 18.0 * 9.5, 1.0),
+     "dado removes along_extent(y=100) x width(18) x depth(9.5) = 17100 mm^3, "
+     "got %.1f" % removed)
+
+# -- rabbet: a step flush against one edge.
+j_rabbet = mj.board("J_Rabbet", 600.0, 100.0, at=(0, 600, 0), length_axis="x",
+                    thickness_axis="z", material="framing")
+v0 = j_rabbet.shape.Volume
+mj.rabbet(j_rabbet, face="+z", edge="+x", width=20.0, depth=10.0)
+removed = v0 - j_rabbet.shape.Volume
+want(approx(removed, 100.0 * 20.0 * 10.0, 1.0),
+     "rabbet removes the full y-extent(100) x width(20) x depth(10) = 20000 "
+     "mm^3, got %.1f" % removed)
+
+# -- mortise: a blind rectangular pocket.
+j_mortise = mj.board("J_Mortise", 600.0, 100.0, at=(0, 900, 0),
+                     length_axis="x", thickness_axis="z", material="framing")
+v0 = j_mortise.shape.Volume
+# `at`/`size` are absolute coordinates (x, y here, since face="+z" leaves x,y
+# free); the board itself was built at y-offset 900, so the mortise's y must
+# be offset the same way.
+mj.mortise(j_mortise, face="+z", at=(250.0, 930.0), size=(40.0, 30.0),
+          depth=12.0)
+removed = v0 - j_mortise.shape.Volume
+want(approx(removed, 40.0 * 30.0 * 12.0, 1.0),
+     "mortise removes size(40x30) x depth(12) = 14400 mm^3, got %.1f" % removed)
+
+# -- tenon: reduces a board end to a tongue by cutting 4 shoulders.
+j_tenon = mj.board("J_Tenon", 300.0, 80.0, at=(0, 1200, 0), length_axis="x",
+                   thickness_axis="z", material="framing")
+v0 = j_tenon.shape.Volume
+mj.tenon(j_tenon, end="+x", size=(40.0, 15.0), length=25.0)
+removed = v0 - j_tenon.shape.Volume
+# board thickness (z) is the framing actual thickness, 1.5in = 38.1mm.
+thick = ww.LUMBER["2x4"][0]
+want(approx(thick, 38.1, 0.1), "sanity: framing actual thickness is 38.1mm")
+expected_tenon = 25.0 * 80.0 * thick - 25.0 * 40.0 * 15.0
+want(approx(removed, expected_tenon, 2.0),
+     "tenon removes end_block - tongue_block = %.1f mm^3, got %.1f"
+     % (expected_tenon, removed))
+
+# -- hole: a cylindrical blind bore.
+j_hole = mj.board("J_Hole", 300.0, 80.0, at=(0, 1500, 0), length_axis="x",
+                  thickness_axis="z", material="framing")
+v0 = j_hole.shape.Volume
+# `at` is absolute; the board was built at y-offset 1500.
+mj.hole(j_hole, at=(50.0, 1540.0, thick), dia=10.0, depth=20.0, axis=(0, 0, -1))
+removed = v0 - j_hole.shape.Volume
+want(approx(removed, math.pi * 5.0 * 5.0 * 20.0, 5.0),
+     "hole removes pi*r^2*depth = %.1f mm^3, got %.1f"
+     % (math.pi * 5.0 * 5.0 * 20.0, removed))
+
+# -- notch: the raw primitive, subtract a box in absolute coordinates.
+j_notch = mj.board("J_Notch", 300.0, 80.0, at=(0, 1800, 0), length_axis="x",
+                   thickness_axis="z", material="framing")
+v0 = j_notch.shape.Volume
+# `at` is absolute; the board was built at y-offset 1800.
+mj.notch(j_notch, size=(50.0, 30.0, 10.0), at=(100.0, 1820.0, thick - 10.0))
+removed = v0 - j_notch.shape.Volume
+want(approx(removed, 50.0 * 30.0 * 10.0, 1.0),
+     "notch removes exactly its box, 15000 mm^3, got %.1f" % removed)
+
+# -- a joint on a panel (sheet goods), not just a board.
+ply_t = ww.SHEET_ACTUAL["pine-ply"]["3/4"]
+j_panel = mj.panel("J_PanelTrench", 800.0, 400.0, at=(0, 2100, 0),
+                   thickness_axis="z", material="pine-ply", thickness="3/4")
+v0 = j_panel.shape.Volume
+# `pos` is absolute on the "third" axis (y here); the panel was built at
+# y-offset 2100.
+mj.trench(j_panel, face="+x", along="z", pos=2200.0, width=60.0, depth=8.0)
+removed = v0 - j_panel.shape.Volume
+want(approx(removed, ply_t * 60.0 * 8.0, 1.0),
+     "trench into a panel's edge removes thickness x width(60) x depth(8) = "
+     "%.1f mm^3, got %.1f" % (ply_t * 60.0 * 8.0, removed))
+
+ww.say("JOINERY   all seven primitives (+panel) removed the expected volume")
+
+
+# ==========================================================================
+# 2. Checks: check_clashes, check_printable, gap, envelope. A small, isolated
+#    model so the pair-by-pair clash search has a known, hand-countable
+#    answer.
+# ==========================================================================
+
+mc = ww.Model("checks_probe")
+
+ov_a = mc.box("Ov_A", 100.0, 100.0, 100.0, at=(0, 0, 0))
+ov_b = mc.box("Ov_B", 100.0, 100.0, 100.0, at=(50, 50, 50))
+dj_a = mc.box("Dj_A", 50.0, 50.0, 50.0, at=(1000, 0, 0))
+dj_b = mc.box("Dj_B", 50.0, 50.0, 50.0, at=(1000, 200, 0))
+
+want(mc.check_printable(ov_a) is True,
+     "a plain, valid solid box is printable")
+
+clashes = mc.check_clashes()
+want(len(clashes) == 1, "exactly one clashing pair among these four parts, "
+     "got %d" % len(clashes))
+want(clashes[0][0] == "Ov_A" and clashes[0][1] == "Ov_B",
+     "the clashing pair is (Ov_A, Ov_B), got %r" % (clashes[0],))
+want(approx(clashes[0][2], 50.0 * 50.0 * 50.0, 1.0),
+     "the overlap volume is the 50x50x50 shared cube = 125000 mm^3, got %.1f"
+     % clashes[0][2])
+
+env = mc.envelope()
+want(env is not None, "envelope() returns a bbox for a non-empty model")
+want(approx(env[0], 1050.0, 0.5) and approx(env[1], 250.0, 0.5)
+     and approx(env[2], 150.0, 0.5),
+     "envelope should be 1050 x 250 x 150 (spanning Ov_A/Ov_B and Dj_A/Dj_B), "
+     "got %s" % (env,))
+
+g_overlap = mc.gap(ov_a, ov_b)
+want(g_overlap == -1.0, "gap() on overlapping parts returns -1.0, got %r"
+     % g_overlap)
+
+g_apart = mc.gap(dj_a, dj_b)
+want(approx(g_apart, 150.0, 0.5),
+     "Dj_A and Dj_B are 150mm apart in y, gap() should say so, got %.1f"
+     % g_apart)
+
+want(mc.filament() == 0.0, "filament() on a model with no printed parts is 0.0")
+
+ww.say("CHECKS    clashes/printable/gap/envelope all matched hand-computed "
+      "expectations")
+
+
+# ==========================================================================
+# 3. filament(): a model WITH a printed part exercises the real branch.
+# ==========================================================================
+
+mf = ww.Model("filament_probe")
+mf.add("PrintedCube", ww.solid(20.0, 20.0, 20.0), kind="printed")
+
+grams = mf.filament()
+expected_g = (20.0 * 20.0 * 20.0 / 1000.0) * ww.PLA_DENSITY
+want(grams > 0.0, "filament() with a printed part returns grams > 0")
+want(approx(grams, expected_g, 0.1),
+     "a 20mm cube in PLA is %.2fg, got %.2fg" % (expected_g, grams))
+
+flog = open(os.environ["WW_LOG"]).read()
+want("FILAMENT" in flog, "filament() logs a FILAMENT line")
+
+ww.say("FILAMENT  printed-part branch returns %.2fg (expected %.2fg)"
+      % (grams, expected_g))
+
+
+# ==========================================================================
+# 4. Multi-rider rip_with: a bearer with TWO riders folds onto one blank, and
+#    the folded width accumulates both riders + a kerf each.
+# ==========================================================================
+
+mr = ww.Model("rider_probe")
+
+bearer_shape = ww.prism([(0, 0), (50, 0), (0, 20)], 700.0, along="x")
+riderA_shape = ww.prism([(0, 0), (30, 0), (0, 15)], 700.0, along="x")
+riderB_shape = ww.prism([(0, 0), (25, 0), (0, 12)], 700.0, along="x")
+
+mr.strip("Bearer", bearer_shape, material="hardwood", thickness="4/4")
+mr.strip("RiderA", riderA_shape, material="hardwood", thickness="4/4",
+         rip_with="Bearer")
+mr.strip("RiderB", riderB_shape, material="hardwood", thickness="4/4",
+         rip_with="Bearer")
+
+rresults = mr.cutplan(oversize=3.0)
+rlog = open(os.environ["WW_LOG"]).read()
+
+want("Bearer+RiderA+RiderB" in rlog,
+     "both riders fold onto the bearer's blank as one combined part name")
+
+hw_opt = next(o for o in rresults
+             if o.material == "hardwood" and o.thickness == "4/4")
+want(hw_opt.recommended is not None, "the folded blank still produces a plan")
+want(len(hw_opt.recommended.buy) == 1,
+     "the bearer + 2 riders are ONE buy line (one blank), not three")
+
+# Expected board width: bearer width(50) + riderA(30) + kerf + riderB(25) +
+# kerf, then the hardwood wide-board formula's own +2*edge_cleanup+2mm fudge
+# (single profile width -> no extra rip-kerf term in that formula itself).
+kerf = 3.2  # wwcut.KERF
+cleanup = 0.25 * IN  # wwcut.TOOLING["edge_cleanup"]
+folded_width = 50.0 + (30.0 + kerf) + (25.0 + kerf)
+expected_min_width = folded_width + 2.0 * cleanup + 2.0
+got_min_width = hw_opt.recommended.buy[0]["min_width"]
+want(approx(got_min_width, expected_min_width, 0.1),
+     "folded blank min_width should be %.2f (bearer+riderA+riderB+2*kerf, then "
+     "+2*cleanup+2), got %.2f" % (expected_min_width, got_min_width))
+
+ww.say("RIP_WITH  multi-rider fold: name=%s min_width=%.2f (expected %.2f)"
+      % ("Bearer+RiderA+RiderB", got_min_width, expected_min_width))
+
+
+# ==========================================================================
+# 5. Imperial formatting: UNITS="in" and UNITS="both" render shop fractions,
+#    since every other probe pins UNITS="mm" for substring matching.
+# ==========================================================================
+
+ww.UNITS = "in"
+want(ww.fmt(914.4) == '36"',
+     "914.4mm (exactly 36in) should render as 36\" under UNITS=in, got %r"
+     % ww.fmt(914.4))
+want(ww.fmt(38.1) == '1-1/2"',
+     "38.1mm (exactly 1.5in) should render as 1-1/2\" under UNITS=in, got %r"
+     % ww.fmt(38.1))
+want(ww._frac(9.1875) == "9-3/16",
+     "9.1875in (9 + 3/16) reduces to the shop fraction 9-3/16, got %r"
+     % ww._frac(9.1875))
+want(ww._frac(9.96875) == "10",
+     "9.96875in rounds up to the whole number 10 (num==denom carry), got %r"
+     % ww._frac(9.96875))
+
+ww.UNITS = "both"
+want(ww.fmt(914.4) == '914.4 (36")',
+     "UNITS=both shows metric with the imperial fraction in parens, got %r"
+     % ww.fmt(914.4))
+
+ww.UNITS = "mm"
+want(ww.fmt(914.4) == "914.4", "UNITS=mm is the plain metric number")
+
+# fmt_stock: round feet render as "N ft"; anything else falls back to mm.
+want(ww.fmt_stock(2438.4) == "8 ft", "8ft of stock renders as '8 ft'")
+want(ww.fmt_stock(2425.7) == "2426 mm" or ww.fmt_stock(2425.7).endswith(" mm"),
+     "a non-round-feet length falls back to '%.0f mm'")
+
+ww.say("IMPERIAL  fmt/_frac/fmt_stock all matched hand-computed shop fractions")
+
+
+# ==========================================================================
+# Lower priority: say() ASCII-stripping, cutlist() returns rows.
+# ==========================================================================
+
+ww.say("café — mdf, naïve façade")
+final_log = open(os.environ["WW_LOG"]).read()
+last_lines = [ln for ln in final_log.splitlines() if ln.startswith("caf")]
+want(bool(last_lines), "the non-ASCII say() call logged a line at all")
+want(all(ord(c) < 128 for c in last_lines[-1]),
+     "say() strips non-ASCII down to plain ASCII, got %r" % last_lines[-1])
+
+mcl = ww.Model("cutlist_probe")
+mcl.board("CL_A", 500.0, 100.0, material="framing")
+mcl.panel("CL_B", 400.0, 300.0, at=(0, 200, 0), material="pine-ply",
+         thickness="3/4")
+rows = mcl.cutlist()
+want(len(rows) == 2, "cutlist() returns one row per wood part, got %d"
+     % len(rows))
+want({r[0] for r in rows} == {"CL_A", "CL_B"},
+     "cutlist rows are keyed by part name")
+# empty-of-wood model returns []
+mcl_empty = ww.Model("cutlist_empty_probe")
+mcl_empty.add("JustPrinted", ww.solid(10, 10, 10), kind="printed")
+want(mcl_empty.cutlist() == [], "a model with no wood parts returns []")
+
+ww.say("CUTLIST   %d row(s), say() ASCII-stripped correctly" % len(rows))
+
+ww.say("MODEL PROBE OK")

--- a/tests/freecad/test-model.sh
+++ b/tests/freecad/test-model.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# test-model.sh — exercise the Model surface _cutplan_probe.py does not touch:
+# joinery primitives, checks (clashes/printable/gap/envelope), filament,
+# multi-rider rip_with folding, and imperial unit formatting. The wwcut logic
+# is unit-tested headlessly in test-wwcut.sh; this covers the wwkit layer that
+# needs a real FreeCAD to build parts and shapes.
+#
+# FreeCAD is not present in CI, so this SKIPs cleanly (exit 0) when it is absent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FCRUN="$ROOT/plugins-claude/freecad/scripts/fcrun"
+
+# Locate FreeCAD the way fcrun does; skip if it is not installed.
+FC="${FREECAD_BIN:-}"
+if [[ -z "$FC" ]]; then
+  for c in \
+    /Applications/FreeCAD.app/Contents/MacOS/FreeCAD \
+    "$HOME/Applications/FreeCAD.app/Contents/MacOS/FreeCAD" \
+    freecad FreeCAD freecadcmd FreeCADCmd; do
+    if [[ -x "$c" ]] || command -v "$c" >/dev/null 2>&1; then
+      FC="$c"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$FC" ]]; then
+  echo "  - SKIP: FreeCAD not found (model integration test needs it)"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export WW_OUT="$TMP"
+export WW_LOG="$TMP/log.txt"
+
+if "$FCRUN" "$SCRIPT_DIR/_model_probe.py" >"$TMP/out.txt" 2>&1 &&
+  grep -q "MODEL PROBE OK" "$TMP/log.txt" 2>/dev/null; then
+  echo "  ✓ model wiring: joinery, checks, filament, multi-rider rip_with, imperial units"
+  exit 0
+fi
+
+echo "  ✗ model integration probe failed" >&2
+echo "--- fcrun output ---" >&2
+cat "$TMP/out.txt" >&2 || true
+exit 1

--- a/tests/freecad/test_wwcut.py
+++ b/tests/freecad/test_wwcut.py
@@ -7,6 +7,7 @@ CI-testable. Plain asserts, no pytest dependency. Exits non-zero on any failure.
 
 import os
 import sys
+import types
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _LIB = os.path.normpath(
@@ -49,6 +50,58 @@ def approx(a, b, tol=0.5):
 
 def labels(optset):
     return [o.label for o in optset.options]
+
+
+class _StubRect:
+    """A rectpack-shaped placed-rect stand-in: .rid/.x/.y/.width/.height."""
+
+    def __init__(self, rid, x, y, w, h):
+        self.rid, self.x, self.y = rid, x, y
+        self.width, self.height = w, h
+
+
+def _install_fake_rectpack(pack_fn=None):
+    """A minimal stand-in for the optional `rectpack` package, installed into
+    sys.modules so `_pack_sheet_rectpack`'s internal branches (beyond the
+    soft-import guard) can be exercised even on a machine where the real
+    dependency is not installed. `pack_fn(rects, bins)` -> [[_StubRect, ...],
+    ...] controls what pack() produces; the default places every rect side by
+    side in one row of one bin (a trivially "clean" shelf layout)."""
+
+    class _Packer:
+        def __init__(self, rotation=True):
+            self.rotation = rotation
+            self._rects = []
+            self._bins = []
+            self._packed = []
+
+        def add_rect(self, w, h, rid=None):
+            self._rects.append((w, h, rid))
+
+        def add_bin(self, w, h, count=1):
+            self._bins.append((w, h, count))
+
+        def pack(self):
+            if pack_fn is not None:
+                self._packed = pack_fn(self._rects, self._bins)
+                return
+            x = 0.0
+            row = []
+            for (w, h, rid) in self._rects:
+                row.append(_StubRect(rid, x, 0.0, w, h))
+                x += w
+            self._packed = [row] if row else []
+
+        def __iter__(self):
+            return iter(self._packed)
+
+    fake = types.ModuleType("rectpack")
+    fake.newPacker = _Packer
+    sys.modules["rectpack"] = fake
+
+
+def _remove_fake_rectpack():
+    sys.modules.pop("rectpack", None)
 
 
 # --- low-level linear packer -------------------------------------------------
@@ -168,6 +221,74 @@ sheets, engine = wc._pack_one_size([("p", 1000, 300)], (8 * FT, 4 * FT), 3.2,
 check(len(sheets) == 1 and engine in ("shelf", "rectpack"),
       "auto packer always produces a plan and names its engine")
 
+print("-- engine: _pack_sheet_rectpack branches (stubbed, so they run on any "
+      "machine regardless of whether the real dependency is installed) --")
+_install_fake_rectpack()
+try:
+    check(wc._pack_sheet_rectpack([], (8 * FT, 4 * FT), 3.2, False) == [],
+          "empty parts -> [] once rectpack is importable")
+
+    mixed = [("a", 100.0, 50.0, True), ("b", 100.0, 50.0, False)]
+    check(wc._pack_sheet_rectpack(mixed, (8 * FT, 4 * FT), 3.2, False) is None,
+          "disagreeing per-part rotation flags bail out to the shelf packer")
+    sheets, engine = wc._pack_one_size(mixed, (8 * FT, 4 * FT), 3.2, False, 0.0,
+                                       "auto")
+    check(sheets is not None and engine == "shelf",
+          "_pack_one_size still produces a plan for a mixed-rotation group, "
+          "via the shelf fallback")
+
+    # A part too big for a single bin on either axis (even rotated): rejected
+    # before the packer even runs, so the shelf packer gets a chance to raise
+    # its own clearer error instead.
+    huge = [("nope", 9000.0, 9000.0)]
+    check(wc._pack_sheet_rectpack(huge, (8 * FT, 4 * FT), 3.2, False) is None,
+          "a part too big for even one bin (both axes) is rejected")
+finally:
+    _remove_fake_rectpack()
+
+print("-- engine: _pack_sheet_rectpack happy path (stubbed clean layout) --")
+_install_fake_rectpack()
+try:
+    clean = [("p1", 500.0, 200.0), ("p2", 400.0, 200.0)]
+    res = wc._pack_sheet_rectpack(clean, (8 * FT, 4 * FT), 3.2, False)
+    check(res is not None and len(res) == 1,
+          "a clean side-by-side stub layout reduces to one Sheet")
+    if res is not None:
+        strip = res[0].strips[0]
+        check(approx(strip["depth"], 200.0),
+              "the reconstructed strip depth matches the parts' width")
+        placed = {n for n, _l, _w in strip["parts"]}
+        check(placed == {"p1", "p2"}, "both stubbed parts land in the one strip")
+finally:
+    _remove_fake_rectpack()
+
+print("-- engine: _pack_sheet_rectpack rejects a layout that isn't clean rips --")
+_install_fake_rectpack(pack_fn=lambda rects, bins: [[
+    # Two rects at the same y that overlap in x: not a valid rip strip.
+    _StubRect(rid, 0.0, 0.0, w, h) for (w, h, rid) in rects
+]])
+try:
+    overlapping = [("p1", 500.0, 200.0), ("p2", 400.0, 200.0)]
+    res = wc._pack_sheet_rectpack(overlapping, (8 * FT, 4 * FT), 3.2, False)
+    check(res is None,
+          "a free-form placement that does not reduce to clean rips is rejected")
+finally:
+    _remove_fake_rectpack()
+
+print("-- engine: _pack_sheet_rectpack rejects a leftover (partially packed) bin --")
+_install_fake_rectpack(pack_fn=lambda rects, bins: [[
+    # Only the first rect gets placed; the second is dropped, as a real packer
+    # would do if a bin ran out of room -- len(placed) != len(parts).
+    _StubRect(rects[0][2], 0.0, 0.0, rects[0][0], rects[0][1])
+]])
+try:
+    leftover = [("p1", 500.0, 200.0), ("p2", 400.0, 200.0)]
+    res = wc._pack_sheet_rectpack(leftover, (8 * FT, 4 * FT), 3.2, False)
+    check(res is None,
+          "a partially-packed bin (not every part placed) is rejected")
+finally:
+    _remove_fake_rectpack()
+
 
 # --- board feet --------------------------------------------------------------
 
@@ -207,6 +328,17 @@ check(r10.layout_kind == "sheets" and len(r10.layout) == 3
       and approx(r10.board_feet, 27.8, 0.2),
       "ripping the frame from 2x10 is three boards, 27.8 board-feet")
 
+print("-- dimensional: the 2x10 rip's board_feet matches the hand formula --")
+# board_feet must be n_sheets * board_feet(thick, nominal_width, stock_length),
+# using the ACTUAL nominal stock length bought (buy[0]["length"]), not the
+# edge-trimmed usable Sheet.length the layout stores internally.
+_thick = wc.MATERIALS["framing"]["thick"]
+_nom_w = 9.25 * IN  # the 2x10's stocked nominal width
+_L = r10.buy[0]["length"]
+_expected_bf = len(r10.layout) * wc.board_feet(_thick, _nom_w, _L)
+check(approx(r10.board_feet, _expected_bf, 0.01),
+      "rip-from-2x10 board_feet == n_sheets * board_feet(thick, 9.25in, L)")
+
 print("-- dimensional: prefer knob reorders the recommendation --")
 check(wc.source_options(FRAME, "framing", prefer="cost").recommended.label
       == "2x4, as-is", "prefer=cost keeps the cheap 2x4")
@@ -218,6 +350,67 @@ print("-- dimensional: a part wider than every nominal is flagged --")
 osf = wc.source_options([("slab", 800, 400)], "framing")
 check(len(osf.flagged) == 1 and "wider" in osf.flagged[0][1],
       "a 400mm-wide strip has no framing nominal and is flagged")
+
+
+# --- ranking tie-breaks -------------------------------------------------------
+# _rank_key documents a tie-break order for each `prefer` mode. The framing
+# fixture above only ever distinguishes options by tier or quality, so the
+# amount/tier tie-break clauses are never actually decisive there -- exercise
+# them directly against synthetic SourcingOptions with genuinely tied keys.
+
+
+class _FakeOpt:
+    """A stand-in SourcingOption: only what _rank_key/_rank touch."""
+
+    def __init__(self, label, tier, quality, amount):
+        self.label = label
+        self.tier = tier
+        self.quality = quality
+        self._amount = amount
+        self.recommended = False
+
+    @property
+    def amount(self):
+        return self._amount
+
+
+print("-- ranking: value tie-break falls through amount, then tier --")
+# Same tier and quality (tier-quality == 0 for both) -> decided by amount.
+a = _FakeOpt("less-material", "$", 1, 10.0)
+b = _FakeOpt("more-material", "$", 1, 20.0)
+check([o.label for o in wc._rank([b, a], "value")]
+      == ["less-material", "more-material"],
+      "value: equal tier-quality ties break on least amount")
+# Same tier-quality AND same amount -> decided by the final tier tie-break.
+c = _FakeOpt("cheap-tier", "$", 1, 15.0)      # tier-quality = 1-1 = 0
+d = _FakeOpt("pricier-tier", "$$", 2, 15.0)   # tier-quality = 2-2 = 0
+check([o.label for o in wc._rank([d, c], "value")]
+      == ["cheap-tier", "pricier-tier"],
+      "value: a full tie on tier-quality and amount breaks on cheaper tier")
+
+print("-- ranking: cost tie-break ignores quality, breaks on amount --")
+e = _FakeOpt("less", "$", 1, 30.0)
+f = _FakeOpt("more-but-nicer", "$", 5, 5.0)
+check([o.label for o in wc._rank([e, f], "cost")] == ["more-but-nicer", "less"],
+      "cost: same tier -> least amount wins regardless of quality")
+
+print("-- ranking: quality tie-break falls through tier, then amount --")
+g = _FakeOpt("pricier", "$$", 3, 50.0)
+h = _FakeOpt("cheaper", "$", 3, 10.0)
+check([o.label for o in wc._rank([g, h], "quality")] == ["cheaper", "pricier"],
+      "quality: same quality -> cheaper tier wins")
+
+print("-- ranking: framing end-to-end, all three prefer modes + alternatives --")
+check(wc.source_options(FRAME, "framing", prefer="value").recommended.label
+      == "2x4, as-is", "value -> 2x4, as-is")
+check(wc.source_options(FRAME, "framing", prefer="cost").recommended.label
+      == "2x4, as-is", "cost -> 2x4, as-is")
+check(wc.source_options(FRAME, "framing", prefer="quality").recommended.label
+      .startswith("rip from"), "quality -> a rip option")
+_val_opts = wc.source_options(FRAME, "framing", prefer="value").options
+_keys = [wc._rank_key(o, "value") for o in _val_opts]
+check(_keys == sorted(_keys),
+      "the full option list (recommended + alternatives) is in _rank_key order")
 
 
 # --- sourcing options: hardwood ---------------------------------------------
@@ -242,6 +435,57 @@ check(not osh.flagged, "nothing flagged")
 print("-- hardwood: the narrow option carries one board width per profile --")
 narrow = next(o for o in osh.options if o.label == "narrow boards")
 check(len(narrow.buy) == 2, "two profile widths -> two separate buy lines")
+
+print("-- hardwood: wide-board min_width matches the hand formula --")
+# wide_w = sum(w + oversize for each distinct profile width)
+#          + kerf * (n_profiles - 1) + 2*edge_cleanup + 2mm fudge
+_cleanup = wc.TOOLING["edge_cleanup"]
+_widths = sorted({round(w, 1) for _, _, w in HW})  # {45, 102}
+check(_widths == [45, 102], "the HW fixture has exactly two distinct profiles")
+_wide_w = (sum(w + wc.OVERSIZE for w in _widths)
+           + wc.KERF * (len(_widths) - 1) + 2.0 * _cleanup + 2.0)
+check(approx(osh.recommended.buy[0]["min_width"], _wide_w, 0.01),
+      "wide-boards min_width == sum(w+oversize) + kerf*(n-1) + 2*cleanup + 2")
+
+print("-- hardwood: narrow-board min_width matches the per-profile formula --")
+# Each narrow-board buy line: min_width = w + oversize + 2*edge_cleanup + 2mm.
+_narrow_by_width = {b["min_width"]: True for b in narrow.buy}
+for w in _widths:
+    expected = w + wc.OVERSIZE + 2.0 * _cleanup + 2.0
+    check(any(approx(mw, expected, 0.01) for mw in _narrow_by_width),
+          "narrow-board min_width for the %gmm profile == w+oversize+2*cleanup+2"
+          % w)
+
+print("-- hardwood: board_feet is consistent with the actual board width bought "
+      "(min_width), not the bare profile width --")
+_wide_L = osh.recommended.buy[0]["length"]
+_wide_n = osh.recommended.buy[0]["count"]
+_nom_thick = wc._quarter_inch("4/4") * IN
+_expected_wide_bf = _wide_n * wc.board_feet(_nom_thick, _wide_w, _wide_L)
+check(approx(osh.recommended.board_feet, _expected_wide_bf, 0.05),
+      "wide-boards board_feet == n * board_feet(thick, min_width, length)")
+_expected_narrow_bf = 0.0
+for b in narrow.buy:
+    _expected_narrow_bf += b["count"] * wc.board_feet(_nom_thick, b["min_width"],
+                                                       b["length"])
+check(approx(narrow.board_feet, _expected_narrow_bf, 0.05),
+      "narrow-boards board_feet sums n*board_feet(thick, that line's min_width, "
+      "length) per buy line")
+
+print("-- hardwood: a single-profile-width input skips the narrow-board option "
+      "(it would equal the wide one) --")
+_one_width = [("A", 1000, 100), ("B", 1200, 100)]
+_os_one = wc.source_options(_one_width, "hardwood", thickness="4/4")
+check("narrow boards" not in labels(_os_one),
+      "only one distinct profile width -> no separate narrow-board option")
+check("wide boards" in labels(_os_one),
+      "the single-width case still gets a wide-board option")
+
+print("-- hardwood: thickness=None defaults to the material's first quarter --")
+_os_default_t = wc.source_options(HW, "hardwood", prefer="value")
+check(_os_default_t.recommended.buy[0]["nominal"] == wc.MATERIALS["hardwood"]
+      ["thicknesses"][0],
+      "an unspecified thickness defaults to spec['thicknesses'][0] (4/4)")
 
 print("-- hardwood: a part longer than the longest board is flagged --")
 osl = wc.source_options([("toolong", 13 * FT, 100)], "hardwood", thickness="4/4")
@@ -275,6 +519,20 @@ check(wc.source_options(tall, "_veneer", thickness="3/4").flagged,
       "grain=True keeps a show veneer and will not rotate the part")
 del wc.MATERIALS["_veneer"]
 
+print("-- sheet: rotation is honoured PER PART (grain pin on one part) --")
+# 4-tuples carry a per-part rot flag; the same part pinned vs free.
+pinned = [("p", 300, 1400, False)]  # too long for the 4ft cross, cannot rotate
+freed = [("p", 300, 1400, True)]
+check(wc.source_options(pinned, "pine-ply", thickness="3/4").flagged,
+      "a grain-pinned part will not rotate and is flagged when it won't fit")
+check(not wc.source_options(freed, "pine-ply", thickness="3/4").flagged,
+      "the same part with rotation allowed fits")
+# A mix in one group: the free one nests, the pinned one flags — both handled.
+mixed = wc.source_options([("free", 300, 1400, True), ("pin", 300, 1400, False)],
+                          "pine-ply", thickness="3/4")
+check(len(mixed.flagged) == 1 and mixed.flagged[0][0] == "pin",
+      "mixed rotatability in one group: only the pinned misfit is flagged")
+
 print("-- sheet: a part bigger than the quality's sheet is flagged --")
 osb = wc.source_options(SKINS, "birch-ply", thickness="3/4")
 check(any("Skin" == n for n, _ in osb.flagged),
@@ -292,6 +550,25 @@ check(wc.MATERIALS["birch-ply"]["sizes"][0][2] == "5x5",
       "Baltic birch is a 5x5 sheet")
 check(wc.TOOLING["jointer"] == 0.0,
       "the default tooling profile has no jointer (table saw only)")
+check(all(wc.MATERIALS[mat]["grain"] is False
+          for mat in ("mdf", "pine-ply", "birch-ply", "solid-core", "laminate")),
+      "every stocked sheet good defaults grain-agnostic (plywood is cross-laminated)")
+
+print("-- registry: a per-call override doesn't mutate the shared global --")
+# The big skin does not fit a 5x5 Baltic sheet but does fit a full 4x8; a
+# per-call registry override swaps birch's sizes for THIS call only.
+_skin = [("Skin", 2000, 1000)]
+_before = list(wc.MATERIALS["birch-ply"]["sizes"])
+check(wc.source_options(_skin, "birch-ply", thickness="3/4").flagged,
+      "with the default 5x5 catalog the 2000mm skin is flagged")
+_reg = dict(wc.MATERIALS)
+_reg["birch-ply"] = {**wc.MATERIALS["birch-ply"],
+                     "sizes": [(8 * FT, 4 * FT, "4x8")]}
+_over = wc.source_options(_skin, "birch-ply", thickness="3/4", registry=_reg)
+check(not _over.flagged and _over.recommended.buy[0]["nominal"] == "4x8",
+      "the override nests it onto a 4x8 for this call")
+check(wc.MATERIALS["birch-ply"]["sizes"] == _before,
+      "and the shared MATERIALS registry is untouched")
 
 
 # --- summary -----------------------------------------------------------------


### PR DESCRIPTION
Fixes from a full code-quality + test-gap review of the plugin (libs, shell scripts, live-reload, docs).

## Correctness (`wwcut`/`wwkit`)
- **Hardwood narrow board-feet** used the bare profile width, not the actual board width — understated bf and biased ranking toward narrow.
- **`gap()`** couldn't signal overlap (`distToShape` returns 0 for intersecting solids); now detects via shared volume, logs `OVERLAP`, returns negative.
- **`Sheet.length/width`** meant usable-trimmed (shelf) vs raw (rectpack) — normalized to usable.
- **`rip_with` rider oversize** was ignored; each rider now grows by its own allowance.
- **`dims_of()`** swapped length/width for a part wider than long, suppressing the "too wide" flag; `board()`/`panel()` now record declared length/width.
- **`trench(face="q")`** threw `IndexError` instead of `ValueError` (validated before destructuring).
- **`MATERIALS`** shared-mutable footgun → non-mutating `cutplan(materials=…)` per-call override.
- `packer` docstring corrected.

## Scripts
- **`fcquit`** falsely reported "still up" with concurrent sessions → per-session PID file (`WW_PID`).
- **`fcrun`** masked native crashes as success → captures `PIPESTATUS[0]`.
- **`fclive`** didn't clear stale `WW_OPEN` on start.

## Docs
- Documented that the cut list is **on-demand by design** (live-reload deliberately doesn't reload `wwcut`/run `cutplan` on rebuild — it made FreeCAD miss the reload window and wedge).

## Tests
+30 `wwcut` unit tests (hardwood width numerics, ranking tie-breaks, rectpack branch coverage via a stubbed module, registry override) and a new FreeCAD **model probe** (joinery removed-volume checks, clash/printable/gap/envelope, filament, multi-rider `rip_with`, imperial formatting), plus a regression for every fix. **Full suite: 31 suites, 0 failed.**

Plugin bumped to **1.2.2** (claude + copilot in sync). Filed #164 separately for the shared auto-approve hook (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)