### PR TITLE
feat(meal-planning): KB-backed recipe, plan, cart, and dinner-lookup skills (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -157,6 +157,15 @@
       "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
       "name": "freecad",
       "source": "./plugins-claude/freecad"
+    },
+    {
+      "author": {
+        "name": "Logan Gagne"
+      },
+      "category": "productivity",
+      "description": "Recipe authoring, meal planning, and grocery cart building against a knowledge-base-backed household profile — dietary restrictions, pantry inventory, and store product vocabulary are read from a KB MCP server rather than embedded in the skills",
+      "name": "meal-planning",
+      "source": "./plugins-claude/meal-planning"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -163,7 +163,7 @@
         "name": "Logan Gagne"
       },
       "category": "productivity",
-      "description": "Recipe authoring, meal planning, and grocery cart building against a knowledge-base-backed household profile — dietary restrictions, pantry inventory, and store product vocabulary are read from a KB MCP server rather than embedded in the skills",
+      "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
       "name": "meal-planning",
       "source": "./plugins-claude/meal-planning"
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ agent-toolkit/                              # marketplace repo
 │   ├── java-toolkit/                        # MCP + skills: Maven Central + class index + jar-explore (Docker Compose)
 │   ├── kb-capture/                          # skills: research-to-document automation
 │   ├── markdown/                            # skill: lint, format, setup
+│   ├── meal-planning/                       # skills: recipe authoring + meal plan + grocery cart (Claude Desktop/Cowork)
 │   ├── notify-on-stop/                      # hook: desktop notification on completion
 │   ├── permission-manager/                  # hook + skills: Bash safety classifier
 │   ├── session/                             # skills: work session management
@@ -278,6 +279,48 @@ A handful of surfaces are intentionally CLI-specific:
 | `statusline` plugin | Claude only | Configures the Claude Code status line — no Copilot equivalent |
 | `git-worktree` extension | Copilot only | Copilot lacks Claude's built-in worktree management; this repo stores its canonical user-level source under `copilot-extensions/git-worktree/` |
 | `sf-code-review` plugin | Copilot only | Depends on Copilot CLI cross-family multi-model review orchestration |
+| `meal-planning` plugin | Claude only | Targets the Claude Desktop **Cowork** surface (see below); no Copilot use case |
+
+### Claude Desktop / Cowork as a consumer surface
+
+Cowork (the agentic tab in Claude Desktop) consumes **the same plugin format as
+Claude Code** — `.claude-plugin/marketplace.json` plus `plugin.json`, with
+`skills/`, `hooks/`, `agents/`, `commands/`, and `mcp.json`. This repo's
+marketplace works there unchanged; no third plugin tree is needed.
+
+Install by adding this repo as a personal marketplace in the app:
+
+> Cowork tab → **Customize** → **Plugins** → *Personal plugins* → **+** →
+> **Add from a repository** → `https://github.com/St0nefish/agent-toolkit`
+
+Surface differences that matter when authoring for Cowork:
+
+- Cowork loads plugins from the **claude.ai account**, not `~/.claude`. Adding a
+  marketplace in Claude Code does not make it available in Desktop, and vice
+  versa — they are separate installs of the same repo.
+- Skills and MCP connectors work in both the Chat and Cowork tabs. **Hooks and
+  sub-agents run only in Cowork** and appear greyed out in Chat.
+- Cowork syncs account-scoped marketplaces **server-side** (the backend clones the
+  repo), unlike Claude Code which clones locally into
+  `~/.claude/plugins/marketplaces/`. A public repo URL always works; private repos
+  require a connected GitHub account with the Claude GitHub App installed — a
+  personal access token in the URL is rejected on this path even though the Claude
+  Code CLI accepts one. Non-GitHub hosts (GitLab, Bitbucket) are supported as
+  generic public git and are account-scoped only.
+- Org-level marketplaces (Team/Enterprise, admin-managed) require a *private* repo
+  and add install-preference controls (`installed by default` / `available` /
+  `required` / `not available`).
+- The Cowork marketplace path is feature-gated server-side, so availability can
+  vary by account even on a supported plan. If *Add from a repository* is absent,
+  that gate — not the repo — is the reason.
+- Desktop reads `skills`, `mcpServers`, `hooks`, and `agents` from an installed
+  plugin, plus a Desktop-only `clis` field for CLI wrapper declarations. There is
+  no separate `commands` field: a legacy `commands/*.md` tree is folded into
+  `skills`, which is another reason the Claude side of this repo is skills-only.
+- Custom skills do **not** sync across surfaces: a zip uploaded to claude.ai, a
+  skill created through the `/v1/skills` API, and a filesystem skill in Claude
+  Code are three separate stores. A git-hosted marketplace is the only mechanism
+  with one source of truth spanning Chat and Cowork.
 
 ```text
 plugins-copilot/<name>/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ agent-toolkit/                              # marketplace repo
 │   ├── java-toolkit/                        # MCP + skills: Maven Central + class index + jar-explore (Docker Compose)
 │   ├── kb-capture/                          # skills: research-to-document automation
 │   ├── markdown/                            # skill: lint, format, setup
-│   ├── meal-planning/                       # skills: recipe authoring + meal plan + grocery cart (Claude Desktop/Cowork)
+│   ├── meal-planning/                       # skills: recipe authoring + plan + cart + dinner lookup (KB-backed)
 │   ├── notify-on-stop/                      # hook: desktop notification on completion
 │   ├── permission-manager/                  # hook + skills: Bash safety classifier
 │   ├── session/                             # skills: work session management
@@ -279,7 +279,7 @@ A handful of surfaces are intentionally CLI-specific:
 | `statusline` plugin | Claude only | Configures the Claude Code status line — no Copilot equivalent |
 | `git-worktree` extension | Copilot only | Copilot lacks Claude's built-in worktree management; this repo stores its canonical user-level source under `copilot-extensions/git-worktree/` |
 | `sf-code-review` plugin | Copilot only | Depends on Copilot CLI cross-family multi-model review orchestration |
-| `meal-planning` plugin | Claude only | Targets the Claude Desktop **Cowork** surface (see below); no Copilot use case |
+| `meal-planning` plugin | Claude only | Non-dev domain plugin; only development plugins are mirrored to Copilot |
 
 ### Claude Desktop / Cowork as a consumer surface
 

--- a/plugins-claude/meal-planning/.claude-plugin/plugin.json
+++ b/plugins-claude/meal-planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meal-planning",
-  "version": "1.0.0",
-  "description": "Recipe authoring, meal planning, and grocery cart building against a knowledge-base-backed household profile. Reads dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
+  "version": "0.1.0",
+  "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
   "author": {
     "name": "Logan Gagne"
   }

--- a/plugins-claude/meal-planning/.claude-plugin/plugin.json
+++ b/plugins-claude/meal-planning/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "meal-planning",
+  "version": "1.0.0",
+  "description": "Recipe authoring, meal planning, and grocery cart building against a knowledge-base-backed household profile. Reads dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
+  "author": {
+    "name": "Logan Gagne"
+  }
+}

--- a/plugins-claude/meal-planning/README.md
+++ b/plugins-claude/meal-planning/README.md
@@ -1,0 +1,91 @@
+# meal-planning
+
+Recipe authoring, cycle planning, and grocery cart building — three skills that
+share one schema contract stored in a knowledge base.
+
+| Skill | Does |
+|---|---|
+| `add-recipe` | Authors a recipe into the KB, or retrofits an existing one to the schema. Resolves dietary restrictions and substitutions **once**, here. |
+| `meal-plan` | Converges conversationally on a set of batches for a cycle, sequenced by perishability. Emits a plan as an artifact. |
+| `grocery-cart` | Reads the active plan, resolves canonical names to store products, drives a logged-in browser session to fill a cart. Never places the order. |
+| `whats-for-dinner` | Answers single-meal questions from the active plan. Reads only — plans nothing, writes nothing. |
+
+Workflow: `meal-plan` → `add-recipe` (only if the plan wants something new) →
+`grocery-cart`.
+
+`whats-for-dinner` sits outside that chain. It's the cheap lookup — "what should I
+make tonight" — kept separate so a one-meal question can't trigger a full planning
+session, which is what a single over-broad description would have caused.
+
+## The personalization seam
+
+**These skills carry no personal data.** No dietary facts, no retailer or vendor
+names, no product names, no pantry contents, no recipes, no target numbers. This
+repository is public; all of that lives in a knowledge base reached over an MCP
+server. Method lives in the skill, facts live in the KB.
+
+Instacart is the one named service, and it is a hard dependency — `grocery-cart`
+exists to automate it. Naming the platform is scope, not disclosure; the
+**retailer** behind it is a household fact and lives only in the KB.
+
+`allowed-tools` is deliberately left unset on all three skills, unlike most skills
+in this repo. These depend on MCP tools whose names vary with how the user has
+registered their KB server, and an `allowed-tools` list that omitted them would
+block the dependency the whole design rests on.
+
+The skills locate **one** document by search — the meal-planning contracts doc —
+and reach everything else through the *Profile documents* index inside it:
+
+| Role | Carries |
+|---|---|
+| Contracts | Schema, line formats, derived formulas, plan-doc structure. Authoritative over the skills. |
+| Restrictions | Hard exclusions and substitutions, applied at authoring time only |
+| Staples | What's stocked, home-sourced, and never stocked |
+| Product mapping | Canonical vocabulary → store products; the cart join key |
+
+Consequences worth knowing before editing:
+
+- **The contracts document wins.** Where a skill and the contracts disagree, the
+  contracts are right and the skill needs updating.
+- **Restrictions are resolved upstream, once.** Only `add-recipe` applies
+  substitutions. If `meal-plan` or `grocery-cart` is reasoning about whether an
+  ingredient is allowed, something upstream failed.
+- **Moving the KB corpus** — a dedicated instance, a re-partitioned domain, extra
+  stores — means editing the index table in the contracts doc. The skills don't
+  change.
+
+## Install
+
+**Claude Code:**
+
+```bash
+claude plugin marketplace add St0nefish/agent-toolkit
+claude plugin install meal-planning@agent-toolkit
+```
+
+**Claude Desktop (Cowork):** Cowork tab → *Customize* → *Plugins* → *Personal
+plugins* → **+** → *Add from a repository* → the repo URL. Cowork clones from the
+default branch server-side, so changes must be merged to `master` before they
+appear, and the marketplace may need a refresh.
+
+Both stores are needed and they do not sync — Claude Code reads the repo locally,
+Cowork loads from the claude.ai account.
+
+`grocery-cart` needs browser control, so it runs from Desktop or Claude Code, not
+from mobile.
+
+> **Unverified:** whether plugin-provided skills reach the claude.ai mobile app.
+> Plugins install to the account rather than to a device, so they may — but this
+> hasn't been confirmed. If they don't, a zip upload of the individual skill is the
+> known route to mobile, at the cost of maintaining a second copy.
+
+## Operational notes
+
+- **KB duplicate detection refuses creates** when a dish is discussed anywhere in
+  the corpus — a cuisine guide mentioning it is enough. Expected, not an error:
+  confirm no recipe document exists, then retry forcing a new document.
+- **`get_document` has timed out in Desktop** where it worked in Claude Code,
+  likely payload size through the HTTP wrapper. A client restart cleared it.
+- `grocery-cart` keeps its browser-automation findings in
+  `skills/grocery-cart/references/instacart-automation.md` — read it before
+  driving the store, and update it when the site changes.

--- a/plugins-claude/meal-planning/skills/add-recipe/SKILL.md
+++ b/plugins-claude/meal-planning/skills/add-recipe/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: add-recipe
+description: "Author a new recipe into the cooking knowledge base, or retrofit an existing one to the meal-planning schema. Use when the user wants to add, import, or write up a recipe; when a meal-planning conversation lands on a dish the KB doesn't have; or when asked to retrofit, backfill, or fix a recipe's frontmatter or shopping list. Applies the household dietary profile and substitutions at authoring time, writes planning metadata, and produces a canonical shopping list that joins to the store product mapping."
+---
+
+# add-recipe
+
+Authors recipes into the knowledge base so `meal-plan` can schedule them and
+`grocery-cart` can source them. This is the keystone skill: the dietary profile
+and its substitutions are resolved **here, once, at authoring time**, so nothing
+downstream has to know about them.
+
+## Where personalization lives
+
+This skill contains **no** dietary facts, no store name, and no pantry contents —
+by design. All of that lives in the knowledge base, reachable over the KB MCP
+server. The skill carries method; the KB carries facts. Never inline a
+restriction, a brand, or a product name into this file.
+
+## Preflight — resolve the profile documents
+
+Do not work from memory, and do not proceed on a partial read.
+
+1. **Resolve the contracts document** by searching the KB for meal planning schema
+   contracts, recipe planning frontmatter, or shopping line format.
+2. **Read it.** Its *Profile documents* table indexes the other three roles —
+   restrictions, staples, and product mapping — and names the active store.
+3. **Read all three in full** before writing anything.
+
+The contracts document is the only thing this skill locates by search, and it is
+authoritative over this file wherever the two disagree. Everything else is
+reached through its index, so the KB can move or re-partition its kitchen corpus
+without touching this skill.
+
+Failure modes, in order of likelihood:
+
+- **Several plausible contracts documents** — ask which is authoritative. Guessing
+  wrong corrupts every recipe written afterward.
+- **No *Profile documents* index in the contracts doc** — fall back to searching
+  for each role directly (dietary restrictions and substitutions; pantry staples
+  and do-not-stock; canonical grocery vocabulary mapped to store products), and
+  report that the index is missing so it can be added.
+- **A role can't be resolved** — stop. Say which role is unresolved and what it
+  was needed for, and offer to create it. Never substitute your own defaults for a
+  missing restrictions or staples document: a recipe authored against assumed
+  restrictions is worse than no recipe, because it looks finished.
+
+Resolve once per session and reuse the paths. Don't re-search per recipe.
+
+## Workflow
+
+### 1. Get the recipe
+
+Source can be the user's own notes, a URL, a photo, or research. If researching,
+prefer one good source over a synthesis of several — recipes assembled from
+fragments carry contradictory ratios.
+
+### 2. Conform it to the profile — silently
+
+This is the step that makes everything downstream simple. Apply the restrictions
+document and the do-not-stock section of the staples document, then rewrite the
+recipe so it is **already correct**.
+
+How to apply them:
+
+- Restrictions are constraints, not preferences. Never frame an excluded
+  ingredient as "optional", never list it as a garnish, never mention it as
+  something the user could add back.
+- Substitute at the level of **flavour role**, not ingredient identity — the
+  substitution tables in the restrictions doc exist for this. Match what the
+  original ingredient was doing in the dish.
+- Prefer subtraction when no substitute does the job. A dish is better without a
+  component than with a bad stand-in for it.
+- Do **not** annotate swaps in the finished document unless the swap changes
+  technique or timing. The recipe should read as though it were always written
+  this way.
+- If the restrictions can't be satisfied without changing what the dish *is*,
+  say so plainly and stop. Offer the nearest dish that does work. Shipping a
+  hollowed-out recipe wastes a cook session to discover it.
+
+### 3. Write the planning frontmatter
+
+The contracts document owns the field list, the value vocabularies, and the
+derived formulas — including how usable nights are capped, how carrier slack is
+computed, and what makes a recipe non-scalable. Follow it; do not restate it
+here and do not recompute it from memory.
+
+What the contracts can't tell you, and you have to get right:
+
+- **Ask for durable facts, not derived ones.** Ask how many pieces make a meal;
+  the nights follow from that and from pack size. Asking "how many nights?" pushes
+  arithmetic onto the user and produces a number that stops being true when the
+  store changes pack size.
+- **Untested recipes:** if the user hasn't cooked it, mark it untested and leave
+  the rating absent. Don't ask for yield-in-nights on something unproven — it's
+  unknowable and asking wastes their time.
+- **Estimate openly.** Where a value is a guess (prep and cook minutes usually
+  are, until cooked once), use your best estimate and list it in the closing
+  report as estimated. Silent guesses become facts nobody audits.
+
+### 4. Step zero for timed carriers
+
+If the recipe has a timed carrier, the method **must open with starting the
+carrier** — a numbered step zero, before prep. Not a serving note, not a tip at
+the bottom.
+
+This is not a style preference. Improvised cooking with no defined start is a
+known, repeating failure mode; the written anchor is the fix.
+
+### 5. Generate the shopping list
+
+The line format and the sourcing classes are defined in the contracts document.
+Two rules govern the work:
+
+**Purchase units only.** The cooking-unit ingredient list and the purchase-unit
+shopping list are separate representations of the same recipe, and they stay
+separate. Never merge them, and never make a downstream skill convert
+tablespoons into bottles.
+
+**Every canonical name must join to the product mapping.** For any that doesn't:
+
+1. Check the store for the product to confirm it exists and capture its exact
+   product string. Use the browser or whatever store connector is available.
+2. If it genuinely isn't carried, classify it as home-sourced with a note. That's
+   a real finding worth surfacing, not a gap to paper over — it tells the user a
+   planned meal has an unsourceable ingredient before they plan around it.
+3. Collect every new canonical and report it at the end so the mapping document
+   can be updated. The mapping is the join key for the whole system; letting it
+   drift silently breaks cart building later.
+
+### 6. Write to the KB
+
+Path convention: the recipes directory under the kitchen area of the KB, one
+document per recipe, slug-named.
+
+- Frontmatter needs the KB's own required fields. `type` is a closed vocabulary —
+  use the closest allowed value and carry the enumerable marker as a **tag**
+  instead. Check the KB's schema rather than assuming a `recipe` type exists.
+- Tags carry protein, cuisine, method, and equipment so `meal-plan` can filter at
+  search time instead of loading every document. Tag equipment only when it's
+  actually used, and don't use the domain name as a tag.
+- **Duplicate detection will refuse the create** when the dish is discussed
+  anywhere else in the KB — a cuisine guide mentioning the dish is enough. This is
+  expected, not an error. Confirm no actual recipe document exists, then retry
+  forcing a new document.
+
+## Shopping-list-only entries
+
+Some dishes are cooked constantly and deliberately undocumented. For these, mark
+the recipe as needing no method, write the planning block and shopping list, and
+skip the method entirely. If the carrier is timed, the step-zero instruction
+still goes in — that's often the only reason the entry exists at all.
+
+## Retrofit mode
+
+Same skill, applied to a recipe already in the KB. Skip step 2 — those recipes
+already went through the user. Otherwise identical: add the planning block,
+convert the shopping list to canonical format, fix the tags.
+
+Watch for restriction violations that predate the schema. Retrofits routinely
+surface excluded ingredients and do-not-stock items that were written in before
+the profile was documented. Fix them in place while you're there, and report what
+you changed — an unannounced edit to a recipe the user has cooked before is
+confusing at the stove.
+
+## What to report at the end
+
+- New canonical names needing product-mapping entries
+- Ingredients the store doesn't carry, and which meals they block
+- Home-sourced items and their fallback shape
+- Fields you estimated rather than knew, so the user can correct them
+- For retrofits: restriction violations found and fixed

--- a/plugins-claude/meal-planning/skills/grocery-cart/SKILL.md
+++ b/plugins-claude/meal-planning/skills/grocery-cart/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: grocery-cart
+description: "Build a grocery cart from a meal plan by driving a logged-in store session in the browser. Use when the user has a plan and wants the shopping done, asks to build or fill a cart, or wants to order groceries for a planned cycle. Resolves canonical shopping names to store products, runs the pantry top-off prompts, surfaces items that must be sourced elsewhere, and stops at checkout — it never places the order."
+---
+
+# grocery-cart
+
+Reads a plan document, resolves its shopping lines to store products, and adds
+them to a cart in a logged-in browser session.
+
+**It never places the order.** The skill ends by handing a verified cart back to
+the user for checkout. This is not a safety hedge to be relaxed when the cart
+looks complete — the user tops off with their own items and reviews substitutions
+before paying, every time.
+
+## Where personalization lives
+
+This skill contains no retailer name, no vendor names, no product names, and no
+pantry contents. All of that lives in the knowledge base. The skill carries method;
+the KB carries facts.
+
+Instacart is named, and is a hard dependency — it is the platform this skill
+automates, not a household fact. The **retailer** behind it is a household fact and
+stays in the KB.
+
+## Preflight
+
+1. **Resolve the contracts document** by searching the KB for meal planning schema
+   contracts or shopping line format. Authoritative over this file.
+2. **Follow its *Profile documents* index** to the product-mapping and staples
+   documents, and note the active store. Read them.
+3. **Read the active plan** from the KB — the contracts document gives its location
+   and frontmatter, and exactly one plan is `active` at a time. It is a complete
+   serialization by contract, so work from it rather than from any planning
+   conversation, which may not exist in this session. If no plan is active, say so
+   and offer to run `/meal-planning:meal-plan`; do not assemble a cart from scratch.
+4. **Before driving the browser**, read
+   `${CLAUDE_PLUGIN_ROOT}/skills/grocery-cart/references/instacart-automation.md`.
+   It carries the extraction technique and the failure modes that cost the most
+   time to rediscover. (If this skill was installed standalone rather than as part
+   of the plugin, the same file is at `references/instacart-automation.md` relative
+   to this one.)
+
+## Sourcing
+
+Every shopping line carries a canonical name and a sourcing class; the contracts
+document defines the classes and the quantity arithmetic. Resolve each canonical
+through the product mapping — that mapping is the join key for the whole system.
+
+When a canonical has no mapping entry, don't guess a product. Search the store,
+confirm the match, and report the new canonical at the end so the mapping can be
+updated. An unreported guess corrupts the join for every future cycle.
+
+## The pantry prompt — three buckets, in this order
+
+The order is deliberate and each bucket asks a different question:
+
+1. **Required and not stocked — cart silently.** The meal does not happen without
+   these. Asking would convert a requirement into an option, which invites a "no"
+   that quietly kills a planned batch.
+2. **Stocked staples this plan draws on — ask, and show the draw.** "Soy sauce —
+   3 of 6 batches this cycle" is answerable; "soy sauce?" is not. Order by **plan
+   draw, heaviest first** — that is the ranking signal you can actually compute.
+   Where the KB marks an item as one the user usually keeps a spare of, drop it
+   down the list; otherwise default a multi-batch draw to **included**, because a
+   redundant jar is a couple of dollars and a missing one ends a batch-cook night.
+
+   Do not attempt a finer-grained depletion estimate. Per-item reserve levels are
+   deliberately not tracked — they would go stale faster than they could be
+   maintained, and a confident-looking estimate built on stale data is worse than
+   an honest "how are you doing on this?"
+3. **Stocked with no draw — one "anything else?"** No draw to show and nothing to
+   rank; just list them.
+
+Then non-food household items as a single on-demand prompt.
+
+**Always ask, every run.** Answers are never stored in the plan, even if the plan
+was written minutes ago. Classification is a property of the plan and stays true;
+"yes, I need it" is a fact about the pantry on the day it's asked.
+
+## Items the store can't supply
+
+Home-sourced lines split by whether a fallback exists, and the split matters:
+
+- **A fallback product exists** — ask a single binary availability question, and
+  only when the plan actually calls for it. No planned batch, no question.
+- **No fallback is possible** — a legal restriction on delivery, a specialty vendor,
+  or a product the store simply doesn't carry. These **must** appear in the final
+  output as a pre-shop to-do, and must never become a cart line.
+
+Do not skip the second group. A cart can look complete while a planned batch is
+missing an ingredient that was never sourceable, and the failure surfaces at the
+stove on the night it was planned for.
+
+## Completion
+
+End by reporting:
+
+- **Expected cart contents, grouped by why each item is there** — required for a
+  batch, pantry top-off, standing item. The grouping is the point: it lets the user
+  audit the reasoning, not just the list.
+- **Unresolved items** — canonicals with no confident product match, and which
+  batches they affect.
+- **Pre-shop reminders** — everything that must be sourced outside the store.
+- **New canonicals** needing mapping entries.
+
+Then prompt the user to verify the cart and check out themselves.
+
+## Invariant — restrictions were already applied
+
+Recipes in the KB are already correct: dietary restrictions were resolved upstream
+in `add-recipe`. This skill never applies a substitution and never re-checks an
+ingredient against a restriction. If you find yourself reasoning about whether an
+ingredient is allowed, something upstream failed — report it rather than fixing it
+here.

--- a/plugins-claude/meal-planning/skills/grocery-cart/references/instacart-automation.md
+++ b/plugins-claude/meal-planning/skills/grocery-cart/references/instacart-automation.md
@@ -1,0 +1,68 @@
+# Instacart automation notes
+
+Observed behaviour of a third-party site and of the browser tooling, recorded
+because each of these cost real time to discover. Instacart's markup and internals
+change without notice — if something here doesn't match what you observe, trust
+what you observe and update this file.
+
+## Session and profile
+
+**Login is the user's job.** Don't attempt to authenticate. Cookies do not cross
+Chrome profiles, so the profile the browser extension is attached to must be the
+one already logged in. If the session isn't authenticated, stop and say so rather
+than working through a logged-out view — a logged-out store renders prices and
+availability that don't reflect the user's store or account.
+
+## Reading order and product data
+
+**Line items are client-rendered.** Fetching a page server-side returns roughly a
+22KB application shell with no item data in it. The data lives in the Apollo
+client cache after hydration.
+
+**Read it out of the Apollo cache via a hidden same-origin iframe:**
+
+```js
+(async () => {
+  const f = document.createElement('iframe');
+  f.style.display = 'none';
+  f.src = '/store/orders/<id>';
+  document.body.appendChild(f);
+  await new Promise(r => setTimeout(r, 3000));   // hydration
+  const data = f.contentWindow.__APOLLO_CLIENT__.cache.extract();
+  f.remove();
+  return data;
+})()
+```
+
+Why an iframe rather than navigation: hydration takes about three seconds, the
+read is same-origin so the cache is reachable, and the current page's state
+survives — no navigation, no losing where you were.
+
+**Order detail lives at `/store/orders/<id>`**, not `/store/account/orders/<id>`.
+The latter looks canonical and isn't.
+
+## Browser tool constraints
+
+- **Top-level `await` is unsupported** in the JS evaluation tool. Wrap everything
+  in an async IIFE, as above.
+- **Batched browser calls failed consistently** with "No tab available". Use
+  standalone calls.
+- **Keep each JS call under about 45 seconds** or the CDP connection times out.
+  Budget at most two or three iframe loads per call, and fewer when a lookup may
+  not find anything — failed searches are the slow path.
+- **Long numeric IDs can trip a base64 filter** on tool output and get mangled.
+  Order IDs in particular are long digit strings. Read them out of anchor `href`s,
+  grouped by path segment, rather than from rendered text.
+
+## Weight mode vs count mode
+
+Loose produce may support ordering **by weight** instead of by count. Check the
+item for a non-null `quantityAttributesWeight` in the extracted cache — when
+present, weight ordering is available, often in fractional-pound increments.
+
+Prefer weight mode for loose produce when it's offered. Count mode on a
+variable-size item means the delivered weight swings widely between orders for the
+same requested quantity, which breaks recipe quantities in both directions.
+
+This is a **per-item** property, not a category rule. Check each item; don't
+generalise from one produce item to the next.

--- a/plugins-claude/meal-planning/skills/meal-plan/SKILL.md
+++ b/plugins-claude/meal-planning/skills/meal-plan/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: meal-plan
+description: "Plan a cooking cycle — converge conversationally on a set of batches, then emit a complete plan document. Use when the user wants to plan a cooking cycle, start a grocery cycle, or rework an existing cycle plan. This is a periodic planning session covering weeks, NOT a single-meal question: 'what should I make tonight' is answered from the existing plan and must not trigger a new planning run. Reads recipes and household planning rules from the knowledge base, sequences batches by perishability, and hands off to grocery-cart for sourcing."
+---
+
+# meal-plan
+
+Converges on a set of batches for a cooking cycle and emits a plan document that
+`grocery-cart` can source from and that the user can cook from on another device.
+
+Workflow position: **meal-plan** → `/meal-planning:add-recipe` (only if the
+conversation wants something the KB doesn't have) → `/meal-planning:grocery-cart`.
+
+## Where personalization lives
+
+This skill contains no recipes, no dietary facts, no store name, and no target
+numbers. All of that lives in the knowledge base. The skill carries method; the KB
+carries facts. Never inline a recipe name, a brand, or a household constant here.
+
+## Preflight
+
+1. **Resolve the contracts document** by searching the KB for meal planning schema
+   contracts, recipe planning frontmatter, or shopping line format. It is the
+   single entry point and is authoritative over this file wherever they disagree.
+2. **Follow its *Profile documents* index** to the staples and product-mapping
+   documents. Read them.
+3. **Enumerate the recipe collection** by searching for the `recipe` **tag**, not
+   by `type` — `type` is a closed vocabulary that rejects `recipe`. Read the
+   planning frontmatter of each candidate; you don't need full methods to plan.
+
+   **Enumeration is not reliable yet, and you must account for it.** KB search is
+   relevance-ranked and returns chunks rather than documents, with a result cap and
+   no total count — so a single tag query can silently come back short, and one
+   recipe can consume several result slots. Run more than one query with differing
+   wording, deduplicate by document path, and **tell the user how many distinct
+   recipes you found.** A stated count lets them notice an obvious shortfall; a
+   silent one means a recipe was never a candidate and nobody knows.
+
+If the contracts document can't be resolved, or its index is missing, stop and say
+so. Do not plan against assumed rules — see the fallback in `add-recipe`.
+
+## Run it as a conversation, not a form
+
+The user talks about what they want; you converge. Don't open with an
+interrogation, don't present a numbered questionnaire, and don't demand a cycle
+length before offering anything. Propose, react, adjust.
+
+## Selection rules
+
+The contracts document owns the numbers — the cooked-nights target, the fridge-life
+cap, the slack thresholds. Follow them; don't restate or recompute them here, and
+don't substitute your own defaults. What follows is the judgment that surrounds
+them, including several rules that run **against** default model behaviour:
+
+- **Plan for fewer cooked nights than the cycle has days.** Flex meals absorb the
+  remainder by design, and that's a feature, not a gap to close. Under-planning is
+  cheap — a gap gets filled by something the user would happily eat. Over-planning
+  is expensive — perishables bought for a dinner that never got cooked rot. The
+  contracts document gives the actual target. Round nights **up** and bias toward
+  fewer batches.
+- **Repetition is a feature. Do not inject variety.** Do not decay ratings by
+  recency, do not penalise cooking the same thing twice in a cycle, do not
+  "balance" cuisines or proteins. A plan that is three batches of favourites is a
+  good plan. This is the rule most likely to be violated by reflex — variety feels
+  like good planning and here it is not.
+- **Sequence ascending by `cook_by_days`.** Week one burns the perishables, later
+  weeks run on freezer and shelf-stable stock. This ordering is what lets a single
+  grocery order cover a long cycle, so it is not cosmetic.
+- **Buy to the meal count.** `portions_per_meal` is the durable fact; nights fall
+  out of pack size. The plan tells the cart how much to buy — never infer the
+  quantity from a recipe pretending to know pack sizes.
+- **Don't let untested recipes anchor the plan.** A recipe the user has never
+  cooked has guessed yield and unproven results. Trying something new is a fine
+  deliberate choice — surface it as one, rather than quietly seating it as a
+  load-bearing batch.
+- **Attach sides, don't schedule them.** Recipes marked `role: side` are never
+  scheduled alone; attach them to a main. This is what makes protein-only recipes
+  into complete meals, so check whether a chosen main needs one.
+- **Flag timed carriers.** Mark batches whose recipe has a timed carrier, so the
+  cooking session knows a second timed process is in play.
+
+## Branching to add-recipe
+
+If the conversation lands on a dish the KB doesn't have, invoke
+`/meal-planning:add-recipe`, let
+it finish, then continue planning with the new recipe available. Don't inline a
+half-specified recipe into the plan — the plan doc has no place to carry a method,
+and the cart can't source a shopping list that was never written.
+
+## Output
+
+**Write the plan to the KB.** The contracts document defines the path, the
+frontmatter, and the sections; follow it. Set the new plan `active`, and mark any
+previously active plan whose window has passed as complete — exactly one plan is
+active at a time, because `whats-for-dinner` resolves "tonight" by reading it.
+
+**Complete serialization is load-bearing.** A cold read on a different device with
+zero conversation context is the *normal* case, not the edge case. Everything the
+cart step and the cooking sessions need must be in the document. If a decision
+only exists in this conversation, it is lost.
+
+Record the store the plan was built against, so a later store change doesn't
+silently invalidate it.
+
+## Invariant — restrictions were already applied
+
+Recipes in the KB are already correct: dietary restrictions and substitutions were
+resolved once, upstream, in `add-recipe`. This skill must never apply a
+substitution, never re-check an ingredient against a restriction, and never
+annotate a recipe as adapted. If you find yourself reasoning about whether an
+ingredient is allowed, something upstream failed — say so rather than patching it
+here, because a fix applied at plan time doesn't reach the recipe the user cooks
+from.

--- a/plugins-claude/meal-planning/skills/whats-for-dinner/SKILL.md
+++ b/plugins-claude/meal-planning/skills/whats-for-dinner/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: whats-for-dinner
+description: "Answer what to cook right now from the active meal plan. Use for single-meal questions — what should I make tonight, what's for dinner, what am I cooking, what's left this week, what needs using up. This is a lookup against an existing plan, not a planning session: it reads the active plan and answers from it, and offers to plan a new cycle only when none is active."
+---
+
+# whats-for-dinner
+
+Answers "what am I cooking" by reading the active meal plan. **It plans nothing and
+writes nothing.**
+
+This skill exists because two questions look alike and cost wildly different
+amounts. "What should I make tonight" is a lookup. Planning a cycle is a long
+session that ends in a grocery order. Answering the first by starting the second is
+the failure this split prevents — so keep it cheap and don't drift into planning.
+
+## Where personalization lives
+
+No recipes, no dietary facts, no household constants. All of it is in the knowledge
+base. The skill carries method; the KB carries facts.
+
+## Do this
+
+1. **Resolve the contracts document** by searching the KB for meal planning schema
+   contracts. It gives the plan location, frontmatter, and section structure.
+2. **Find the active plan.** Exactly one plan should be `active`. Check that today
+   falls inside its cycle window.
+3. **Answer from the plan.** Prefer the plan's own batch ordering — it is sequenced
+   by perishability, so the next unmade batch is usually the right answer. Say which
+   batch, and why it's next.
+
+Keep the answer short. This is a question asked while standing in the kitchen, not
+a request for a briefing.
+
+## What to surface without being asked
+
+- **Anything with a short window.** If a batch is near the end of its cook-by
+  window, lead with that — it's the one decision that gets expensive if deferred.
+- **A timed carrier.** If the batch has one, say so up front, because it changes
+  when cooking has to start. The recipe's step zero covers the rest.
+- **An attached side**, if the batch has one.
+
+## When there's no usable plan
+
+If no plan is `active`, or the active plan's window has already passed, say so
+plainly and **offer to run `/meal-planning:meal-plan`**. Wait for an answer.
+
+Do not improvise a meal from the recipe collection, and do not quietly start
+planning a cycle. An unplanned suggestion means shopping that didn't happen, so a
+recipe picked at random is likely to be missing an ingredient — which is worse than
+saying there's no plan.
+
+## Staying in scope
+
+- **Never write to the plan.** Not to mark a batch cooked, not to adjust an order.
+  If the user says they cooked something or wants the plan changed, tell them what
+  would need to change and let them direct it.
+- **Never apply a dietary substitution.** Recipes in the KB are already correct.
+- **Don't re-plan the cycle** because a batch looks unappealing tonight. Offer
+  another batch already in the plan, or flex — the plan deliberately covers fewer
+  nights than the cycle has days, and flex meals are a feature.


### PR DESCRIPTION
## Summary

Adds a `meal-planning` plugin with four skills covering the cooking workflow:

| Skill | Does |
|---|---|
| `add-recipe` | Authors a recipe into the KB, or retrofits one to the schema. Resolves dietary restrictions **once**, here. |
| `meal-plan` | Converges conversationally on a cycle of batches, sequenced by perishability. Writes the plan to the KB. |
| `grocery-cart` | Resolves canonical names to store products and drives a logged-in Instacart session. Never places the order. |
| `whats-for-dinner` | Cheap lookup against the active plan. Reads only. |

## Why the personalization seam

This repo is public, so the skills carry **no** dietary facts, retailer name, pantry contents, recipes, or household constants. All of that lives in a knowledge base reached over an MCP server at runtime — the skills carry method, the KB carries facts.

The skills locate exactly **one** document by search (the meal-planning contracts doc) and reach everything else through a profile-document index inside it. Moving or re-partitioning the KB corpus means editing that index and nothing else.

Instacart is the one named service and is a hard dependency — `grocery-cart` exists to automate it. Naming the platform is scope, not disclosure; the retailer behind it stays in the KB.

## Notes

- **Version is `0.1.0`, not `1.0.0`** — none of this has been run yet. It is untested by design of the version number.
- `whats-for-dinner` is deliberately separate from `meal-plan`: the two questions look alike but cost wildly different amounts, and answering "what should I make tonight" by starting a two-week planning session was a real failure mode caught in review.
- `allowed-tools` is intentionally unset on all four skills, unlike most skills in this repo. These depend on MCP tools whose names vary with how the user registered their KB server; an explicit list omitting them would block the dependency the whole design rests on. Documented in the plugin README.
- Not mirrored to `plugins-copilot/` — only development plugins are. Recorded in the CLI-specific surfaces table.
- CLAUDE.md gains a section documenting Claude Desktop / Cowork as a consumer surface, which shares the Claude Code plugin format.

## Test plan

- `bash test.sh` — 1944 passed, 0 failed
- `bash .github/scripts/validate-plugins.sh` — 302 checks, 0 failures
- `bash .github/scripts/validate-frontmatter.sh` — 105 checks, 0 failures
- `rumdl check` — clean across the plugin and CLAUDE.md
- `claude plugin validate` — passes for both the plugin and the marketplace manifest

Runtime behaviour is **unverified** — no skill in this plugin has been executed against a live KB or store session yet. That is what `0.1.0` is signalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
