### PR TITLE
feat(meal-planning): plan a batch order, not a calendar (v0.3.0)

### DIFF
--- a/plugins-claude/meal-planning/.claude-plugin/plugin.json
+++ b/plugins-claude/meal-planning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meal-planning",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Recipe authoring, meal planning, grocery cart building, and dinner lookup against a knowledge-base-backed household profile. Reads preferences, dietary restrictions, pantry inventory, and store product vocabulary from a KB MCP server rather than embedding them.",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/meal-planning/README.md
+++ b/plugins-claude/meal-planning/README.md
@@ -6,7 +6,7 @@ share one schema contract stored in a knowledge base.
 | Skill | Does |
 |---|---|
 | `add-recipe` | Authors a recipe into the KB, or retrofits an existing one to the schema. Resolves dietary restrictions and substitutions **once**, here. |
-| `meal-plan` | Converges conversationally on a set of batches for a cycle, sequenced by perishability. Emits a plan as an artifact. |
+| `meal-plan` | Converges conversationally on a set of batches for a cycle, ordered by perishability. Writes the plan to the KB. |
 | `grocery-cart` | Reads the active plan, resolves canonical names to store products, drives a logged-in browser session to fill a cart. Never places the order. |
 | `whats-for-dinner` | Answers single-meal questions from the active plan. Reads only — plans nothing, writes nothing. |
 
@@ -38,8 +38,8 @@ and reach everything else through the *Profile documents* index inside it:
 
 | Role | Carries |
 |---|---|
-| Contracts | Schema, line formats, derived formulas, the scheduling chain, plan-doc structure. Authoritative over the skills. |
-| Preferences | Household constants — cadence, batch sizing, freezing, cycle rhythm, tone. Authoritative over any skill default. |
+| Contracts | Schema, line formats, derived formulas, the batch ordering chain, plan-doc structure. Authoritative over the skills. |
+| Preferences | Household constants — cadence, cycle length, batch sizing, freezing, cycle rhythm, tone. Authoritative over any skill default. |
 | Restrictions | Hard exclusions and substitutions, applied at authoring time only |
 | Staples | What's stocked, home-sourced, and never stocked |
 | Product mapping | Canonical vocabulary → store products; the cart join key |
@@ -48,6 +48,17 @@ Consequences worth knowing before editing:
 
 - **The contracts document wins.** Where a skill and the contracts disagree, the
   contracts are right and the skill needs updating.
+- **Plans carry an order, not a calendar.** Batches are ranked and given a rough
+  week at most — never a cook date, never named nights. Real life reorders the
+  chain constantly, and a dated plan turns an ordinary slip into a plan that reads
+  as broken and an agent that argues with the user about what they ate. Cycle
+  length comes from Preferences.
+- **Whether anything tracks what was actually cooked is a preference.** The skills
+  work with a cook log or without one and enforce neither; a household that wants
+  the history says so in Preferences, and one that finds the bookkeeping unwelcome
+  says nothing. Absent a stated preference the skills assume no tracking, because
+  listing a week's batches works either way while inferring a position from a
+  record nobody maintains does not.
 - **A preference hardcoded in a skill can't be edited by the person whose
   preference it is.** Anything that looks like a household constant — a target, a
   cadence, a sizing rule — belongs in the Preferences document, not in a skill file.

--- a/plugins-claude/meal-planning/skills/meal-plan/SKILL.md
+++ b/plugins-claude/meal-planning/skills/meal-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meal-plan
-description: "Plan a cooking cycle — converge conversationally on a set of batches, then write a complete plan document. Use when the user wants to plan a cooking cycle, start a grocery cycle, or rework an existing cycle plan. This is a periodic planning session covering weeks, NOT a single-meal question: 'what should I make tonight' is answered from the existing plan and must not trigger a new planning run. Reads recipes and household planning rules from the knowledge base, schedules batches as a dated serial chain, and hands off to grocery-cart for sourcing."
+description: "Plan a cooking cycle — converge conversationally on a set of batches, then write a complete plan document. Use when the user wants to plan a cooking cycle, start a grocery cycle, or rework an existing cycle plan. This is a periodic planning session covering weeks, NOT a single-meal question: 'what should I make tonight' is answered from the existing plan and must not trigger a new planning run. Reads recipes and household planning rules from the knowledge base, orders batches into a serial chain, and hands off to grocery-cart for sourcing."
 ---
 
 # meal-plan
@@ -75,32 +75,58 @@ length before offering anything. Propose, react, adjust.
 Keep the prose lean and say things once — Preferences covers tone, and repeating a
 caveat that was already acknowledged is actively unwelcome.
 
-## Build the chain, don't just pick a set
+## Order the chain, don't date it
 
 Batches run **serially** — cook one, eat it until it's gone, then cook the next.
-The contracts document owns the computation: forward from the cycle start, with
-each batch's cook day falling where the previous one runs out.
+The output is an **order**, not a calendar. The contracts document owns the
+computation and Preferences §1 owns the rule; both are authoritative over this
+file.
 
-Follow it exactly, and in particular:
+**Do not assign cook dates or named nights to batches, ever.** A batch is cooked
+when the one before it runs out, which is not a date anyone commits to in advance.
+Real life reorders the chain routinely — that is what flex nights are for, and a
+plan that dates its batches turns an ordinary slip into a plan that reads as
+broken. It also invites arguing with the user about what they ate on a given day,
+which you have no way to know and no business asserting.
 
-- **Produce dates, not a night count.** A set of batches with totals that add up is
-  not a plan. Every batch gets a cook date and the specific nights it covers.
+What the plan carries instead:
+
+- **A rank per batch** — first, second, third. This is the load-bearing part: it
+  puts perishable batches ahead of durable ones.
+- **A rough week**, if the cycle spans more than one. Week 1 / week 2 is the
+  finest date resolution wanted. Never a day.
+- **Relative deadlines where an ingredient forces one** — "cook this one early,
+  the mushrooms are what binds it." That is a real constraint and belongs in the
+  plan; a calendar date is not.
+
+And in particular:
+
+- **Size the cycle, don't schedule it.** `usable_nights` still decides how many
+  batches a cycle needs and whether the coverage target is met — it just never
+  resolves to named nights. The cycle length itself comes from Preferences; don't
+  assume a fortnight.
 - **Derive each batch's window from its ingredients**, per the contracts: the
-  minimum across the `required` lines, where anything freezable or shelf-stable
-  doesn't bind. A recipe is not one ingredient — a braise whose beef freezes fine
-  is still pinned by the fresh thing in it.
-- **Check that derived window against the scheduled cook day**, not against the
-  cycle start — that check is the whole reason the ordering exists.
-- **Name the binding ingredient** next to the date. "Cook by Aug 4 — the
-  mushrooms" tells the user what to substitute if the date is inconvenient; a bare
-  date makes them re-derive the chain to find out why.
-- **Emit thaw dates for frozen ingredients**, roughly 48 hours ahead. Permission to
-  freeze is not a plan step; the date is.
-- **Run the contracts' validity checks before showing anything.** A schedule that
-  puts three cook days in a row is wrong, not merely unpolished, and presenting it
-  costs the user a correction round.
+  minimum across the `required` and `home` lines, where anything freezable or
+  shelf-stable doesn't bind. A recipe is not one ingredient — a braise whose beef
+  freezes fine is still pinned by the fresh thing in it.
+- **Check that derived window against the batch's position in the chain**, not
+  against the cycle start — that check is the whole reason the ordering exists. A
+  batch placed in week 2 needs ingredients that survive into week 2.
+- **Name the binding ingredient** next to the rank. "Second — the mushrooms are
+  what binds it" tells the user what to substitute if the slot is inconvenient,
+  and makes mid-cycle reordering cheap when something starts to turn.
+- **State thaw leads relatively** — "move it to the fridge ~48 hours before you
+  cook it" — never as a calendar date. Permission to freeze is not a plan step;
+  the lead is.
+- **Run the contracts' validity checks before showing anything.** Never three cook
+  sessions back to back still holds; without dates it constrains how many batches
+  the cycle carries, not a calendar.
 - **Report `cook_sessions`.** It is the efficiency metric that matters under serial
   consumption; cooked nights alone will make a bad plan look fine.
+
+**Reordering mid-cycle is not a re-plan.** If the user says a batch moved, or an
+ingredient is turning, swap the ranks and move on. Don't rebuild the cycle and
+don't ask for preconditions first.
 
 ## Selection
 
@@ -136,10 +162,16 @@ the server rejects the document without.
   outcome *before* the new one goes active. Two plans reading `active` breaks
   `/meal-planning:whats-for-dinner`, which resolves "tonight" by finding the
   active plan.
-- **Record thaw dates, not just thaw facts.** A batch that needs its protein moved
-  to the fridge needs the date it has to happen.
-- **Include the cook log** — one checkable line per planned night. The gap between
-  planned and actually cooked is the most useful thing the history carries.
+- **Record thaw leads, not just thaw facts.** A batch that needs its protein moved
+  to the fridge needs the lead time — "~48 hours before cooking" — attached to the
+  batch, so a cold read knows when to act without a date to miss.
+- **Whether the plan records what was actually cooked is a preference, not a rule
+  this skill owns.** Some households want a cook log and the history it gives;
+  others find being asked to account for what they ate actively unwelcome. Read
+  Preferences and do what it says — emit a log in the shape it asks for, or emit
+  none. **Absent a stated preference, don't emit one and don't ask for one**: a
+  plan with no log still works, whereas a log nobody maintains makes every later
+  read confidently wrong about what happened.
 
 **Complete serialization is load-bearing.** A cold read on a different device with
 zero conversation context is the *normal* case. Everything the cart step and the

--- a/plugins-claude/meal-planning/skills/whats-for-dinner/SKILL.md
+++ b/plugins-claude/meal-planning/skills/whats-for-dinner/SKILL.md
@@ -32,25 +32,50 @@ assuming. A guess stated as fact is the failure mode this chain is most prone to
 1. **Resolve the contracts document** by searching the KB for meal planning schema
    contracts. It gives the plan location, frontmatter, and section structure.
 2. **Find the active plan.** Exactly one plan is `active`; anything `archived` is
-   not current, whatever its dates say. Check that today falls inside its cycle
-   window.
-3. **Answer from the plan's own schedule.** The plan records each batch's cook date
-   and the specific nights it covers — read them. Do **not** recompute the chain,
-   and do not infer dates from night counts; the plan was written so a cold read
-   wouldn't have to. Say which batch and which night you're reading.
-4. **Read the cook log** before answering. It records what was actually cooked
-   against what was scheduled, so a batch that slipped changes what tonight is.
-   The schedule is the plan; the log is what happened.
+   not current. Check that today falls inside its cycle window — the window is the
+   only date the plan carries.
+3. **Work out which rough week the cycle is in** — today against `cycle_start`.
+   That is the only date arithmetic this skill does, and it stops there. The plan
+   carries an order and a rough week, never cook dates or named nights.
+4. **List that week's batches in chain order and let the user say which.** Give
+   them with whatever makes the choice easy — the binding ingredient, a thaw lead,
+   a timed carrier — and stop there. If the week is nearly done or the list is
+   thin, include the neighbouring week's batches too.
+5. **If the plan carries a record of what's been cooked, use it** to lead with the
+   likeliest batch — while still showing the rest of the week, because the record
+   lags reality and this skill never writes to it. Whether such a record exists at
+   all is a preference; see below.
 
 Keep the answer short. This is a question asked while standing in the kitchen, not
 a request for a briefing.
 
+## Tracking is a preference
+
+**Do not enforce a position in either direction.** Whether the household tracks
+what actually got cooked lives in Preferences, and it changes what this skill can
+lean on:
+
+- **Tracking on** — the plan carries a record. Read it, lead with what it implies,
+  and stay correctable.
+- **Tracking off** — there is nothing to read. List the week's batches and let the
+  user pick.
+
+**Absent a stated preference, assume nothing is tracked.** Listing the week works
+either way; inferring a position from a record that doesn't exist does not.
+
+Either way, **never assert what the user cooked or ate**, and don't interrogate
+them to reconstruct it. They can see the fridge in one glance and will say. If they
+contradict the plan or the record, they're right.
+
 ## What to surface without being asked
 
-- **Anything with a short window.** If a batch is near the end of its cook-by
-  window, lead with that — it's the one decision that gets expensive if deferred.
+- **Anything with a short window.** If a later batch is pinned by something that's
+  about to turn, say so — that's a reason to reorder, and reordering is routine,
+  not a re-plan. Name the binding ingredient, not a deadline date.
 - **A timed carrier.** If the batch has one, say so up front, because it changes
   when cooking has to start. The recipe's step zero covers the rest.
+- **A thaw lead.** If a batch coming up this week needs its protein moved to the
+  fridge ~48 hours ahead, that has to be said tonight, not the night it's cooked.
 - **An attached side**, if the batch has one.
 
 ## When there's no usable plan
@@ -65,9 +90,12 @@ saying there's no plan.
 
 ## Staying in scope
 
-- **Never write to the plan.** Not to mark a batch cooked, not to adjust an order.
-  If the user says they cooked something or wants the plan changed, tell them what
-  would need to change and let them direct it.
+- **Never write to the plan.** Not to record a batch as cooked, not to adjust the
+  order. If the user says they cooked something or wants the order changed, tell
+  them what would need to change and let them direct it.
+- **Never argue about what the user has eaten or cooked.** They know; you don't.
+  If they say a batch is done, it's done — answer from what's left. The plan is a
+  proposed order, not a record of events.
 - **Never apply a dietary substitution.** Recipes in the KB are already correct.
 - **Don't re-plan the cycle** because a batch looks unappealing tonight. Offer
   another batch already in the plan, or flex — the plan deliberately covers fewer


### PR DESCRIPTION
## Summary

The meal-planning skills told the agent to build a **dated serial chain** and to reconcile a per-night cook log against it. Plans are never followed to the day, so the first slip invalidated every date after it — and the agent ended up asserting what the user had eaten on a given night, which it has no way to know.

The KB contracts document already reversed this (§3, *Order the chain, don't date it*). The plugin was still building against the old contract.

### meal-plan

- "Build the chain" → **"Order the chain, don't date it."** Batches carry a rank, a rough week at most, and relative deadlines that name the binding ingredient — never a cook date or named nights.
- `usable_nights` still sizes the cycle; it just never resolves to named nights.
- Thaw leads are stated relatively ("~48 hours ahead"), never as a calendar date.
- Cycle length is read from Preferences instead of assuming a fortnight.
- Reordering mid-cycle is an instruction to execute, not a re-plan.

### whats-for-dinner

- Lists the current rough week's batches in chain order and lets the user say which, instead of resolving "tonight" from dates.
- Never asserts what the user cooked or ate, and never interrogates them to reconstruct it.

### Tracking is now a preference, not a rule

Whether anything records what was actually cooked belongs in the Preferences document, not in a public skill — other people use this marketplace and a household that wants the history should be able to say so. Both skills read the preference and enforce neither position. Absent a stated preference they assume no tracking, since listing a week's batches works either way while inferring a position from a record nobody maintains does not.

### README

Documents the order-not-calendar design and the tracking seam; corrects the stale "emits a plan as an artifact" line (plans have been written to the KB since v0.2.0).

Version bumped 0.2.0 → 0.3.0. No Copilot mirror — meal-planning is Claude-only by design.

## Test plan

- [x] `bash .github/scripts/validate-plugins.sh` — 301 checks, 0 failures
- [x] `bash .github/scripts/validate-frontmatter.sh` — 103 checks, 0 failures
- [x] `rumdl check plugins-claude/meal-planning` — clean
- [x] Grepped the plugin for `cook date` / `cook log` / `dated` / `calendar` — remaining hits are the new prohibitions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
