### PR TITLE
feat(meal-planning): rework skills from first end-to-end run (v0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -163,7 +163,7 @@
         "name": "Logan Gagne"
       },
       "category": "productivity",
-      "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
+      "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads preferences, dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
       "name": "meal-planning",
       "source": "./plugins-claude/meal-planning"
     }

--- a/plugins-claude/meal-planning/.claude-plugin/plugin.json
+++ b/plugins-claude/meal-planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meal-planning",
-  "version": "0.1.0",
-  "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
+  "version": "0.2.0",
+  "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads preferences, dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
   "author": {
     "name": "Logan Gagne"
   }

--- a/plugins-claude/meal-planning/README.md
+++ b/plugins-claude/meal-planning/README.md
@@ -38,7 +38,8 @@ and reach everything else through the *Profile documents* index inside it:
 
 | Role | Carries |
 |---|---|
-| Contracts | Schema, line formats, derived formulas, plan-doc structure. Authoritative over the skills. |
+| Contracts | Schema, line formats, derived formulas, the scheduling chain, plan-doc structure. Authoritative over the skills. |
+| Preferences | Household constants — cadence, batch sizing, freezing, cycle rhythm, tone. Authoritative over any skill default. |
 | Restrictions | Hard exclusions and substitutions, applied at authoring time only |
 | Staples | What's stocked, home-sourced, and never stocked |
 | Product mapping | Canonical vocabulary → store products; the cart join key |
@@ -47,6 +48,9 @@ Consequences worth knowing before editing:
 
 - **The contracts document wins.** Where a skill and the contracts disagree, the
   contracts are right and the skill needs updating.
+- **A preference hardcoded in a skill can't be edited by the person whose
+  preference it is.** Anything that looks like a household constant — a target, a
+  cadence, a sizing rule — belongs in the Preferences document, not in a skill file.
 - **Restrictions are resolved upstream, once.** Only `add-recipe` applies
   substitutions. If `meal-plan` or `grocery-cart` is reasoning about whether an
   ingredient is allowed, something upstream failed.

--- a/plugins-claude/meal-planning/skills/add-recipe/SKILL.md
+++ b/plugins-claude/meal-planning/skills/add-recipe/SKILL.md
@@ -23,9 +23,14 @@ Do not work from memory, and do not proceed on a partial read.
 
 1. **Resolve the contracts document** by searching the KB for meal planning schema
    contracts, recipe planning frontmatter, or shopping line format.
-2. **Read it.** Its *Profile documents* table indexes the other three roles —
-   restrictions, staples, and product mapping — and names the active store.
-3. **Read all three in full** before writing anything.
+2. **Read it.** Its *Profile documents* table indexes the other roles —
+   preferences, restrictions, staples, and product mapping — and names the active
+   store.
+3. **Read all of them in full** before writing anything.
+
+   **Preferences is authoritative over any default this skill would apply** —
+   batch sizing, equipment ceilings, freezing, and tone. It is where household
+   constants live, so a value it states beats anything assumed here.
 
 The contracts document is the only thing this skill locates by search, and it is
 authoritative over this file wherever the two disagree. Everything else is
@@ -37,9 +42,10 @@ Failure modes, in order of likelihood:
 - **Several plausible contracts documents** — ask which is authoritative. Guessing
   wrong corrupts every recipe written afterward.
 - **No *Profile documents* index in the contracts doc** — fall back to searching
-  for each role directly (dietary restrictions and substitutions; pantry staples
-  and do-not-stock; canonical grocery vocabulary mapped to store products), and
-  report that the index is missing so it can be added.
+  for each role directly (cooking and meal-planning preferences; dietary
+  restrictions and substitutions; pantry staples and do-not-stock; canonical
+  grocery vocabulary mapped to store products), and report that the index is
+  missing so it can be added.
 - **A role can't be resolved** — stop. Say which role is unresolved and what it
   was needed for, and offer to create it. Never substitute your own defaults for a
   missing restrictions or staples document: a recipe authored against assumed
@@ -97,6 +103,31 @@ What the contracts can't tell you, and you have to get right:
 - **Estimate openly.** Where a value is a guess (prep and cook minutes usually
   are, until cooked once), use your best estimate and list it in the closing
   report as estimated. Silent guesses become facts nobody audits.
+- **Size the yield to the household, never to the source recipe.** Published
+  recipes are mostly written for families, and an inherited `servings` is a bug —
+  it produces a batch that doesn't fit the pot and more leftovers than get eaten
+  before they turn. Preferences sets both ceilings; scale down to them and say
+  you did.
+- **`scalable` is about this kitchen's equipment**, not the technique in the
+  abstract. If the vessel is the limit, set it false and name the vessel in
+  `scale_limit` — "it doubles fine" is useless advice if the pot doesn't.
+- **Don't set `cook_by_days`.** It is derived from the ingredients at plan time,
+  not stored on the recipe. Set it only when the *dish itself* is the constraint —
+  a dough that must be shaped the day it bakes — and then record `cook_by_driver`
+  saying why. If the reason names an ingredient, it belongs in Staples instead.
+- **Perishability is an ingredient fact, so record it on the ingredient.** When a
+  shopping line introduces a canonical Staples doesn't yet describe, capture
+  `keeps_unfrozen_days` and `freezes_raw` for it there — once — rather than
+  encoding it into this recipe. `freezes_raw` covers the raw ingredient only; a
+  source recipe's "freezes beautifully for three months" note is about cooked
+  leftovers and is never evidence for it.
+
+**Preferences override behaviour, not facts.** A recipe stating that its leftovers
+freeze for three months is recording something true about the food. A preference
+not to eat frozen leftovers governs whether the plan ever does it. Both are correct
+at once, and the recipe keeps its statement — don't delete a physical fact because
+a preference disagrees with acting on it. The same goes for yields, keeping times,
+and scaling notes: record what's true, let Preferences decide what's done.
 
 ### 4. Step zero for timed carriers
 
@@ -128,17 +159,36 @@ tablespoons into bottles.
    can be updated. The mapping is the join key for the whole system; letting it
    drift silently breaks cart building later.
 
+**An ingredient can be restriction-safe and still unmapped — keep it.** The
+restrictions document permits things the staples document doesn't stock, so an
+ingredient can be both explicitly allowed and absent from the pantry and the
+mapping. That is neither a violation to fix nor a mapped item to source, and the
+instinct to drop it is wrong: it silently removes something the user wants.
+
+Leave it in the recipe, classify it honestly, and report it as a new canonical.
+Subtraction is for restriction conflicts only — never for "I couldn't find it in
+the mapping."
+
 ### 6. Write to the KB
 
 Path convention: the recipes directory under the kitchen area of the KB, one
 document per recipe, slug-named.
 
-- Frontmatter needs the KB's own required fields. `type` is a closed vocabulary —
-  use the closest allowed value and carry the enumerable marker as a **tag**
-  instead. Check the KB's schema rather than assuming a `recipe` type exists.
+- Frontmatter needs the KB's own required fields — `description` among them, and
+  a missing one is rejected. `type` is a closed vocabulary, so use the closest
+  allowed value and carry the enumerable marker as a **tag** instead.
+- **The contracts document is authoritative for recipe tagging**, not the KB's
+  general frontmatter schema. That schema governs a closed tag vocabulary for the
+  corpus at large and does not enumerate recipe descriptors; the recipe collection
+  is an explicit exception to it. Don't "fix" a recipe's tags to satisfy the
+  general schema — you would break the tag-based filtering `meal-plan` depends on.
 - Tags carry protein, cuisine, method, and equipment so `meal-plan` can filter at
   search time instead of loading every document. Tag equipment only when it's
   actually used, and don't use the domain name as a tag.
+- **A write that fails may tell you nothing** — the server can reject a document
+  with no field name and no reason. Suspect frontmatter first, and change one
+  field at a time. Don't create throwaway probe documents in the corpus to bisect;
+  if you can't resolve it in a couple of attempts, report what you tried.
 - **Duplicate detection will refuse the create** when the dish is discussed
   anywhere else in the KB — a cuisine guide mentioning the dish is enough. This is
   expected, not an error. Confirm no actual recipe document exists, then retry
@@ -162,6 +212,19 @@ surface excluded ingredients and do-not-stock items that were written in before
 the profile was documented. Fix them in place while you're there, and report what
 you changed — an unannounced edit to a recipe the user has cooked before is
 confusing at the stove.
+
+### Finding what needs retrofitting
+
+**An unretrofitted recipe is invisible to search.** The `recipe` tag is what makes
+a recipe enumerable, so a recipe missing that tag — or missing its `planning`
+block — cannot be found by asking for recipes. There is no query for "recipes with
+no planning metadata," because the marker being queried is the thing that's absent.
+Real recipes have been discovered only because another document mentioned them in
+prose.
+
+So when asked to find retrofit candidates, **sweep the recipes directory by path,
+not by tag**, and check each document for the tag and the planning block. Report
+what's missing rather than retrofitting a pile of recipes unasked.
 
 ## What to report at the end
 

--- a/plugins-claude/meal-planning/skills/grocery-cart/SKILL.md
+++ b/plugins-claude/meal-planning/skills/grocery-cart/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: grocery-cart
-description: "Build a grocery cart from a meal plan by driving a logged-in store session in the browser. Use when the user has a plan and wants the shopping done, asks to build or fill a cart, or wants to order groceries for a planned cycle. Resolves canonical shopping names to store products, runs the pantry top-off prompts, surfaces items that must be sourced elsewhere, and stops at checkout — it never places the order."
+description: "Build a grocery cart from the active meal plan by driving a logged-in Instacart session in the browser. Use when the user has a plan and wants the shopping done, asks to build or fill a cart, or wants to order groceries for a planned cycle. Resolves canonical shopping names to store products, runs the pantry top-off prompts, resolves and records new product mappings, surfaces items that must be sourced elsewhere, and stops at checkout — it never places the order."
 ---
 
 # grocery-cart
 
-Reads a plan document, resolves its shopping lines to store products, and adds
+Reads the active plan, resolves its shopping lines to store products, and adds
 them to a cart in a logged-in browser session.
 
-**It never places the order.** The skill ends by handing a verified cart back to
-the user for checkout. This is not a safety hedge to be relaxed when the cart
-looks complete — the user tops off with their own items and reviews substitutions
-before paying, every time.
+**It never places the order.** The skill ends by handing a verified cart back for
+checkout. This is not a hedge to relax once the cart looks complete — the user
+tops off with their own items and reviews substitutions before paying, every time.
 
 ## Where personalization lives
 
@@ -19,7 +18,7 @@ This skill contains no retailer name, no vendor names, no product names, and no
 pantry contents. All of that lives in the knowledge base. The skill carries method;
 the KB carries facts.
 
-Instacart is named, and is a hard dependency — it is the platform this skill
+Instacart is named and is a hard dependency — it is the platform this skill
 automates, not a household fact. The **retailer** behind it is a household fact and
 stays in the KB.
 
@@ -27,37 +26,83 @@ stays in the KB.
 
 1. **Resolve the contracts document** by searching the KB for meal planning schema
    contracts or shopping line format. Authoritative over this file.
-2. **Follow its *Profile documents* index** to the product-mapping and staples
-   documents, and note the active store. Read them.
-3. **Read the active plan** from the KB — the contracts document gives its location
-   and frontmatter, and exactly one plan is `active` at a time. It is a complete
+2. **Read every document in its *Profile documents* index** — Preferences,
+   Restrictions, Staples, Product mapping. Preferences is authoritative over any
+   default this skill would otherwise apply.
+3. **Read the active plan.** Exactly one plan is `active`. It is a complete
    serialization by contract, so work from it rather than from any planning
    conversation, which may not exist in this session. If no plan is active, say so
    and offer to run `/meal-planning:meal-plan`; do not assemble a cart from scratch.
 4. **Before driving the browser**, read
    `${CLAUDE_PLUGIN_ROOT}/skills/grocery-cart/references/instacart-automation.md`.
-   It carries the extraction technique and the failure modes that cost the most
-   time to rediscover. (If this skill was installed standalone rather than as part
-   of the plugin, the same file is at `references/instacart-automation.md` relative
-   to this one.)
+   It carries the click technique, the verification signal, and the failure modes
+   that cost the most time to rediscover. (Installed standalone rather than as a
+   plugin, the same file is at `references/instacart-automation.md` relative to
+   this one.)
 
-## Sourcing
+## Resolving a canonical to a product
 
-Every shopping line carries a canonical name and a sourcing class; the contracts
-document defines the classes and the quantity arithmetic. Resolve each canonical
-through the product mapping — that mapping is the join key for the whole system.
+The mapping is the join key for the whole system. Match on what the mapping says —
+**brand and size** — not on what the search ranks first.
 
-When a canonical has no mapping entry, don't guess a product. Search the store,
-confirm the match, and report the new canonical at the end so the mapping can be
-updated. An unreported guess corrupts the join for every future cycle.
+- **Search rank is not evidence.** A store-brand mapping entry has resolved to a
+  premium different-brand product at more than twice the price simply because it
+  ranked first. If the top result isn't the mapped brand, keep looking.
+- **Size is part of the key.** Stores sell distinct products under identical names
+  at different sizes and wildly different prices. A name-only match is ambiguous;
+  resolve size too, and if you can't, surface it rather than picking.
+- **Never silently substitute a different brand.** If the mapped product isn't
+  available, that is a substitution and needs approval.
+
+**A product the search surfaced is not evidence the mapping is wrong.** Before
+editing a mapping entry, check it against order history — a "correction" made from
+a search result has already replaced a correct entry with a wrong one.
+
+**Pick pack format from the plan's computed draw**, not from a static preference.
+A format that suits a heavy single-cook draw is the wrong choice for a slow
+teaspoon-at-a-time draw, and the reverse. Where the KB states a format preference,
+read it as the answer to a past question rather than a law — and if a stated rule
+and the shelf make an item unbuyable, that collision is the finding. Say so; don't
+force one of them.
+
+## Resolving a canonical with no mapping
+
+Finding new products is normal and expected. It is a designed path, not an error
+path — and the mapping only grows through it.
+
+The goal is **hands-off with exactly one human decision:**
+
+1. **Detect, don't interrupt.** Any canonical in the plan with no mapping entry
+   goes into a resolve queue. Don't stop the run, and don't ask about them one at a
+   time as they surface.
+2. **Search unattended.** For each, search the store in the already-open session.
+   Prefer the store brand and the size matching the recipe's purchase unit. Gather
+   the top candidates with product string, size, and price.
+3. **Ask once, in a batch.** Present the queue together near the end of the run —
+   one line per canonical, recommended product plus alternatives. Batching is the
+   point: the interruption cost is per-prompt, not per-item.
+4. **The user approves the choice.** This is the only required human step and it is
+   not optional. Never select silently, and never cart an unapproved substitute.
+5. **Persist immediately.** On approval, write the canonical → product string into
+   the mapping document, in the right section, with size and any consolidation
+   behaviour. An approved choice that isn't written down is worthless next cycle.
+6. **Report** which canonicals were newly resolved.
+
+Two outcomes are findings, not failures:
+
+- **Not carried by the store.** Reclassify as home-sourced with a fallback shape,
+  say which planned meal it affects, and record it so no future cycle re-searches
+  it.
+- **Never deliverable** — anything that legally or practically can't be delivered.
+  These produce pre-shop reminders and **must never enter the resolve queue.**
 
 ## The pantry prompt — three buckets, in this order
 
 The order is deliberate and each bucket asks a different question:
 
 1. **Required and not stocked — cart silently.** The meal does not happen without
-   these. Asking would convert a requirement into an option, which invites a "no"
-   that quietly kills a planned batch.
+   these. Asking converts a requirement into an option and invites a "no" that
+   quietly kills a planned batch.
 2. **Stocked staples this plan draws on — ask, and show the draw.** "Soy sauce —
    3 of 6 batches this cycle" is answerable; "soy sauce?" is not. Order by **plan
    draw, heaviest first** — that is the ranking signal you can actually compute.
@@ -80,17 +125,28 @@ was written minutes ago. Classification is a property of the plan and stays true
 
 ## Items the store can't supply
 
-Home-sourced lines split by whether a fallback exists, and the split matters:
+Home-sourced lines split by whether a fallback exists:
 
 - **A fallback product exists** — ask a single binary availability question, and
   only when the plan actually calls for it. No planned batch, no question.
 - **No fallback is possible** — a legal restriction on delivery, a specialty vendor,
-  or a product the store simply doesn't carry. These **must** appear in the final
-  output as a pre-shop to-do, and must never become a cart line.
+  or a product the store doesn't carry. These **must** appear in the final output as
+  a pre-shop to-do, and must never become a cart line.
 
 Do not skip the second group. A cart can look complete while a planned batch is
 missing an ingredient that was never sourceable, and the failure surfaces at the
 stove on the night it was planned for.
+
+## Audit the cart before reporting
+
+**Do not report what you believe you added.** Adds fail silently, brands resolve
+wrong, and decrement loops overshoot — all three happened on the first real run,
+and every one would have been caught here.
+
+Read the actual cart contents, diff them against the plan's shopping list, and
+report any mismatch: missing lines, unexpected lines, wrong quantities. It is one
+read at the end of the run, and it is the only thing standing between a confident
+summary and a wrong cart.
 
 ## Completion
 
@@ -99,17 +155,18 @@ End by reporting:
 - **Expected cart contents, grouped by why each item is there** — required for a
   batch, pantry top-off, standing item. The grouping is the point: it lets the user
   audit the reasoning, not just the list.
-- **Unresolved items** — canonicals with no confident product match, and which
-  batches they affect.
-- **Pre-shop reminders** — everything that must be sourced outside the store.
-- **New canonicals** needing mapping entries.
+- **Audit result** — anything the cart/plan diff turned up.
+- **Newly resolved canonicals** and what was written to the mapping.
+- **Unresolved items** and which batches they affect.
+- **Pre-shop reminders** — everything sourced outside the store.
 
-Then prompt the user to verify the cart and check out themselves.
+Then prompt the user to verify the cart and check out themselves. Say each caveat
+once; repeating an acknowledged warning is unwelcome.
 
 ## Invariant — restrictions were already applied
 
 Recipes in the KB are already correct: dietary restrictions were resolved upstream
-in `add-recipe`. This skill never applies a substitution and never re-checks an
-ingredient against a restriction. If you find yourself reasoning about whether an
-ingredient is allowed, something upstream failed — report it rather than fixing it
-here.
+in `/meal-planning:add-recipe`. This skill never applies a substitution and never
+re-checks an ingredient against a restriction. If you find yourself reasoning about
+whether an ingredient is allowed, something upstream failed — report it rather than
+fixing it here.

--- a/plugins-claude/meal-planning/skills/grocery-cart/references/instacart-automation.md
+++ b/plugins-claude/meal-planning/skills/grocery-cart/references/instacart-automation.md
@@ -41,6 +41,117 @@ survives — no navigation, no losing where you were.
 **Order detail lives at `/store/orders/<id>`**, not `/store/account/orders/<id>`.
 The latter looks canonical and isn't.
 
+## Adding items to the cart
+
+There are three ways to trigger an Add button, in ascending order of observed
+reliability. Use the third one by default.
+
+- **Element-ref clicks** (clicking by accessibility-tree reference) report
+  success and add nothing to the cart, silently, when they land right after a
+  navigation. Three items were lost this way in a single run before the pattern
+  was noticed — the tool call returned "ok" every time.
+- **Coordinate clicks** computed from `getBoundingClientRect` work, but break
+  when layout shifts between the measurement and the click. A late-rendering
+  sponsored banner pushed a product card down about 64px between the two steps
+  and the click landed on the wrong element.
+- **Calling `button.click()` directly in page JS**, after polling for the
+  button to exist, worked every time and is also the fastest of the three.
+  Treat this as the default.
+
+```js
+(async () => {
+  const deadline = Date.now() + 10000;
+  let button;
+  while (Date.now() < deadline) {
+    button = document.querySelector('<add-button-selector>');
+    if (button) break;
+    await new Promise(r => setTimeout(r, 250));
+  }
+  if (!button) return { ok: false, reason: 'add button never appeared' };
+  button.click();
+  await new Promise(r => setTimeout(r, 500));
+  return { ok: true, label: button.getAttribute('aria-label') };
+})()
+```
+
+Poll for up to about 10 seconds, click in-page once the button exists, then
+verify (see below) — don't trust the click itself as confirmation.
+
+## Carting through a hidden iframe
+
+The same hidden-iframe technique used to read the Apollo cache also works for
+writing. Load a search URL in a hidden same-origin iframe, click the Add button
+inside that frame, then discard the frame. The main page never navigates, so
+none of its state is disturbed.
+
+Because the main page doesn't navigate, a helper function defined once on
+`window` survives for the rest of the session, and several items can be carted
+per tool call instead of one — roughly 3x the throughput of navigating the
+visible tab per item.
+
+```js
+(async () => {
+  window.__cartAdd ??= async (url, matchText) => {
+    const f = document.createElement('iframe');
+    f.style.display = 'none';
+    f.src = url;
+    document.body.appendChild(f);
+    await new Promise(r => setTimeout(r, 3000));   // hydration
+    const doc = f.contentWindow.document;
+    const deadline = Date.now() + 10000;
+    let button;
+    while (Date.now() < deadline) {
+      button = [...doc.querySelectorAll('button[aria-label]')]
+        .find(b => b.getAttribute('aria-label').includes(matchText));
+      if (button) break;
+      await new Promise(r => setTimeout(r, 250));
+    }
+    if (!button) { f.remove(); return { ok: false, reason: 'not found' }; }
+    button.click();
+    await new Promise(r => setTimeout(r, 500));
+    const label = button.getAttribute('aria-label');
+    f.remove();
+    return { ok: true, label };
+  };
+  return window.__cartAdd('/store/search/<query>', '<match text>');
+})()
+```
+
+## Verifying an add
+
+**The cart badge is not a confirmation signal.** It lags the actual cart state,
+and it counts distinct line items rather than units — bumping a quantity from
+one to two doesn't move it at all. Don't poll the badge to confirm anything.
+
+The reliable per-item signal is the Add button's own `aria-label`, which flips
+from an add state (e.g. "Add item") to an increment state that includes the
+current quantity (e.g. "Increase quantity to 1") once the click registers.
+Read that label back after clicking, as in the snippets above, and treat a
+label that still reads as an add state as a failed add.
+
+## Cart panel vs. search-result labels
+
+The quantity-bearing label described above is a property of **search-result**
+buttons. The cart panel's increment/decrement buttons use a label that omits
+the quantity entirely, so a loop that reads its stop condition from the label
+in the cart panel never terminates — one item overshot on the way down during
+a decrement loop and needed a correcting click back up.
+
+In the cart panel, parse the quantity from the panel's rendered text instead of
+the label. Watch for an ordering trap when doing this from a text dump: the
+quantity string for a line **precedes** its product name in document order,
+not follows it. Grabbing "the number next to this product name" by proximity
+in a naive left-to-right scan pairs the quantity with the wrong item.
+
+## Removing items and fixing quantities
+
+An item can only be removed or decremented from a view that currently lists
+it. If it isn't present in the active search results, there is no
+remove/decrement control to act on, and the attempt does nothing — silently,
+with no error. The cart panel reliably lists everything actually in the cart,
+so treat "open the cart panel" as the standard place to make any quantity
+correction or removal, rather than trying to do it from search results.
+
 ## Browser tool constraints
 
 - **Top-level `await` is unsupported** in the JS evaluation tool. Wrap everything
@@ -56,13 +167,19 @@ The latter looks canonical and isn't.
 
 ## Weight mode vs count mode
 
-Loose produce may support ordering **by weight** instead of by count. Check the
-item for a non-null `quantityAttributesWeight` in the extracted cache — when
-present, weight ordering is available, often in fractional-pound increments.
+Don't look for a weight-based ordering option on loose produce, and don't
+prompt the user about one. On the one produce item this was checked against,
+the item page sold by count only — "About N lb each, $X/lb, final cost by
+weight" — with no weight selector anywhere on the page. A prior version of
+this note claimed weight mode was commonly available for produce; that could
+not be reproduced and appears to have been wrong. For produce, the size
+variance between orders of the same requested count is a fact of the category,
+not something a technique here can route around.
 
-Prefer weight mode for loose produce when it's offered. Count mode on a
-variable-size item means the delivered weight swings widely between orders for the
-same requested quantity, which breaks recipe quantities in both directions.
+**Per-pound meat behaves differently, and correctly.** Those items add at a
+default weight and then increment in fixed weight steps, so weight-based
+ordering genuinely works for them.
 
-This is a **per-item** property, not a category rule. Check each item; don't
-generalise from one produce item to the next.
+The `quantityAttributesWeight` field in the extracted Apollo cache is still the
+right way to tell which mode an item supports — just check it per item and
+expect produce to come back empty.

--- a/plugins-claude/meal-planning/skills/meal-plan/SKILL.md
+++ b/plugins-claude/meal-planning/skills/meal-plan/SKILL.md
@@ -1,43 +1,70 @@
 ---
 name: meal-plan
-description: "Plan a cooking cycle — converge conversationally on a set of batches, then emit a complete plan document. Use when the user wants to plan a cooking cycle, start a grocery cycle, or rework an existing cycle plan. This is a periodic planning session covering weeks, NOT a single-meal question: 'what should I make tonight' is answered from the existing plan and must not trigger a new planning run. Reads recipes and household planning rules from the knowledge base, sequences batches by perishability, and hands off to grocery-cart for sourcing."
+description: "Plan a cooking cycle — converge conversationally on a set of batches, then write a complete plan document. Use when the user wants to plan a cooking cycle, start a grocery cycle, or rework an existing cycle plan. This is a periodic planning session covering weeks, NOT a single-meal question: 'what should I make tonight' is answered from the existing plan and must not trigger a new planning run. Reads recipes and household planning rules from the knowledge base, schedules batches as a dated serial chain, and hands off to grocery-cart for sourcing."
 ---
 
 # meal-plan
 
-Converges on a set of batches for a cooking cycle and emits a plan document that
-`grocery-cart` can source from and that the user can cook from on another device.
+Converges on a set of batches for a cooking cycle and writes a plan document that
+`/meal-planning:grocery-cart` sources from and that the cooking sessions run from.
 
 Workflow position: **meal-plan** → `/meal-planning:add-recipe` (only if the
 conversation wants something the KB doesn't have) → `/meal-planning:grocery-cart`.
 
 ## Where personalization lives
 
-This skill contains no recipes, no dietary facts, no store name, and no target
-numbers. All of that lives in the knowledge base. The skill carries method; the KB
-carries facts. Never inline a recipe name, a brand, or a household constant here.
+This skill contains no recipes, no dietary facts, no store name, and no household
+constants — not even the cooked-nights target. All of that lives in the knowledge
+base. The skill carries method; the KB carries facts.
+
+**A preference hardcoded here cannot be edited by the person whose preference it
+is.** If you are about to write a number, a cadence, or a habit into this file, it
+belongs in the Preferences document instead.
 
 ## Preflight
 
 1. **Resolve the contracts document** by searching the KB for meal planning schema
    contracts, recipe planning frontmatter, or shopping line format. It is the
-   single entry point and is authoritative over this file wherever they disagree.
-2. **Follow its *Profile documents* index** to the staples and product-mapping
-   documents. Read them.
-3. **Enumerate the recipe collection** by searching for the `recipe` **tag**, not
-   by `type` — `type` is a closed vocabulary that rejects `recipe`. Read the
-   planning frontmatter of each candidate; you don't need full methods to plan.
+   single entry point and is authoritative over this file.
+2. **Read every document in its *Profile documents* index** — Preferences,
+   Restrictions, Staples, Product mapping. Not a skim, and not just the ones that
+   look relevant.
 
-   **Enumeration is not reliable yet, and you must account for it.** KB search is
+   **Preferences is authoritative over anything this skill would otherwise
+   default to** — cadence, batch sizing, freezing, cycle rhythm, ranking, tone.
+   Where it and your instincts disagree, it wins.
+3. **Enumerate the recipe collection** by searching for the `recipe` **tag**, not
+   by `type` — `type` is a closed vocabulary that rejects `recipe`.
+
+   **Enumeration is unreliable and you must account for it.** KB search is
    relevance-ranked and returns chunks rather than documents, with a result cap and
-   no total count — so a single tag query can silently come back short, and one
-   recipe can consume several result slots. Run more than one query with differing
-   wording, deduplicate by document path, and **tell the user how many distinct
-   recipes you found.** A stated count lets them notice an obvious shortfall; a
-   silent one means a recipe was never a candidate and nobody knows.
+   no total count, so one query silently comes back short — in practice it has
+   dropped the single most-cooked dish in the collection. Run several queries with
+   differing wording, deduplicate by document path, and **state how many distinct
+   recipes you found.** A stated count lets the user notice a shortfall; a silent
+   one means a recipe was never a candidate and nobody knows.
 
 If the contracts document can't be resolved, or its index is missing, stop and say
-so. Do not plan against assumed rules — see the fallback in `add-recipe`.
+so rather than planning against assumed rules.
+
+## Never invent a constraint
+
+This is the most damaging way this skill fails, because it is silent and it
+contaminates the KB.
+
+A guess and a recorded preference look identical once written in prose. An
+invented constraint gets recorded in the plan as design rationale, carried forward
+into profile documents as though it were stated, and survives review because it
+sounds reasonable — while quietly producing a worse schedule.
+
+- **Ask when the KB doesn't answer a scheduling question.** One question is cheap.
+- **Any assumption about work, sleep, travel, or availability is fabricated** —
+  none of that is in the KB unless Preferences says it. Do not reason from what is
+  typical.
+- **When a constraint is doing real work in the plan, cite where it came from.**
+  If it can't be cited, it is a question, not a constraint.
+- **Never write an unverified assumption into the plan document.** Plans are inputs
+  to the next run; a guess recorded there is laundered into fact.
 
 ## Run it as a conversation, not a form
 
@@ -45,69 +72,87 @@ The user talks about what they want; you converge. Don't open with an
 interrogation, don't present a numbered questionnaire, and don't demand a cycle
 length before offering anything. Propose, react, adjust.
 
-## Selection rules
+Keep the prose lean and say things once — Preferences covers tone, and repeating a
+caveat that was already acknowledged is actively unwelcome.
 
-The contracts document owns the numbers — the cooked-nights target, the fridge-life
-cap, the slack thresholds. Follow them; don't restate or recompute them here, and
-don't substitute your own defaults. What follows is the judgment that surrounds
-them, including several rules that run **against** default model behaviour:
+## Build the chain, don't just pick a set
 
-- **Plan for fewer cooked nights than the cycle has days.** Flex meals absorb the
-  remainder by design, and that's a feature, not a gap to close. Under-planning is
-  cheap — a gap gets filled by something the user would happily eat. Over-planning
-  is expensive — perishables bought for a dinner that never got cooked rot. The
-  contracts document gives the actual target. Round nights **up** and bias toward
-  fewer batches.
-- **Repetition is a feature. Do not inject variety.** Do not decay ratings by
-  recency, do not penalise cooking the same thing twice in a cycle, do not
-  "balance" cuisines or proteins. A plan that is three batches of favourites is a
-  good plan. This is the rule most likely to be violated by reflex — variety feels
-  like good planning and here it is not.
-- **Sequence ascending by `cook_by_days`.** Week one burns the perishables, later
-  weeks run on freezer and shelf-stable stock. This ordering is what lets a single
-  grocery order cover a long cycle, so it is not cosmetic.
-- **Buy to the meal count.** `portions_per_meal` is the durable fact; nights fall
-  out of pack size. The plan tells the cart how much to buy — never infer the
-  quantity from a recipe pretending to know pack sizes.
-- **Don't let untested recipes anchor the plan.** A recipe the user has never
-  cooked has guessed yield and unproven results. Trying something new is a fine
-  deliberate choice — surface it as one, rather than quietly seating it as a
-  load-bearing batch.
-- **Attach sides, don't schedule them.** Recipes marked `role: side` are never
-  scheduled alone; attach them to a main. This is what makes protein-only recipes
-  into complete meals, so check whether a chosen main needs one.
-- **Flag timed carriers.** Mark batches whose recipe has a timed carrier, so the
-  cooking session knows a second timed process is in play.
+Batches run **serially** — cook one, eat it until it's gone, then cook the next.
+The contracts document owns the computation: forward from the cycle start, with
+each batch's cook day falling where the previous one runs out.
+
+Follow it exactly, and in particular:
+
+- **Produce dates, not a night count.** A set of batches with totals that add up is
+  not a plan. Every batch gets a cook date and the specific nights it covers.
+- **Derive each batch's window from its ingredients**, per the contracts: the
+  minimum across the `required` lines, where anything freezable or shelf-stable
+  doesn't bind. A recipe is not one ingredient — a braise whose beef freezes fine
+  is still pinned by the fresh thing in it.
+- **Check that derived window against the scheduled cook day**, not against the
+  cycle start — that check is the whole reason the ordering exists.
+- **Name the binding ingredient** next to the date. "Cook by Aug 4 — the
+  mushrooms" tells the user what to substitute if the date is inconvenient; a bare
+  date makes them re-derive the chain to find out why.
+- **Emit thaw dates for frozen ingredients**, roughly 48 hours ahead. Permission to
+  freeze is not a plan step; the date is.
+- **Run the contracts' validity checks before showing anything.** A schedule that
+  puts three cook days in a row is wrong, not merely unpolished, and presenting it
+  costs the user a correction round.
+- **Report `cook_sessions`.** It is the efficiency metric that matters under serial
+  consumption; cooked nights alone will make a bad plan look fine.
+
+## Selection
+
+Preferences owns the targets, the ranking rules, and the cadence. Do not restate
+them here and do not substitute your own. What this skill has to get right:
+
+- **Don't let untested recipes anchor the plan.** Absent `tested` means untested.
+  Trying something new is fine as a surfaced, deliberate choice — but its yield is
+  a guess, so it shouldn't be the batch the cycle leans on.
+- **Attach sides, don't schedule them.** A `role: side` recipe is never a batch;
+  check whether a chosen main needs one.
+- **Flag timed carriers**, so the cooking session knows a second timed process is
+  in play.
+- **When the user's chosen batches overrun the target**, follow the contracts: trim
+  nights within a batch before dropping a batch they asked for, least-certain yield
+  first. If trimming can't close the gap, ask rather than deciding.
 
 ## Branching to add-recipe
 
 If the conversation lands on a dish the KB doesn't have, invoke
-`/meal-planning:add-recipe`, let
-it finish, then continue planning with the new recipe available. Don't inline a
-half-specified recipe into the plan — the plan doc has no place to carry a method,
-and the cart can't source a shopping list that was never written.
+`/meal-planning:add-recipe`, let it finish, then continue with the new recipe
+available. Don't inline a half-specified recipe into the plan — the plan has no
+place to carry a method, and the cart can't source a shopping list that was never
+written.
 
 ## Output
 
 **Write the plan to the KB.** The contracts document defines the path, the
-frontmatter, and the sections; follow it. Set the new plan `active`, and mark any
-previously active plan whose window has passed as complete — exactly one plan is
-active at a time, because `whats-for-dinner` resolves "tonight" by reading it.
+frontmatter, and the sections. Follow it exactly — it carries required fields that
+the server rejects the document without.
+
+- **Close the previous cycle first.** Archive the outgoing plan and record its
+  outcome *before* the new one goes active. Two plans reading `active` breaks
+  `/meal-planning:whats-for-dinner`, which resolves "tonight" by finding the
+  active plan.
+- **Record thaw dates, not just thaw facts.** A batch that needs its protein moved
+  to the fridge needs the date it has to happen.
+- **Include the cook log** — one checkable line per planned night. The gap between
+  planned and actually cooked is the most useful thing the history carries.
 
 **Complete serialization is load-bearing.** A cold read on a different device with
-zero conversation context is the *normal* case, not the edge case. Everything the
-cart step and the cooking sessions need must be in the document. If a decision
-only exists in this conversation, it is lost.
+zero conversation context is the *normal* case. Everything the cart step and the
+cooking sessions need must be in the document. If a decision exists only in this
+conversation, it is lost.
 
-Record the store the plan was built against, so a later store change doesn't
-silently invalidate it.
+Record the store the plan was built against.
 
 ## Invariant — restrictions were already applied
 
 Recipes in the KB are already correct: dietary restrictions and substitutions were
-resolved once, upstream, in `add-recipe`. This skill must never apply a
-substitution, never re-check an ingredient against a restriction, and never
-annotate a recipe as adapted. If you find yourself reasoning about whether an
-ingredient is allowed, something upstream failed — say so rather than patching it
-here, because a fix applied at plan time doesn't reach the recipe the user cooks
-from.
+resolved once, upstream, in `/meal-planning:add-recipe`. This skill must never
+apply a substitution, re-check an ingredient against a restriction, or annotate a
+recipe as adapted. If you find yourself reasoning about whether an ingredient is
+allowed, something upstream failed — say so rather than patching it here, because a
+fix applied at plan time never reaches the recipe the user cooks from.

--- a/plugins-claude/meal-planning/skills/whats-for-dinner/SKILL.md
+++ b/plugins-claude/meal-planning/skills/whats-for-dinner/SKILL.md
@@ -18,15 +18,29 @@ the failure this split prevents — so keep it cheap and don't drift into planni
 No recipes, no dietary facts, no household constants. All of it is in the knowledge
 base. The skill carries method; the KB carries facts.
 
+The contracts document's *Profile documents* index includes a Preferences
+document. Read it — it governs tone as well as planning, and this skill's whole job
+is a short spoken-aloud answer. Say things once; a caveat repeated after it's been
+acknowledged is unwelcome.
+
+**Never invent a constraint.** If something about tonight isn't in the plan or the
+profile documents — whether there's time, whether a thaw happened — ask instead of
+assuming. A guess stated as fact is the failure mode this chain is most prone to.
+
 ## Do this
 
 1. **Resolve the contracts document** by searching the KB for meal planning schema
    contracts. It gives the plan location, frontmatter, and section structure.
-2. **Find the active plan.** Exactly one plan should be `active`. Check that today
-   falls inside its cycle window.
-3. **Answer from the plan.** Prefer the plan's own batch ordering — it is sequenced
-   by perishability, so the next unmade batch is usually the right answer. Say which
-   batch, and why it's next.
+2. **Find the active plan.** Exactly one plan is `active`; anything `archived` is
+   not current, whatever its dates say. Check that today falls inside its cycle
+   window.
+3. **Answer from the plan's own schedule.** The plan records each batch's cook date
+   and the specific nights it covers — read them. Do **not** recompute the chain,
+   and do not infer dates from night counts; the plan was written so a cold read
+   wouldn't have to. Say which batch and which night you're reading.
+4. **Read the cook log** before answering. It records what was actually cooked
+   against what was scheduled, so a batch that slipped changes what tonight is.
+   The schedule is the plan; the log is what happened.
 
 Keep the answer short. This is a question asked while standing in the kitchen, not
 a request for a briefing.


### PR DESCRIPTION
## Summary

Applies the defect log from the first real use of this plugin against a live knowledge base and a live store session. Four skills, one reference file, README, and manifests.

**The through-line:** household constants moved out of the skills and into a Preferences document in the KB. A preference hardcoded in a skill file can't be edited by the person whose preference it is — so targets, cadence, batch sizing, freezing rules, and tone now live in one place the user owns, and the skills defer to it.

**The root defect was scheduling.** Nothing in the skills or the schema said batches run *serially* — cook one, eat it until it's gone, then cook the next. So plans were built as sets whose totals added up, and the first real run produced four cook sessions in five days. The skills now derive a dated chain and validate it before showing anything.

## Changes by skill

**`meal-plan`**
- Derives the serial chain with real dates; validates cadence before presenting
- Reports `cook_sessions`, the metric that actually matters under serial consumption
- Derives each batch's window from its *ingredients* rather than a per-recipe field, and names the binding ingredient beside the date
- Defers all targets and ranking rules to Preferences instead of restating them

**`grocery-cart`**
- New product-mapping discovery flow: detect into a queue, search unattended, batch-ask once, user approves, persist immediately. Previously an unmapped ingredient just dead-ended
- Post-build cart audit diffing the actual cart against the plan — three silent failures in the first run would have been caught by one read
- Resolves products by brand and size from the mapping rather than by search rank, which had carted a wrong-brand item at 2.6x the price
- Ranks the pantry prompt by plan draw; per-item reserve depth is deliberately not tracked, since it would go stale faster than it could be maintained

**`add-recipe`**
- Keeps restriction-safe-but-unstocked ingredients rather than silently dropping them
- Sizes yields to the household's equipment and appetite, not the source recipe's servings
- Preferences override *behaviour*, not *facts* — don't delete a physical claim because a preference disagrees with acting on it

**`whats-for-dinner`**
- Reads dates and the cook log from the plan instead of recomputing the chain

**`references/instacart-automation.md`**
- In-page `button.click()` after polling is now the documented approach; element-ref clicks fail silently after navigation
- Hidden-iframe carting (previously documented for reads only) — roughly 3x throughput
- Cart-panel labels omit quantity unlike search-result labels, so decrement loops never terminate
- Weight-mode claim corrected: produce is count-only; per-pound meat genuinely supports it

**All skills:** never invent a constraint — ask, cite constraints doing real work, and never write an unverified assumption into a document. This is the failure that contaminates the KB, because a guess and a stated preference look identical once written in prose.

## Notes

- Version `0.2.0`. Still untested-by-design in the sense that this pass is itself the product of testing — but no skill here has been re-run since the rework.
- Corresponding KB-side schema work (serial chain, ingredient-level perishability, derived `cook_by_days`) landed separately in the knowledge base, which is a private repo.
- Four issues filed against the KB MCP server for opaque write failures, status vocabulary, delete hangs, and missing enumeration.

## Test plan

- `bash .github/scripts/validate-plugins.sh` — 302 checks, 0 failures
- `bash .github/scripts/validate-frontmatter.sh` — 105 checks, 0 failures
- `rumdl check` — clean across the plugin
- `claude plugin validate` — passes for plugin and marketplace manifests
- `bash test.sh` — CI is the gate; local run was still in progress at push time

Changes are markdown content within an already-validated plugin structure, so no structural surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
