### PR TITLE
fix(freecad): Linux/Flatpak session control, permission preflight, fcsnap view arg

### DIFF
--- a/plugins-claude/freecad/scripts/fcrun
+++ b/plugins-claude/freecad/scripts/fcrun
@@ -69,12 +69,40 @@ run_fc() {
 
 flatpak_preflight() {
   [[ "$FC" == "flatpak-run" ]] || return 0
-  if ! flatpak info --show-permissions org.freecad.FreeCAD 2>/dev/null |
-    grep -q 'filesystem=host'; then
+  # The key is `filesystems` (PLURAL) and `host` is one of several
+  # semicolon-separated values, each optionally suffixed with :ro/:rw/:create:
+  #   filesystems=/run/spnav.sock:ro;host;xdg-run/gvfs;
+  # Matching the literal string `filesystem=host` therefore never succeeded, so
+  # this warning fired on every single Linux run — including runs where access
+  # was granted — and became noise people learned to scroll past.
+  local fs
+  fs="$(flatpak info --show-permissions org.freecad.FreeCAD 2>/dev/null |
+    sed -n 's/^filesystems=//p')"
+  if ! grep -qE '(^|;)(host|home)(:[a-z]+)*(;|$)' <<<"$fs"; then
     echo "fcrun: warning — the FreeCAD Flatpak lacks filesystem=host." >&2
     echo "fcrun: it will not be able to read your model script or wwkit." >&2
     echo "fcrun: fix: flatpak override --user --filesystem=host org.freecad.FreeCAD" >&2
   fi
+}
+
+# Flatpak gives the sandbox a PRIVATE /tmp, so a path under it that the caller
+# can see is simply absent inside FreeCAD. Passing one produces a baffling
+# failure — FreeCAD falls back to treating the argument as a Python expression
+# and reports a SyntaxError pointing at <string> line 1 — so name the real
+# problem instead. Same trap catches WW_OUT, where exports would vanish into
+# the sandbox's tmpfs while the run reports success.
+flatpak_tmp_guard() {
+  [[ "$FC" == "flatpak-run" ]] || return 0
+  local what="$1" path="$2"
+  case "$path" in
+  /tmp/* | /var/tmp/*)
+    echo "fcrun: $what is under /tmp ($path)." >&2
+    echo "fcrun: the Flatpak sandbox replaces /tmp with a private tmpfs, so" >&2
+    echo "fcrun: FreeCAD cannot see it. Put it under \$HOME instead." >&2
+    return 1
+    ;;
+  esac
+  return 0
 }
 
 if [[ "${1:-}" == "--bin" ]]; then
@@ -159,6 +187,10 @@ OUT_FILE="$(mktemp "${TMPDIR:-/tmp}/fcrun.XXXXXX")"
 trap 'rm -f "$OUT_FILE"' EXIT
 
 flatpak_preflight
+flatpak_tmp_guard "the model script" "$SCRIPT" || exit 5
+if [[ -n "${WW_OUT:-}" ]]; then
+  flatpak_tmp_guard "WW_OUT" "$WW_OUT" || exit 5
+fi
 
 # Capture FreeCAD's REAL exit status (PIPESTATUS[0], the head of the pipe)
 # without pipefail+set -e bailing out first. A bare `|| true` here would discard

--- a/plugins-claude/freecad/scripts/fcsession
+++ b/plugins-claude/freecad/scripts/fcsession
@@ -5,12 +5,31 @@
 # control files live for a given model script. Sets: WW_LOG, WW_STOP, WW_SNAP,
 # WW_OPEN, WW_PID.
 
+# Where the control files live.
+#
+# These are written by the host-side scripts and read by the watcher running
+# INSIDE FreeCAD, so both ends must agree on a path both can actually see.
+# Under Flatpak they do not: the sandbox replaces /tmp with a private tmpfs, so
+# anything written to ${TMPDIR:-/tmp} is invisible to the watcher, and the PID
+# file the watcher writes never reaches the host. That takes out the entire
+# control channel silently -- fcquit reports "nothing running" while FreeCAD is
+# plainly up, fcsnap always times out with "session did not respond", and only
+# the log appears to work (the host writes that one itself).
+#
+# $HOME is reachable from inside the sandbox (Flathub's FreeCAD is granted
+# filesystem=host) and is equally valid natively, so use a stable dir there on
+# every platform rather than special-casing Flatpak.
+_fcsession_dir() {
+  local d="${WW_SESSION_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/fclive}"
+  mkdir -p "$d" 2>/dev/null || true
+  printf '%s' "$d"
+}
+
 _fcsession_paths() {
   local script="$1"
-  local base
+  local base dir
   base="$(basename "${script%.py}")"
-  # TMPDIR is set on macOS and usually unset on Linux.
-  local dir="${TMPDIR:-/tmp}"
+  dir="$(_fcsession_dir)"
   : "${WW_LOG:=${dir%/}/fclive-${base}.log}"
   : "${WW_STOP:=${dir%/}/fclive-${base}.stop}"
   : "${WW_SNAP:=${dir%/}/fclive-${base}.snap}"

--- a/plugins-claude/freecad/scripts/fcsnap
+++ b/plugins-claude/freecad/scripts/fcsnap
@@ -27,8 +27,23 @@ source "$HERE/fcsession"
 
 SCRIPT="${1:-}"
 if [[ -z "$SCRIPT" || ! -f "$SCRIPT" ]]; then
-  echo "fcsnap: usage: fcsnap <model.py> [out_dir]" >&2
+  echo "fcsnap: usage: fcsnap <model.py> [out_dir] [view]" >&2
   exit 2
+fi
+
+# Validate the view here rather than letting the watcher silently ignore an
+# unknown name: a typo would otherwise return the user's camera and look like
+# the canned view simply not working.
+VIEW="${3:-}"
+if [[ -n "$VIEW" ]]; then
+  case "${VIEW,,}" in
+  iso | axo | front | rear | top | bottom | left | right) ;;
+  *)
+    echo "fcsnap: unknown view '$VIEW'." >&2
+    echo "fcsnap: expected one of: iso axo front rear top bottom left right" >&2
+    exit 2
+    ;;
+  esac
 fi
 
 if ! _fc_running; then
@@ -43,7 +58,10 @@ OUT="$(cd "$OUT" && pwd)"
 _fcsession_paths "$SCRIPT"
 
 rm -f "$OUT/snapshot.json"
-echo "$OUT" >"$WW_SNAP"
+# The watcher reads the out-dir from line 1 and the canned view from line 2.
+# Line 2 was never written, so the documented [view] argument did nothing at all
+# and every snap came back as the user's current camera.
+printf '%s\n%s\n' "$OUT" "$VIEW" >"$WW_SNAP"
 
 # The watcher polls once a second; give it a few beats to answer.
 for _ in $(seq 1 20); do


### PR DESCRIPTION
## Summary

All three fixes share one root cause: the toolchain was developed on macOS
with a native FreeCAD, and several of its assumptions don't hold once you're
running the Flathub FreeCAD build on Linux. Verified fixed on Linux/Wayland
with the Flatpak build.

### 1. `fcsession` — control files were unreachable from inside the sandbox (the big one)

`_fcsession_paths` put every control file in `${TMPDIR:-/tmp}`, reasoning
that "TMPDIR is set on macOS and usually unset on Linux." But Flatpak gives
the sandbox a **private /tmp**, so the watcher running inside FreeCAD sees a
different, empty /tmp than the host:

```
host:    /tmp/fclive-station.log            exists
sandbox: ls: cannot access '/tmp/fclive-station.log': No such file or directory
```

This silently took out the entire control channel, and the symptoms all
looked like unrelated bugs:

- `fcquit` wrote a stop file nobody could read → "FreeCAD still up after 30s
  — it may be showing a modal dialog." There was never a modal.
- `fcsnap` wrote a request nobody could read → always timed out with
  "session did not respond".
- The watcher wrote its PID file into the sandbox's tmpfs, so the host never
  saw it → `fcquit` reported "nothing running" while FreeCAD was plainly up.
- Only the log appeared to work, because the host writes that one itself.

**Fix:** control files now live in
`${WW_SESSION_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/fclive}`. `$HOME` is
reachable from inside the sandbox (Flathub's FreeCAD is granted
`filesystem=host`) and is equally valid natively, so this isn't a
Flatpak-only special case.

### 2. `fcrun` — permission preflight never matched, plus a /tmp guard

The preflight grepped for the literal `filesystem=host`, but the key is
`filesystems` (plural) with `host` as one of several `;`-separated values,
each optionally suffixed `:ro`/`:rw`/`:create`:

```
filesystems=/run/spnav.sock:ro;host;xdg-run/gvfs;
```

So the warning fired on *every* Linux run, including ones where access
**was** granted — noise people learn to scroll past. Now parses the list
properly.

Added `flatpak_tmp_guard`: passing a script under `/tmp` made FreeCAD fall
back to treating the path as a Python expression, producing
`SyntaxError: invalid decimal literal` pointing at `<string>` line 1 —
completely baffling. Now caught with a message naming the real problem. The
same guard covers `WW_OUT`, where exports would otherwise vanish into the
sandbox's tmpfs while the run reported success.

### 3. `fcsnap` — the documented `[view]` argument did nothing

The watcher reads the out-dir from line 1 of the request file and the
canned view from **line 2**. `fcsnap` only ever wrote the out-dir, so `$3`
was documented in the usage line and the header comment and then never
read. Every `fcsnap model.py out iso` silently returned the user's current
camera, which read as the canned-view feature being broken. Now writes both
lines, and validates the view name up front so a typo errors instead of
silently falling through to the user's camera.

## Test plan

- [x] `./test.sh` — full suite passes (1922 passed, 0 failed)
- [x] Manually verified on Linux/Wayland with the Flathub FreeCAD Flatpak:
      session control files reachable from both host and sandbox, permission
      preflight no longer false-positives on a granted `filesystems=...;host;...`
      list, `/tmp` script/`WW_OUT` paths now caught with a clear error instead
      of a baffling `SyntaxError`, and `fcsnap model.py out iso` now honors the
      canned view.
