### PR TITLE
fix(git-tools): repair Gitea repo info and issue list author

### DIFF
--- a/plugins-claude/git-tools/.claude-plugin/plugin.json
+++ b/plugins-claude/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/git-tools/scripts/git-cli
+++ b/plugins-claude/git-tools/scripts/git-cli
@@ -419,7 +419,7 @@ case "$cmd:$sub" in
         ;;
       gitea)
         args=(--output json --limit "$limit" --state "$state"
-              --fields "index,title,body,state,labels,milestone,comments,created,updated,assignees,url")
+              --fields "index,title,body,state,author,labels,milestone,comments,created,updated,assignees,url")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
         [[ -n "$label"    ]] && args+=(--labels "$label")
         cli_json '[.[] | {number: (.index | tonumber? // .index), title, body: (.body // ""), state, author: (.author // ""), labels: (if .labels and (.labels | type) == "array" then [.labels[].name] elif .labels and (.labels | type) == "string" and .labels != "" then [.labels] else [] end), milestone: (.milestone // null), assignees: (if .assignees and (.assignees | type) == "array" then [.assignees[].login] elif .assignees and (.assignees | type) == "string" and .assignees != "" then [.assignees] else [] end), created_at: (.created // ""), updated_at: (.updated // null), url: (.url // "")}]' \
@@ -1448,11 +1448,13 @@ case "$cmd:$sub" in
           env GH_NO_COLOR=1 gh repo view --json "name,owner,description,defaultBranchRef,visibility,url,stargazerCount,forkCount"
         ;;
       gitea)
-        remote_slug=$(git remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
-        NO_COLOR=1 tea repos list --output json 2>/dev/null \
-          | jq --arg repo "$remote_slug" \
-            '.[] | select(.full_name == $repo) | {name, owner: .owner, description, default_branch, visibility: (if .private then "private" else "public" end), url: .html_url, stars: .stars_count, forks: .forks_count}' \
-          2>/dev/null || echo "{}"
+        # tea repos list can't satisfy this: no full_name, no default_branch,
+        # and paginated at 30/page. Fetch directly, as run:show does (#133).
+        # Two sed expressions, not one — POSIX ERE has no lazy quantifier, so
+        # `([^/]+/[^/]+?)(\.git)?$` matches greedily and keeps the .git.
+        remote_slug=$(git remote get-url origin | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+        cli_json '{name, owner: .owner.login, description, default_branch, visibility: (if .private then "private" else "public" end), url: .html_url, stars: .stars_count, forks: .forks_count}' \
+          env NO_COLOR=1 tea api "repos/$remote_slug"
         ;;
     esac
     ;;

--- a/plugins-claude/session/.claude-plugin/plugin.json
+++ b/plugins-claude/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-claude/session/scripts/git-cli
+++ b/plugins-claude/session/scripts/git-cli
@@ -419,7 +419,7 @@ case "$cmd:$sub" in
         ;;
       gitea)
         args=(--output json --limit "$limit" --state "$state"
-              --fields "index,title,body,state,labels,milestone,comments,created,updated,assignees,url")
+              --fields "index,title,body,state,author,labels,milestone,comments,created,updated,assignees,url")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
         [[ -n "$label"    ]] && args+=(--labels "$label")
         cli_json '[.[] | {number: (.index | tonumber? // .index), title, body: (.body // ""), state, author: (.author // ""), labels: (if .labels and (.labels | type) == "array" then [.labels[].name] elif .labels and (.labels | type) == "string" and .labels != "" then [.labels] else [] end), milestone: (.milestone // null), assignees: (if .assignees and (.assignees | type) == "array" then [.assignees[].login] elif .assignees and (.assignees | type) == "string" and .assignees != "" then [.assignees] else [] end), created_at: (.created // ""), updated_at: (.updated // null), url: (.url // "")}]' \
@@ -1448,11 +1448,13 @@ case "$cmd:$sub" in
           env GH_NO_COLOR=1 gh repo view --json "name,owner,description,defaultBranchRef,visibility,url,stargazerCount,forkCount"
         ;;
       gitea)
-        remote_slug=$(git remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
-        NO_COLOR=1 tea repos list --output json 2>/dev/null \
-          | jq --arg repo "$remote_slug" \
-            '.[] | select(.full_name == $repo) | {name, owner: .owner, description, default_branch, visibility: (if .private then "private" else "public" end), url: .html_url, stars: .stars_count, forks: .forks_count}' \
-          2>/dev/null || echo "{}"
+        # tea repos list can't satisfy this: no full_name, no default_branch,
+        # and paginated at 30/page. Fetch directly, as run:show does (#133).
+        # Two sed expressions, not one — POSIX ERE has no lazy quantifier, so
+        # `([^/]+/[^/]+?)(\.git)?$` matches greedily and keeps the .git.
+        remote_slug=$(git remote get-url origin | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+        cli_json '{name, owner: .owner.login, description, default_branch, visibility: (if .private then "private" else "public" end), url: .html_url, stars: .stars_count, forks: .forks_count}' \
+          env NO_COLOR=1 tea api "repos/$remote_slug"
         ;;
     esac
     ;;

--- a/plugins-copilot/git-tools/.claude-plugin/plugin.json
+++ b/plugins-copilot/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "GitHub and Gitea tooling — unified CLI wrapper (issues, PRs, CI runs) plus a ship orchestrator that drives the full branch/commit/push/PR/watch/cleanup lifecycle",
   "author": {
     "name": "Logan Gagne"

--- a/plugins-copilot/session/.claude-plugin/plugin.json
+++ b/plugins-copilot/session/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Work session management — issue-driven and freeform doors sharing an explore-then-plan spine, with multi-agent orchestration and a review-gated PR finalizer",
   "author": {
     "name": "Logan Gagne"

--- a/tests/git-cli/test-gitea-repo-info-issue-author.sh
+++ b/tests/git-cli/test-gitea-repo-info-issue-author.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# test-gitea-repo-info-issue-author.sh — regression tests for two Gitea-path
+# defects in git-cli, both caused by asking `tea` for a shape it does not emit.
+#
+#  1. `repo info` filtered `tea repos list --output json` on `.full_name`, but
+#     that command emits only {owner,name,type,ssh}. The select never matched,
+#     so the command always printed nothing and exited 0. It is also paginated
+#     (30/page) and cannot report default_branch at all. Fixed by fetching the
+#     repo directly via `tea api repos/{owner}/{repo}` — same shape as #133.
+#
+#  2. The remote_slug regex `([^/]+/[^/]+?)(\.git)?$` relied on a lazy
+#     quantifier. POSIX ERE has none, so `+?` matched greedily, `(\.git)?`
+#     matched empty, and the slug kept its ".git" suffix — which would have
+#     404'd the new API call.
+#
+#  3. `issue list` requested --fields without `author`, while the normalizer
+#     read `.author`. tea emits only the fields named, so author was always "".
+#
+# Uses mock git/tea scripts via PATH injection.
+#
+# Usage: bash tests/git-cli/test-gitea-repo-info-issue-author.sh [filter]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GIT_CLI="$SCRIPT_DIR/../../utils/git-cli"
+
+PASS=0
+FAIL=0
+SKIP=0
+FILTER="${1:-}"
+
+MOCK_DIR=""
+cleanup() { [[ -n "$MOCK_DIR" ]] && rm -rf "$MOCK_DIR"; }
+trap cleanup EXIT
+MOCK_DIR=$(mktemp -d)
+
+# Mocks communicate back to the test through these files.
+export GIT_CLI_TEST_REMOTE="$MOCK_DIR/remote_url" # git mock reads the URL here
+export GIT_CLI_TEST_SENTINEL="$MOCK_DIR/repos_list_called"
+export GIT_CLI_TEST_API_PATH="$MOCK_DIR/api_path"    # tea mock records the path asked for
+export GIT_CLI_TEST_FIELDS="$MOCK_DIR/issues_fields" # tea mock records --fields
+
+pass() {
+  printf "  \033[32m✓\033[0m %s\n" "$1"
+  ((PASS++)) || true
+}
+
+fail() {
+  printf "  \033[31m✗\033[0m %s  (%s)\n" "$1" "$2"
+  ((FAIL++)) || true
+}
+
+skip_filter() {
+  [[ -n "$FILTER" ]] && ! echo "$1" | grep -qi "$FILTER"
+}
+
+# ---------------------------------------------------------------------------
+# Mocks
+# ---------------------------------------------------------------------------
+
+# Mock git: report whatever remote URL the current test wrote, so platform
+# detection resolves to "gitea" and the slug regex sees a realistic URL.
+cat >"$MOCK_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") cat "$GIT_CLI_TEST_REMOTE" ;;
+  *) command git "$@" ;;
+esac
+EOF
+chmod +x "$MOCK_DIR/git"
+
+# Mock tea:
+#  - login list  → advertise a login for the remote host (so platform == gitea)
+#  - repos list  → MUST NOT be called by the fixed repo:info; record a sentinel
+#                  and emit the real (insufficient) shape so the old filter,
+#                  if reintroduced, still yields nothing
+#  - api repos/<slug> → canned repo object; records the path it was asked for
+#  - issues list → honours --fields the way tea does: emit ONLY those fields
+cat >"$MOCK_DIR/tea" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2 $3" in
+  "login list --output")
+    echo '[{"url":"https://git.stonefish.tech"}]'
+    exit 0
+    ;;
+  "repos list --output")
+    touch "$GIT_CLI_TEST_SENTINEL"
+    echo '[{"owner":"owner","name":"repo","type":"source","ssh":"ssh://git@git.stonefish.tech:2222/owner/repo.git"}]'
+    exit 0
+    ;;
+esac
+
+if [[ "$1" == "api" ]]; then
+  printf '%s' "$2" >"$GIT_CLI_TEST_API_PATH"
+  if [[ "$2" != "repos/owner/repo" ]]; then
+    echo "404 Not Found: $2" >&2
+    exit 1
+  fi
+  cat <<'JSON'
+{
+  "name": "repo",
+  "full_name": "owner/repo",
+  "owner": {"login": "owner"},
+  "description": "a test repo",
+  "default_branch": "trunk",
+  "private": true,
+  "html_url": "https://git.stonefish.tech/owner/repo",
+  "stars_count": 7,
+  "forks_count": 3
+}
+JSON
+  exit 0
+fi
+
+if [[ "$1 $2" == "issues list" ]]; then
+  fields=""
+  while [[ $# -gt 0 ]]; do
+    [[ "$1" == "--fields" ]] && fields="$2"
+    shift
+  done
+  printf '%s' "$fields" >"$GIT_CLI_TEST_FIELDS"
+  # tea emits only the requested fields — mirror that faithfully.
+  jq -nc --arg f "$fields" '
+    ($f | split(",")) as $keys
+    | [ {index: "42", title: "a bug", body: "", state: "open", author: "octocat",
+         labels: [], milestone: "", comments: "0", created: "2026-01-01T00:00:00Z",
+         updated: "2026-01-01T00:00:00Z", assignees: [], url: "https://x/42"}
+        | with_entries(select(.key | IN($keys[]))) ]'
+  exit 0
+fi
+
+echo "unexpected tea call: $*" >&2
+exit 1
+EOF
+chmod +x "$MOCK_DIR/tea"
+
+echo "ssh://git@git.stonefish.tech:2222/owner/repo.git" >"$GIT_CLI_TEST_REMOTE"
+
+# ---------------------------------------------------------------------------
+# Test: repo info returns a populated, normalized object
+# ---------------------------------------------------------------------------
+
+echo "── repo info: Gitea REST path ──"
+
+label="repo info emits populated normalized JSON"
+if ! skip_filter "$label"; then
+  exit_code=0
+  output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" repo info 2>"$MOCK_DIR/stderr") || exit_code=$?
+  stderr=$(cat "$MOCK_DIR/stderr")
+
+  if [[ "$exit_code" != "0" ]]; then
+    fail "$label" "exit=$exit_code stderr=$stderr"
+  elif ! echo "$output" | jq -e . >/dev/null 2>&1; then
+    fail "$label (valid JSON)" "output=$output stderr=$stderr"
+  else
+    errs=()
+    [[ "$(echo "$output" | jq -r '.name')" == "repo" ]] || errs+=("name != repo")
+    [[ "$(echo "$output" | jq -r '.owner')" == "owner" ]] || errs+=("owner != owner (needs .owner.login)")
+    [[ "$(echo "$output" | jq -r '.description')" == "a test repo" ]] || errs+=("description wrong")
+    [[ "$(echo "$output" | jq -r '.default_branch')" == "trunk" ]] || errs+=("default_branch != trunk")
+    [[ "$(echo "$output" | jq -r '.visibility')" == "private" ]] || errs+=("visibility != private")
+    [[ "$(echo "$output" | jq -r '.url')" == "https://git.stonefish.tech/owner/repo" ]] || errs+=("url wrong")
+    [[ "$(echo "$output" | jq -r '.stars')" == "7" ]] || errs+=("stars != 7")
+    [[ "$(echo "$output" | jq -r '.forks')" == "3" ]] || errs+=("forks != 3")
+
+    if [[ ${#errs[@]} -eq 0 ]]; then
+      pass "$label"
+    else
+      fail "$label" "$(
+        IFS='; '
+        echo "${errs[*]}"
+      ); output=$output"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test: regression guard — `tea repos list` is never invoked
+# ---------------------------------------------------------------------------
+
+label="repo info does not call 'tea repos list'"
+if ! skip_filter "$label"; then
+  if [[ -f "$GIT_CLI_TEST_SENTINEL" ]]; then
+    fail "$label" "sentinel present — old repos-list path was used"
+  else
+    pass "$label"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test: the .git suffix is stripped from the slug, across remote URL forms
+# ---------------------------------------------------------------------------
+
+echo "── repo info: remote slug parsing ──"
+
+for remote in \
+  "ssh://git@git.stonefish.tech:2222/owner/repo.git" \
+  "git@git.stonefish.tech:owner/repo.git" \
+  "https://git.stonefish.tech/owner/repo.git" \
+  "https://git.stonefish.tech/owner/repo"; do
+
+  label="slug strips .git — $remote"
+  if ! skip_filter "$label"; then
+    echo "$remote" >"$GIT_CLI_TEST_REMOTE"
+    : >"$GIT_CLI_TEST_API_PATH"
+    exit_code=0
+    PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" repo info >/dev/null 2>"$MOCK_DIR/stderr" || exit_code=$?
+    asked=$(cat "$GIT_CLI_TEST_API_PATH")
+
+    if [[ "$asked" == "repos/owner/repo" && "$exit_code" == "0" ]]; then
+      pass "$label"
+    else
+      fail "$label" "asked=$asked exit=$exit_code"
+    fi
+  fi
+done
+
+echo "ssh://git@git.stonefish.tech:2222/owner/repo.git" >"$GIT_CLI_TEST_REMOTE"
+
+# ---------------------------------------------------------------------------
+# Test: issue list requests and reports the author
+# ---------------------------------------------------------------------------
+
+echo "── issue list: author field ──"
+
+label="issue list requests 'author' in --fields"
+if ! skip_filter "$label"; then
+  exit_code=0
+  output=$(PATH="$MOCK_DIR:$PATH" bash "$GIT_CLI" issue list 2>"$MOCK_DIR/stderr") || exit_code=$?
+  stderr=$(cat "$MOCK_DIR/stderr")
+  fields=$(cat "$GIT_CLI_TEST_FIELDS")
+
+  if [[ "$exit_code" != "0" ]]; then
+    fail "$label" "exit=$exit_code stderr=$stderr"
+  elif [[ ",$fields," != *",author,"* ]]; then
+    fail "$label" "--fields lacked author: $fields"
+  else
+    pass "$label"
+  fi
+
+  label="issue list reports a non-empty author"
+  if ! skip_filter "$label"; then
+    author=$(echo "$output" | jq -r '.[0].author // ""')
+    if [[ "$author" == "octocat" ]]; then
+      pass "$label"
+    else
+      fail "$label" "author='$author' output=$output"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Total: $((PASS + FAIL))  PASS: $PASS  FAIL: $FAIL  SKIP: $SKIP"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/utils/git-cli
+++ b/utils/git-cli
@@ -419,7 +419,7 @@ case "$cmd:$sub" in
         ;;
       gitea)
         args=(--output json --limit "$limit" --state "$state"
-              --fields "index,title,body,state,labels,milestone,comments,created,updated,assignees,url")
+              --fields "index,title,body,state,author,labels,milestone,comments,created,updated,assignees,url")
         [[ -n "$assignee" ]] && args+=(--assignee "$assignee")
         [[ -n "$label"    ]] && args+=(--labels "$label")
         cli_json '[.[] | {number: (.index | tonumber? // .index), title, body: (.body // ""), state, author: (.author // ""), labels: (if .labels and (.labels | type) == "array" then [.labels[].name] elif .labels and (.labels | type) == "string" and .labels != "" then [.labels] else [] end), milestone: (.milestone // null), assignees: (if .assignees and (.assignees | type) == "array" then [.assignees[].login] elif .assignees and (.assignees | type) == "string" and .assignees != "" then [.assignees] else [] end), created_at: (.created // ""), updated_at: (.updated // null), url: (.url // "")}]' \
@@ -1448,11 +1448,13 @@ case "$cmd:$sub" in
           env GH_NO_COLOR=1 gh repo view --json "name,owner,description,defaultBranchRef,visibility,url,stargazerCount,forkCount"
         ;;
       gitea)
-        remote_slug=$(git remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
-        NO_COLOR=1 tea repos list --output json 2>/dev/null \
-          | jq --arg repo "$remote_slug" \
-            '.[] | select(.full_name == $repo) | {name, owner: .owner, description, default_branch, visibility: (if .private then "private" else "public" end), url: .html_url, stars: .stars_count, forks: .forks_count}' \
-          2>/dev/null || echo "{}"
+        # tea repos list can't satisfy this: no full_name, no default_branch,
+        # and paginated at 30/page. Fetch directly, as run:show does (#133).
+        # Two sed expressions, not one — POSIX ERE has no lazy quantifier, so
+        # `([^/]+/[^/]+?)(\.git)?$` matches greedily and keeps the .git.
+        remote_slug=$(git remote get-url origin | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+        cli_json '{name, owner: .owner.login, description, default_branch, visibility: (if .private then "private" else "public" end), url: .html_url, stars: .stars_count, forks: .forks_count}' \
+          env NO_COLOR=1 tea api "repos/$remote_slug"
         ;;
     esac
     ;;


### PR DESCRIPTION
## Summary

Three defects on the Gitea path of `git-cli`, all the same root cause as #133: the code asks `tea` for a shape it does not emit. All three fail silently — empty output or an empty string, never an error — which is why they survived.

Found while using the `git-tools` plugin against a self-hosted Gitea instance.

## 1. `repo info` returns nothing on Gitea

It filtered `tea repos list --output json` with `select(.full_name == $slug)`. That command emits only `{owner, name, type, ssh}`:

```console
$ tea repos list --output json | jq -c '.[0]'
{"owner":"cal","name":"agency-agents","type":"mirror","ssh":"ssh://git@…/cal/agency-agents.git"}
```

So the select dropped every row. The trailing `2>/dev/null || echo "{}"` then swallowed the evidence, leaving an empty result and exit 0.

A jq-only fix isn't possible: `tea repos list --fields` offers `description,forks,id,name,owner,stars,ssh,updated,url,permission,type` — no `full_name`, no `default_branch`, no visibility — and it is paginated at 30/page, so a filter would miss any repo past the first page regardless.

Fixed by fetching the repo directly via `tea api repos/{owner}/{repo}`, which returns all the required fields. This is the same shape #133 introduced for `run show`.

## 2. The remote slug kept its `.git` suffix

```sh
sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|'
```

This relies on `+?` being lazy. POSIX ERE has no lazy quantifiers, so `[^/]+` matched greedily, `(\.git)?` matched empty, and the result was `owner/repo.git`:

```console
$ echo 'git@host:owner/repo.git' | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|'
owner/repo.git
```

Masked before this change rather than latent — the `select` failed on `.full_name` first, so a wrong slug never got the chance to surface. Two independent bugs hiding each other. Fatal once the slug is interpolated into an API path. Now stripped in its own expression.

## 3. `issue list` always reports `author: ""`

The `--fields` request omitted `author` while the normalizer reads `.author`. `tea` emits only the fields named, so it was always the empty fallback:

```console
$ tea issues list --fields "index,title,state,author" --output json | jq -c '.[0]'
{"index":"10","title":"…","state":"open","author":"cal"}
```

`issue show` is unaffected — it uses `tea issues <N>`, which emits `user`, and the code already reads `.user`. That path was correct and is unchanged.

## Testing

New suite `tests/git-cli/test-gitea-repo-info-issue-author.sh`, 8 cases, following the mock-PATH pattern from `test-run-show.sh`:

- `repo info` emits a populated normalized object (name, owner, description, default_branch, visibility, url, stars, forks)
- regression guard: `tea repos list` is never invoked (sentinel)
- slug resolves to `repos/owner/repo` across all four remote URL forms — `ssh://…:2222/…`, `git@host:…`, `https://…/….git`, and no-suffix
- `issue list` requests `author` in `--fields` and reports a non-empty author

The `tea` mock honours `--fields` the way tea does (emitting only the named fields), so case 4 genuinely fails if the field is dropped again.

**All 8 fail against the pre-change code and pass after.**

Also run locally:

- `bash tests/test.sh` — no new failures. `permission-manager/test-classify` fails with 9 cases, but it fails identically on a pristine `origin/master` worktree; pre-existing and unrelated.
- `bash .github/scripts/validate-plugins.sh` — 300 checks, 0 failures (includes vendored-drift and version-sync)
- `bash .github/scripts/validate-frontmatter.sh` — 103 checks, 0 failures

CI's `shellcheck --severity=error` job covers the changed scripts; no executable line differs from the reviewed diff.

Also verified against a live Gitea instance (tea 0.14.1), old code vs new, on real repos with `git@host:owner/repo.git` remotes:

- `repo info` — old printed nothing and exited 0; new returns the populated object (name, owner, description, `default_branch`, visibility, url, stars, forks).
- `issue list` — old reported `author: ""` for every issue; new reports the real login.
- slug parsing — checked directly across all four remote URL forms; the old expression left `owner/repo.git` on the three `.git`-suffixed ones, the new one strips it.

## Notes for the reviewer

- Edited `utils/git-cli` and re-ran `utils/sync.sh`; vendored copies for `git-tools` and `session` are in the same commit.
- Bumped `git-tools` 2.2.1 → 2.2.2 and `session` 4.5.0 → 4.5.1 (both vendor `git-cli`), claude and copilot manifests together.
- **Deliberate behaviour change:** `repo info` on Gitea now surfaces errors instead of swallowing them, because it routes through `cli_json` rather than `… 2>/dev/null || echo "{}"`. This aligns it with the rest of the file rather than departing from it:
  - Every data-returning subcommand goes through `cli_json`, which `die`s on a non-zero exit with the CLI's stderr — all 23 call sites, covering `issue list/show`, `issue comment`, `pr list/show`, `pr comment`, and `run list/show`.
  - Scope of that, precisely: `cli_json` catches *process* failure (network, auth, a missing `tea`). It does not catch API-level errors, because `tea api` prints `{"message":"not found",…}` and still exits 0 — a 404 therefore yields a null-filled object rather than an error. That is not new here: `run show` behaves identically, and has since #133. Worth a follow-up across all `tea api` call sites, but out of scope for this fix.
  - `repo info`'s own **GitHub** arm, three lines above the Gitea arm, already used `cli_json`. Before this change the two platform branches of one subcommand disagreed about whether a fetch failure is an error: on GitHub it aborted, on Gitea it printed nothing and exited 0.
  - The `2>/dev/null || <fallback>` sites elsewhere are a different layer — the ship/wait loops, which soften the results of git-cli's own already-`cli_json`'d subcommands. That's intentional and documented at `_ci_status`: *"Every API call is guarded so a probe failure degrades to `none` and never aborts the wait loop."* "No CI run yet for this branch" is a legitimate state during a poll, not an error.
  - The only other `|| echo` fallbacks are `repo:default-branch`'s `|| echo "main"` (tail of a git-local resolution chain, no API call) and that `_ci_status` probe. The old `repo info` line was the sole primitive-layer swallow in the file.
