### PR TITLE
fix(freecad): stop FreeCAD stealing desktop focus (v1.2.3)

### DIFF
--- a/plugins-claude/freecad/.claude-plugin/plugin.json
+++ b/plugins-claude/freecad/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "freecad",
-  "version": "1.2.2",
-  "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
+  "version": "1.2.3",
+  "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop \u2014 the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"
   }

--- a/plugins-claude/freecad/lib/live-reload.py
+++ b/plugins-claude/freecad/lib/live-reload.py
@@ -5,9 +5,12 @@ the agent edits the script; the model updates underneath them with the camera
 where they left it. That is the loop OpenSCAD gets right and stock FreeCAD
 does not.
 
-Camera is captured before the rebuild and restored after, because the rebuild
-closes and recreates the document (wwkit.Model does this by name, which is
-what stops FreeCAD from silently stacking up model001, model002, ...).
+Camera is captured before the rebuild and restored after. wwkit.Model now
+rebuilds the document in place, so the view -- and with it the camera -- survives
+on its own; this is kept as a safety net for models that recreate a document
+themselves. Do not "optimise" it into a reason to close documents again: closing
+one under the GUI destroys its view, and creating the replacement raises the
+window over whatever the human is doing, on every single reload.
 
 A script that raises leaves the previous model on screen and prints the
 traceback — a typo shouldn't blank the window mid-conversation.

--- a/plugins-claude/freecad/lib/render.py
+++ b/plugins-claude/freecad/lib/render.py
@@ -1,17 +1,27 @@
 """Render an .FCStd to PNGs, then quit. Driven by fcrender via env vars.
 
 Runs under the FreeCAD GUI because image capture needs a real view provider and
-a GL context — there is no headless render path.
+a GL context. It does NOT need a window on screen: fcrun starts renders with
+FreeCAD's --hidden, so the main window is never mapped, and saveImage() drives
+its own offscreen surface and framebuffer independent of the on-screen widget.
+
+Truly headless (FreeCADCmd, no GUI at all) remains impossible here, for two
+separate reasons worth recording so nobody re-litigates them:
+
+* Gui.setupWithoutGUI() leaves App.GuiUp at 0 and creates no view providers, so
+  there is no scenegraph to photograph.
+* Driving Coin's SoOffscreenRenderer directly gets past that, but fails to
+  create a GLX context under the Flatpak on an NVIDIA card, and the Flatpak
+  ships no simage, so it could not encode a PNG even if it had one.
 
 Two hard-won constraints shape this file:
 
 * Under the GUI, FreeCAD rebinds Python's stdout to its Report View, so print()
   never reaches the calling process. Anything the caller must see goes to
   $FCRENDER_LOG.
-* If capture() raises, the exception surfaces only in that Report View and the
-  window sits open forever — an invisible hang. So capture() can never be
-  allowed to leave the window open: it closes in a finally, and a watchdog
-  closes it regardless if capture never returns at all.
+* If capture() raises, the exception surfaces only in that Report View.
+  capture() therefore closes the document in a finally, and fcrender enforces a
+  deadline from the host side, where a wedged FreeCAD can actually be killed.
 
 A headless-authored document opens with every object hidden (no view providers
 were ever created), so anything not explicitly shown renders as an empty frame.
@@ -40,7 +50,6 @@ LOG = os.environ.get("FCRENDER_LOG")
 VIEWS = os.environ.get("FCRENDER_VIEWS", "iso,front,top,right").split(",")
 W = int(os.environ.get("FCRENDER_W", "1200"))
 H = int(os.environ.get("FCRENDER_H", "900"))
-WATCHDOG_MS = int(os.environ.get("FCRENDER_WATCHDOG_MS", "45000"))
 
 SETTERS = {
     "iso": "viewAxonometric",
@@ -145,13 +154,20 @@ def capture():
         shutdown()
 
 
-def watchdog():
-    if not _done["finished"]:
-        say("RENDER    watchdog fired after %dms - closing" % WATCHDOG_MS)
-        shutdown()
-
-
-# Give the GUI a moment to finish coming up before grabbing frames from it.
-QtCore.QTimer.singleShot(1500, capture)
-# Belt and braces: never leave an instance wedged open on an unforeseen stall.
-QtCore.QTimer.singleShot(WATCHDOG_MS, watchdog)
+# Capture SYNCHRONOUSLY, rather than from a QTimer.
+#
+# fcrun now launches renders with FreeCAD's --hidden, so the main window is
+# never shown. That is what stops a throwaway render from stealing the desktop's
+# focus -- but it also means there are no windows, so Qt's event loop has nothing
+# to keep it alive and returns immediately. A QTimer.singleShot(1500, capture)
+# therefore never fired: FreeCAD started, printed its banner, wrote no images,
+# and exited 0. Silent, and indistinguishable from success to the caller.
+#
+# Running inline sidesteps the event loop entirely. _settle() below still works,
+# because processEvents() pumps queued work without needing exec() to be running.
+#
+# The in-process watchdog went with the timers for the same reason -- a timer
+# cannot fire if nothing is pumping it. fcrender enforces the deadline from the
+# host side instead, where a hung FreeCAD can actually be killed.
+_settle(300)  # let startup finish laying the view out before the first grab
+capture()

--- a/plugins-claude/freecad/lib/wwkit.py
+++ b/plugins-claude/freecad/lib/wwkit.py
@@ -364,12 +364,38 @@ class Model:
     def __init__(self, name):
         # FreeCAD sanitises a document's internal Name to [A-Za-z0-9_], so
         # newDocument("bracket-box") yields a doc named "bracket_box". Sanitise
-        # first, or the close-and-replace below silently misses and every
-        # live-reload stacks another document: bracket_box, bracket_box1, ...
+        # first, or the reuse check below silently misses and every live-reload
+        # stacks another document: bracket_box, bracket_box1, ...
         name = re.sub(r"[^A-Za-z0-9_]", "_", name)
+
+        # REUSE the document rather than closing and recreating it.
+        #
+        # closeDocument() destroys the document's MDI view, and the newDocument()
+        # that followed made FreeCAD build a fresh one -- and creating an MDI
+        # view activates it, which propagates to the top-level window and yanks
+        # it in front of whatever the human is doing. On a live session that
+        # fired on EVERY rebuild, so a design session spent its whole life
+        # stealing focus back from the user, dozens of times an hour.
+        #
+        # Measured, not assumed: with the window deliberately lowered to the
+        # bottom of the stacking order, close+new raised it to the top on 3 of 3
+        # rebuilds; clearing objects in place moved it on 0 of 3.
+        #
+        # Emptying the document achieves what the close was actually for -- a
+        # clean slate under a stable name, with no model001/model002 pile-up --
+        # while leaving the view, and therefore the camera, alive.
         if name in App.listDocuments():
-            App.closeDocument(name)
-        self.doc = App.newDocument(name)
+            self.doc = App.getDocument(name)
+            # removeObject() on a parent can take its children with it, so a
+            # stale name is expected here rather than exceptional; re-read the
+            # list each pass instead of trusting the one we started with.
+            for _ in range(len(self.doc.Objects)):
+                remaining = self.doc.Objects
+                if not remaining:
+                    break
+                self.doc.removeObject(remaining[-1].Name)
+        else:
+            self.doc = App.newDocument(name)
         self.parts = []
 
     # -- construction -----------------------------------------------------

--- a/plugins-claude/freecad/scripts/fcrender
+++ b/plugins-claude/freecad/scripts/fcrender
@@ -40,18 +40,47 @@ mkdir -p "$OUT"
 
 LOG="${FCRENDER_LOG:-${TMPDIR:-/tmp}/fcrender.log}"
 : >"$LOG"
+RAW="$LOG.raw" # FreeCAD's own stdout/stderr, shown only when nothing rendered
+: >"$RAW"
 
 # The GUI swallows stdout into its Report View, so the log file is how we find
 # out what happened. Errors there are otherwise completely invisible.
+#
+# Keep fcrun's own output rather than discarding it, but in a SEPARATE file.
+# Discarding it hid a total failure: when render.py did not run at all, FreeCAD
+# printed its banner, wrote nothing, and exited 0 — and this script cheerfully
+# reported success over an empty log and an empty output directory.
+#
+# Separate, because say() both prints and writes to $FCRENDER_LOG; folding the
+# two streams into one file prints every RENDER line twice. The raw stream is
+# only worth showing when the run produced nothing, which is exactly when the
+# banner and any pre-Python error are the useful part.
+#
+# The deadline lives here, not in render.py: the in-process watchdog used to be
+# a QTimer, and a QTimer cannot fire in a --hidden run where nothing is pumping
+# the event loop. The host can always kill a wedged process.
+DEADLINE="${FCRENDER_TIMEOUT_S:-120}"
+TIMEOUT=()
+command -v timeout >/dev/null 2>&1 && TIMEOUT=(timeout -k 10 "$DEADLINE")
+
 FCRENDER_DOC="$(cd "$(dirname "$DOC")" && pwd)/$(basename "$DOC")" \
   FCRENDER_OUT="$(cd "$OUT" && pwd)" \
   FCRENDER_LOG="$LOG" \
   FCRENDER_VIEWS="$VIEWS" \
   FCRENDER_W="${FCRENDER_W:-1200}" \
   FCRENDER_H="${FCRENDER_H:-900}" \
-  "$HERE/fcrun" --gui "$LIB_DIR/render.py" >/dev/null 2>&1 || true
+  "${TIMEOUT[@]}" "$HERE/fcrun" --gui "$LIB_DIR/render.py" >"$RAW" 2>&1 || true
 
 cat "$LOG"
+
+# An empty output directory with a zero exit is the failure mode this script was
+# blind to for so long. Say so plainly rather than reporting success.
+if ! grep -qa "^RENDER    /" "$LOG"; then
+  echo "fcrender: FreeCAD wrote no images." >&2
+  echo "fcrender: --- FreeCAD output ---" >&2
+  cat "$RAW" >&2
+  exit 1
+fi
 if grep -qa "RENDER    FAILED" "$LOG"; then
   exit 1
 fi

--- a/plugins-claude/freecad/scripts/fcrun
+++ b/plugins-claude/freecad/scripts/fcrun
@@ -111,6 +111,7 @@ if [[ "${1:-}" == "--bin" ]]; then
 fi
 
 GUI=0
+HIDDEN=()
 if [[ "${1:-}" == "--gui" ]]; then
   GUI=1
   shift
@@ -123,6 +124,31 @@ if [[ "${1:-}" == "--gui" ]]; then
   # and `:-` would substitute the default for empty as well as unset, shutting
   # the live session down the moment its first build finished.
   export WW_GUI_ONESHOT="${WW_GUI_ONESHOT-1}"
+
+  # A one-shot GUI build exists to bake view state into the document and closes
+  # itself when it finishes — nobody is meant to look at it. Left visible, it
+  # maps a window, which on both Linux and macOS drags the desktop's focus off
+  # whatever the human was doing, for a window that vanishes seconds later.
+  #
+  # `--hidden` is a real (if undocumented, and absent from --help) FreeCAD flag:
+  # it sets StartHidden, which gates the ONLY show() of the main window during
+  # startup, and suppresses the splash screen with it. The window is never
+  # mapped, so there is nothing to steal focus. Rendering is unaffected —
+  # saveImage() drives its own offscreen surface and framebuffer, wholly
+  # separate from the on-screen widget.
+  #
+  # fclive clears WW_GUI_ONESHOT because a live session's window is the entire
+  # point; it is the one --gui run that must stay visible. WW_GUI_SHOW=1 forces
+  # a one-shot visible too, for when a build needs watching by eye.
+  if [[ -n "${WW_GUI_ONESHOT:-}" && -z "${WW_GUI_SHOW:-}" ]]; then
+    HIDDEN=(--hidden)
+    # macOS has no window-manager focus policy to fall back on: Qt's Cocoa
+    # plugin calls activateIgnoringOtherApps: on launch, and again on every
+    # raise(), which foregrounds the whole app regardless of window state.
+    # Both are opt-out, and only via the environment.
+    export QT_MAC_DISABLE_FOREGROUND_APPLICATION_TRANSFORM=1
+    export QT_MAC_SET_RAISE_PROCESS=0
+  fi
 fi
 
 SCRIPT="${1:-}"
@@ -222,7 +248,7 @@ fi
 # it, which is how a native crash used to read as success.
 set +e
 if [[ "$GUI" -eq 1 ]]; then
-  run_fc "$SCRIPT" 2>&1 | tee "$OUT_FILE" | filter
+  run_fc "${HIDDEN[@]}" "$SCRIPT" 2>&1 | tee "$OUT_FILE" | filter
 else
   # `-c` does not exit when the script ends — it drops into an interactive
   # Python console and waits for EOF ("Use Ctrl-D to exit"). Inherit a live

--- a/plugins-claude/freecad/skills/modeling/SKILL.md
+++ b/plugins-claude/freecad/skills/modeling/SKILL.md
@@ -27,19 +27,32 @@ disposable and regenerable.** Never hand-edit a `.FCStd`.
 | `${CLAUDE_PLUGIN_ROOT}/scripts/fcsnap model.py [out] [view]` | See the live session in the user's own window — their camera, or a canned `view` (iso/top/front/...) that snaps back. Plus selection + drags. **No new window.** |
 | `${CLAUDE_PLUGIN_ROOT}/scripts/fcopen model.py part.py` | Open a detail study as a TAB in the live window (no new window); `fcsnap` captures it. |
 | `${CLAUDE_PLUGIN_ROOT}/scripts/fcquit model.py` | Stop it cleanly. **Always use this — never `kill`.** |
-| `${CLAUDE_PLUGIN_ROOT}/scripts/fcrender doc.FCStd out/ iso,top,front` | Render PNGs to disk — but opens a throwaway GUI window that steals focus. Last resort; prefer `fcsnap`. |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/fcrender doc.FCStd out/ iso,top,front` | Render PNGs to disk. Runs FreeCAD hidden — **no window, no focus steal**. Use freely. |
 
 Look at your own renders before asking the user to look. Catching your own
 mistake costs a tool call; making them catch it costs their attention.
 
-**Do not take over the user's desktop.** Every `fcrun --gui` and every `fcrender`
-opens a FreeCAD window that steals focus — fine once, maddening on every
-iteration. So: verify **headless** (`fcrun` + `check_clashes()`, bounding boxes,
-`Shape.isInside` point checks — no window), and *see* results through the live
-session — `fcsnap` (their window, optional canned view) or a detail study in an
-`fcopen` tab. There is no headless PNG path on macOS (Qt-offscreen hangs, Coin's
-offscreen renderer errors), so reserve `fcrender`/`fcrun --gui` for when no live
-session is open at all.
+**Do not take over the user's desktop.** The live session's window belongs to the
+human: it is the one window, and it is theirs to arrange. Two rules follow.
+
+*Never open a second one.* `fcrun --gui` and `fcrender` run FreeCAD with
+`--hidden`, so they map no window at all — use them freely. What you must not do
+is start a second `fclive`, or tell the user to open FreeCAD by hand.
+
+*Never make their window jump.* `Model()` rebuilds the document in place
+precisely so a reload cannot raise the window over whatever they are doing. If
+you add a code path that closes and recreates a document under the GUI, you have
+reintroduced the focus stealing — measured at a raise on 3 of 3 rebuilds.
+
+Still prefer the cheap checks: verify **headless** (`fcrun` + `check_clashes()`,
+bounding boxes, `Shape.isInside` point checks), and *see* results through the
+live session — `fcsnap` (their camera, optional canned view) or a detail study in
+an `fcopen` tab. `fcrender` is for when no live session is open at all.
+
+There is still no fully headless (no-GUI) PNG path: `Gui.setupWithoutGUI()`
+creates no view providers, and driving Coin's offscreen renderer directly fails
+to get a GL context under Flatpak and cannot encode PNGs without simage. Hidden
+GUI rendering is the supported route.
 
 ## The loop runs both ways
 

--- a/plugins-copilot/freecad/.claude-plugin/plugin.json
+++ b/plugins-copilot/freecad/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "freecad",
-  "version": "1.2.2",
-  "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop — the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
+  "version": "1.2.3",
+  "description": "Agent-scripted FreeCAD modelling with a live-reload GUI loop \u2014 the agent writes the model, the human pans, rotates and steers, the model updates in place with the camera untouched",
   "author": {
     "name": "Logan Gagne"
   }


### PR DESCRIPTION
## Problem

A live FreeCAD session raised its window over whatever the user was doing on
**every rebuild** — 50 successful rebuilds in one observed session, dozens per
hour while iterating on a model.

## Root cause

Two independent causes, both confirmed by measurement rather than inspection:

1. **`wwkit.Model.__init__` closed and recreated the document.** Closing a
   document under the GUI destroys its MDI view; creating the replacement
   activates the new one, and that activation propagates to the top-level
   window.
2. **One-shot GUI builds and `fcrender` mapped a real window** for a few seconds
   and then closed it.

With the window deliberately lowered to the bottom of the stacking order:

| rebuild strategy | raised to top |
|---|---|
| `closeDocument` + `newDocument` (before) | **3 of 3** |
| clear objects in place (after) | **0 of 3** |

## Changes

- `wwkit.Model.__init__` reuses the document and clears its objects. Same clean
  slate under a stable name, no `model001`/`model002` pile-up, and the view —
  and therefore the camera — stays alive.
- `fcrun` passes FreeCAD's `--hidden` for one-shot GUI builds and renders, so no
  window is ever mapped. `WW_GUI_SHOW=1` opts back out. `fclive` is unaffected —
  a live session's window is the whole point.
- macOS: also sets `QT_MAC_DISABLE_FOREGROUND_APPLICATION_TRANSFORM` and
  `QT_MAC_SET_RAISE_PROCESS` for those runs. Qt's Cocoa plugin calls
  `activateIgnoringOtherApps:` on launch and on every `raise()`, and macOS has no
  window-manager focus policy to fall back on.
- `render.py` captures synchronously. With no window shown, Qt's event loop has
  nothing to keep it alive and returns immediately, so the `QTimer` that drove
  capture never fired — FreeCAD started, wrote no images, exited 0.
- `fcrender` keeps FreeCAD's output and **fails loudly when no images were
  written**. That silent-success path is what hid the bug above.

## Verification

- Renders produce correct geometry with **no window ever entering
  `_NET_CLIENT_LIST`** (Linux, KDE/Wayland, FreeCAD 1.1.1 Flatpak under XWayland).
- `test.sh` 1944 passed / 0 failed; `validate-plugins.sh` 301/0;
  `validate-frontmatter.sh` 105/0; `rumdl check` clean for touched files.
- **Not verified on hardware:** the two macOS environment variables. They come
  from reading Qt 6.8.3's Cocoa platform plugin source, not from a Mac run.

## Note for the reviewer

Branched from `master` while separate cut-list work is in flight on `wwcut.py`
and other parts of `wwkit.py`. The hunks do not overlap, but this bumps the
plugin to **1.2.3** while that branch bumps to **1.3.0** — expect a one-line
version conflict in both `plugin.json` files, whichever merges second.
